### PR TITLE
feat: configurable KG extraction retry + GLiNER threshold

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -117,6 +117,11 @@ RAG_KG_GRAPH_CONTEXT_TOKEN_BUDGET: int = int(
 RAG_KG_ENABLE_GRAPH_CONTEXT_INJECTION: bool = os.environ.get(
     "RAG_KG_ENABLE_GRAPH_CONTEXT_INJECTION", "false"
 ).lower() in ("true", "1", "yes")
+# LLM extraction rate-limit retry policy
+RAG_KG_LLM_RATE_LIMIT_RETRIES = int(os.environ.get("RAG_KG_LLM_RATE_LIMIT_RETRIES", "3"))
+RAG_KG_LLM_RATE_LIMIT_BACKOFF_S = float(os.environ.get("RAG_KG_LLM_RATE_LIMIT_BACKOFF_S", "1.0"))
+# GLiNER entity prediction confidence threshold
+RAG_KG_GLINER_THRESHOLD = float(os.environ.get("RAG_KG_GLINER_THRESHOLD", "0.5"))
 
 # --- Semantic Chunking ---
 SEMANTIC_CHUNKING_ENABLED = os.environ.get(

--- a/src/knowledge_graph/extraction/gliner_extractor.py
+++ b/src/knowledge_graph/extraction/gliner_extractor.py
@@ -2,7 +2,8 @@
 # GLiNER-based zero-shot NER entity extractor for the KG subsystem.
 # Exports: GLiNEREntityExtractor
 # Deps: re, logging, typing, src.knowledge_graph.common.schemas, src.knowledge_graph.common.types,
-#       src.knowledge_graph.common.utils, src.knowledge_graph.extraction.regex_extractor
+#       src.knowledge_graph.common.utils, src.knowledge_graph.extraction.regex_extractor,
+#       config.settings
 # @end-summary
 """GLiNER entity extractor for the KG subsystem.
 
@@ -171,7 +172,8 @@ class GLiNEREntityExtractor:
         entities: List[str] = []
         seen: set[str] = set()
 
-        predictions = self._model.predict_entities(clean, self._labels, threshold=0.5)
+        from config.settings import RAG_KG_GLINER_THRESHOLD
+        predictions = self._model.predict_entities(clean, self._labels, threshold=RAG_KG_GLINER_THRESHOLD)
         for pred in predictions:
             entity_text = pred["text"].strip()
             if len(entity_text) <= 2:

--- a/src/knowledge_graph/extraction/llm_extractor.py
+++ b/src/knowledge_graph/extraction/llm_extractor.py
@@ -4,7 +4,8 @@
 # Validates results against SchemaDefinition, handles retries and rate limits.
 # Exports: LLMEntityExtractor
 # Deps: json, logging, time, src.knowledge_graph.common.schemas,
-#        src.knowledge_graph.common.types, src.platform.llm.provider
+#        src.knowledge_graph.common.types, src.platform.llm.provider,
+#        config.settings
 # @end-summary
 """LLM-based entity and relationship extraction.
 
@@ -297,8 +298,9 @@ class LLMEntityExtractor:
         Raises:
             Exception: Re-raises non-rate-limit errors after logging.
         """
-        max_rate_limit_retries = 3
-        backoff_seconds = 1.0
+        from config.settings import RAG_KG_LLM_RATE_LIMIT_RETRIES, RAG_KG_LLM_RATE_LIMIT_BACKOFF_S
+        max_rate_limit_retries = RAG_KG_LLM_RATE_LIMIT_RETRIES
+        backoff_seconds = RAG_KG_LLM_RATE_LIMIT_BACKOFF_S
 
         for attempt in range(max_rate_limit_retries + 1):
             try:


### PR DESCRIPTION
## Summary
- Add `RAG_KG_LLM_RATE_LIMIT_RETRIES`, `RAG_KG_LLM_RATE_LIMIT_BACKOFF_S`, and `RAG_KG_GLINER_THRESHOLD` config keys to `config/settings.py`
- Wire retry/backoff config into `llm_extractor.py` replacing hardcoded values
- Wire GLiNER prediction threshold into `gliner_extractor.py` replacing hardcoded `0.5`

## Test plan
- [x] `python3 -c "from config.settings import RAG_KG_LLM_RATE_LIMIT_RETRIES, RAG_KG_LLM_RATE_LIMIT_BACKOFF_S, RAG_KG_GLINER_THRESHOLD; print('config ok')"` passes
- [x] All 81 KG unit tests pass (`pytest tests/knowledge_graph/`)
- [ ] Verify env var overrides work in integration (e.g. `RAG_KG_GLINER_THRESHOLD=0.7`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)