### PR TITLE
fix: 3 production safety bugs in retry, streaming, and dict access

### DIFF
--- a/server/routes/query.py
+++ b/server/routes/query.py
@@ -489,8 +489,8 @@ def create_query_router(
                     )
                     return
 
-                context_texts = [c["text"] for c in chunks]
-                scores = [c["score"] for c in chunks]
+                context_texts = [c.get("text", "") for c in chunks]
+                scores = [c.get("score", 0.0) for c in chunks]
                 gen_start = time.perf_counter()
                 token_count = 0
                 generation_stages: list[dict] = []
@@ -531,7 +531,7 @@ def create_query_router(
                         "token_budget": _stream_token_budget,
                     },
                 )
-                if request.memory_enabled:
+                if request.memory_enabled and stream_error_message is None:
                     mem_start = time.perf_counter()
                     memory.append_turn(
                         tenant_id=tenant_id,

--- a/src/platform/reliability/local_retry.py
+++ b/src/platform/reliability/local_retry.py
@@ -63,6 +63,10 @@ class LocalRetryProvider(RetryProvider):
                 time.sleep(backoff)
                 backoff = min(backoff * policy.backoff_multiplier, policy.max_backoff_seconds)
 
-        assert last_error is not None
+        if last_error is None:
+            raise RuntimeError(
+                f"Unexpected state: {operation_name} exhausted {policy.max_attempts} "
+                "attempts but no exception was raised"
+            )
         raise last_error
 


### PR DESCRIPTION
## Summary
- **Replace assert with explicit error in retry logic** (`src/platform/reliability/local_retry.py`): `assert last_error is not None` is stripped by `python -O`, causing a confusing `raise None`. Now raises `RuntimeError` with a descriptive message.
- **Prevent memory pollution on stream error** (`server/routes/query.py`): When generation fails, the code no longer appends user/assistant turns to conversation memory, avoiding history corruption.
- **Defensive dict access on activity results** (`server/routes/query.py`): `c["text"]` and `c["score"]` replaced with `.get()` defaults to prevent `KeyError` on unexpected Temporal activity payloads.

## Test plan
- [x] Syntax verified via `py_compile` for both files
- [x] Unit tests pass (pre-existing failure in `tests/import_check/test_fixer.py` is unrelated)
- [ ] Manual verification: confirm retry exhaustion raises RuntimeError under `-O`
- [ ] Manual verification: confirm failed stream does not append to conversation memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)