### PR TITLE
fix: route db and vector_db imports through public API

### DIFF
--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -2,7 +2,8 @@
 # Public API for the db subsystem: config-driven backend dispatcher and document store functions.
 # Exports: create_persistent_client, get_client, close_client, ensure_bucket,
 #          put_document, get_document, delete_document, document_exists, get_document_url,
-#          list_documents, build_document_id, StoredDocument
+#          list_documents, build_document_id, StoredDocument,
+#          create_client, store_page_images, delete_page_images, get_page_image_url
 # Deps: config.settings, src.db.backend, src.db.common.schemas, src.db.minio.store
 # @end-summary
 """Public API for the document store subsystem (MinIO and future backends).
@@ -19,7 +20,14 @@ from typing import Any, Generator, Optional
 
 from src.db.backend import DocumentBackend
 from src.db.common import StoredDocument
-from src.db.minio import build_document_id
+from src.db.minio import (
+    build_document_id,
+    # Visual image operations
+    create_client,
+    delete_page_images,
+    get_page_image_url,
+    store_page_images,
+)
 
 logger = logging.getLogger("rag.db")
 
@@ -168,6 +176,11 @@ __all__ = [
     "document_exists",
     "get_document_url",
     "list_documents",
+    # Visual image operations
+    "create_client",
+    "delete_page_images",
+    "get_page_image_url",
+    "store_page_images",
     # Re-exported schemas and utilities
     "StoredDocument",
     "build_document_id",

--- a/src/ingest/embedding/nodes/visual_embedding.py
+++ b/src/ingest/embedding/nodes/visual_embedding.py
@@ -3,7 +3,7 @@
 # Extracts page images via Docling, stores in MinIO, embeds via ColQwen2,
 # indexes in Weaviate visual collection.
 # Exports: visual_embedding_node
-# Deps: src.ingest.support.colqwen, src.db.minio.store,
+# Deps: src.ingest.support.colqwen, src.db,
 #       src.vector_db.weaviate.visual_store, src.ingest.common.shared
 # @end-summary
 
@@ -35,10 +35,7 @@ from typing import Any
 
 from PIL import Image
 
-from src.db.minio import (
-    delete_page_images,
-    store_page_images,
-)
+from src.db import delete_page_images, store_page_images
 from src.ingest.common import append_processing_log
 from src.ingest.embedding.state import EmbeddingPipelineState
 from src.ingest.support import (

--- a/src/retrieval/pipeline/rag_chain.py
+++ b/src/retrieval/pipeline/rag_chain.py
@@ -305,10 +305,7 @@ class RAGChain:
             vs_span.set_attribute("result_count", len(page_records))
 
         # FR-607: generate presigned URLs per result (per-page isolation — NFR-905)
-        from src.db.minio import (
-            create_client,
-            get_page_image_url,
-        )
+        from src.db import create_client, get_page_image_url
 
         results: List[VisualPageResult] = []
         with self.tracer.span("visual_retrieval.presigned_urls"):

--- a/src/retrieval/query/nodes/reranker.py
+++ b/src/retrieval/query/nodes/reranker.py
@@ -3,7 +3,7 @@
 # Key exports: LocalBGEReranker, RankedResult
 # Deps: transformers, torch, config.settings (RERANKER_MODEL_PATH, RERANK_TOP_K,
 #       RERANKER_MAX_LENGTH, RERANKER_BATCH_SIZE, RERANKER_PRECISION),
-#       src.vector_db.common.schemas, src.retrieval.common.schemas,
+#       src.vector_db, src.retrieval.common.schemas,
 #       src.retrieval.common.exceptions
 # @end-summary
 """Local BAAI bge-reranker-v2-m3 wrapper for reranking search results.
@@ -28,7 +28,7 @@ from config.settings import (
     RERANKER_PRECISION,
 )
 from src.platform.observability import get_tracer
-from src.vector_db.common import SearchResult
+from src.vector_db import SearchResult
 from src.retrieval.common import RankedResult
 from src.retrieval.common import ModelLoadError
 


### PR DESCRIPTION
## Summary
- Added `store_page_images`, `delete_page_images`, `get_page_image_url`, and `create_client` to `src/db/__init__.py` public exports
- Updated `src/ingest/embedding/nodes/visual_embedding.py` to import from `src.db` instead of `src.db.minio`
- Updated `src/retrieval/pipeline/rag_chain.py` to import from `src.db` instead of `src.db.minio`
- Updated `src/retrieval/query/nodes/reranker.py` to import `SearchResult` from `src.vector_db` instead of `src.vector_db.common`

## Test plan
- [ ] Verify `from src.db import store_page_images, delete_page_images, get_page_image_url, create_client` works
- [ ] Verify `from src.vector_db import SearchResult` works
- [ ] Run visual embedding pipeline end-to-end
- [ ] Run retrieval pipeline with visual retrieval enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)