### PR TITLE
refactor: route src.retrieval imports through public API

### DIFF
--- a/server/activities.py
+++ b/server/activities.py
@@ -2,7 +2,7 @@
 # Temporal activity that executes RAG queries against a preloaded RAGChain singleton.
 # The singleton is initialized once by the worker at startup — not per request.
 # Exports: execute_rag_query, init_rag_chain, shutdown_rag_chain
-# Deps: temporalio, src.retrieval.pipeline.rag_chain, dataclasses
+# Deps: temporalio, src.retrieval, dataclasses
 # @end-summary
 """Temporal activities for the RAG query pipeline.
 
@@ -37,7 +37,7 @@ def init_rag_chain() -> None:
         logger.warning("RAGChain already initialized, skipping re-init")
         return
 
-    from src.retrieval.pipeline import RAGChain
+    from src.retrieval import RAGChain
     logger.info("Initializing RAGChain (loading models into memory)...")
     start = time.time()
     _rag_chain = RAGChain()

--- a/server/worker.py
+++ b/server/worker.py
@@ -2,7 +2,7 @@
 # Temporal worker that preloads RAGChain at startup, then processes query
 # activities. Models load once (~22s) and stay in GPU memory for all requests.
 # Exports: main
-# Deps: temporalio, server.activities, server.workflows, config.settings
+# Deps: temporalio, server.activities, server.workflows, config.settings, src.retrieval
 # @end-summary
 """Temporal worker — the process where GPU models live.
 
@@ -72,7 +72,7 @@ async def main() -> None:
     logger.info("Models loaded in %.1fs — ready to serve queries", time.time() - start)
 
     # Phase 1b: Pre-warm Ollama so the first query doesn't pay cold-start cost
-    from src.retrieval.query.nodes import warm_up_ollama
+    from src.retrieval import warm_up_ollama
     warm_up_ollama()
 
     # Phase 2: Connect to Temporal

--- a/src/guardrails/shared/faithfulness.py
+++ b/src/guardrails/shared/faithfulness.py
@@ -2,7 +2,7 @@
 # Faithfulness and hallucination detection rail using NeMo self-check-facts
 # approach with claim scoring, entity hallucination detection, and LLM fallback.
 # Exports: FaithfulnessChecker, FaithfulnessResult, ClaimScore
-# Deps: config.settings, logging, re, json
+# Deps: config.settings, src.retrieval, src.common, logging, re, json
 # @end-summary
 """Faithfulness and hallucination detection rail.
 
@@ -250,9 +250,9 @@ class FaithfulnessChecker:
         )
 
         try:
-            from src.retrieval.query.nodes import _call_ollama
+            from src.retrieval import call_ollama
 
-            response = _call_ollama(
+            response = call_ollama(
                 prompt,
                 system=(
                     "You are a faithfulness evaluator. Output only a number "
@@ -298,10 +298,10 @@ class FaithfulnessChecker:
         )
 
         try:
-            from src.retrieval.query.nodes import _call_ollama
+            from src.retrieval import call_ollama
             from src.common import parse_json_object
 
-            response = _call_ollama(
+            response = call_ollama(
                 prompt,
                 system="You are a faithfulness evaluator. Output only JSON.",
             )

--- a/src/guardrails/shared/injection.py
+++ b/src/guardrails/shared/injection.py
@@ -3,7 +3,7 @@
 # classifier, regex patterns, and LLM fallback. Defense-in-depth layered approach.
 # Runtime injected at construction — no direct GuardrailsRuntime.get() call.
 # Exports: InjectionDetector, InjectionResult
-# Deps: src.guardrails.common.schemas, config.settings, logging, hashlib, re
+# Deps: src.guardrails.common.schemas, config.settings, src.retrieval, src.common, logging, hashlib, re
 # @end-summary
 """Injection and jailbreak detection rail.
 
@@ -301,10 +301,10 @@ class InjectionDetector:
             f"<msg>{query}</msg>"
         )
 
-        from src.retrieval.query.nodes import _call_ollama
+        from src.retrieval import call_ollama
         from src.common import parse_json_object
 
