### PR TITLE
chore: clean up src/core/__init__.py with proper @summary and __all__

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,8 +1,10 @@
 # @summary
-# Empty file. Provides no purpose, exports, or dependencies.
+# Core package public API: local BGE embeddings and legacy knowledge graph builder.
+# Exports: LocalBGEEmbeddings, EntityExtractor, GraphQueryExpander, KnowledgeGraphBuilder, export_obsidian
+# Deps: src.core.embeddings, src.core.knowledge_graph
 # @end-summary
+"""Core subsystem — local embedding models and legacy knowledge graph."""
 
-# --- Auto-generated re-exports (fix_encapsulation.py) ---
 from src.core.embeddings import LocalBGEEmbeddings
 from src.core.knowledge_graph import (
     EntityExtractor,
@@ -10,3 +12,11 @@ from src.core.knowledge_graph import (
     KnowledgeGraphBuilder,
     export_obsidian,
 )
+
+__all__ = [
+    "LocalBGEEmbeddings",
+    "EntityExtractor",
+    "GraphQueryExpander",
+    "KnowledgeGraphBuilder",
+    "export_obsidian",
+]


### PR DESCRIPTION
## Summary
- Replaced stale auto-generated comment in `src/core/__init__.py` with a proper `@summary` block following codebase conventions
- Added module docstring describing the core subsystem
- Added `__all__` list for explicit public API surface (5 exports)

## Test plan
- [x] Verified `__all__` contents via AST parsing
- [x] Confirmed existing tests are unaffected (pre-existing failures in unrelated modules only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)