-        result = _call_ollama(
+        result = call_ollama(
             prompt, system="You are a security classifier. Output only JSON."
         )
         if result:

--- a/src/guardrails/shared/topic_safety.py
+++ b/src/guardrails/shared/topic_safety.py
@@ -3,7 +3,7 @@
 # Adapted from NeMo's built-in topic_safety library action.
 # Runtime injected at construction — no direct GuardrailsRuntime.get() call.
 # Exports: TopicSafetyChecker, TopicSafetyResult
-# Deps: src.guardrails.common.schemas, logging
+# Deps: src.guardrails.common.schemas, src.retrieval, logging
 # @end-summary
 """Topic safety rail for off-topic query detection.
 
@@ -132,9 +132,9 @@ class TopicSafetyChecker:
             `TopicSafetyResult` derived from the LLM's "on-topic"/"off-topic"
             response.
         """
-        from src.retrieval.query.nodes import _call_ollama
+        from src.retrieval import call_ollama
 
-        result = _call_ollama(
+        result = call_ollama(
             f"User message: {query}",
             system=self._system_prompt,
         )

--- a/src/guardrails/shared/toxicity.py
+++ b/src/guardrails/shared/toxicity.py
@@ -2,7 +2,7 @@
 # Toxicity detection rail using NeMo self-check prompts with keyword fallback.
 # Runtime injected at construction — no direct GuardrailsRuntime.get() call.
 # Exports: ToxicityFilter, ToxicityResult
-# Deps: src.guardrails.common.schemas, config.settings, logging, re
+# Deps: src.guardrails.common.schemas, config.settings, src.retrieval, logging, re
 # @end-summary
 """Toxicity filtering rail.
 
@@ -147,9 +147,9 @@ class ToxicityFilter:
         else:
             prompt = _SELF_CHECK_INPUT_PROMPT.format(text=text)
 
-        from src.retrieval.query.nodes import _call_ollama
+        from src.retrieval import call_ollama
 
-        result = _call_ollama(
+        result = call_ollama(
             prompt,
             system="You are a content safety classifier. Output only 'yes' or 'no'.",
         )

--- a/src/retrieval/__init__.py
+++ b/src/retrieval/__init__.py
@@ -1,6 +1,6 @@
 # @summary
 # Retrieval package public API.
-# Exports: RAGRequest, RAGChain, RAGResponse, process_query, QueryResult, QueryAction, LocalBGEReranker, RankedResult, OllamaGenerator, ConfidenceBreakdown, PostGuardrailAction, compute_composite_confidence
+# Exports: RAGRequest, RAGChain, RAGResponse, process_query, QueryResult, QueryAction, LocalBGEReranker, RankedResult, OllamaGenerator, ConfidenceBreakdown, PostGuardrailAction, compute_composite_confidence, warm_up_ollama, call_ollama
 # Deps: src.retrieval.common, src.retrieval.pipeline, src.retrieval.query, src.retrieval.generation
 # @end-summary
 
@@ -12,9 +12,11 @@ from src.retrieval.common import (
 from src.retrieval.query import (
     QueryAction,
     QueryResult,
+    warm_up_ollama,
 )
 from src.retrieval.query.nodes import process_query
 from src.retrieval.query.nodes import LocalBGEReranker
+from src.retrieval.query.nodes import _call_ollama as call_ollama
 from src.retrieval.pipeline import RAGChain
 from src.retrieval.generation.nodes import OllamaGenerator
 from src.retrieval.generation.confidence import (
@@ -36,4 +38,6 @@ __all__ = [
     "ConfidenceBreakdown",
     "PostGuardrailAction",
     "compute_composite_confidence",
+    "warm_up_ollama",
+    "call_ollama",
 ]


### PR DESCRIPTION
## Summary
- Added `warm_up_ollama` and `call_ollama` to `src/retrieval/__init__.py` public exports
- Updated `server/worker.py` and `server/activities.py` to import from `src.retrieval` instead of internal modules
- Updated 4 guardrails modules (`faithfulness`, `toxicity`, `topic_safety`, `injection`) to use `call_ollama` from the public API instead of `_call_ollama` from internal `query.nodes`
- Updated `@summary` dependency annotations in all modified files

## Test plan
- [ ] Verify `from src.retrieval import warm_up_ollama, call_ollama` resolves correctly
- [ ] Run guardrails unit tests to confirm LLM call paths still work
- [ ] Run server worker/activities tests to confirm RAGChain init path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)