### PR TITLE
fix: prevent Triple mutation and validate document_id before MinIO ops

### DIFF
--- a/src/ingest/embedding/nodes/visual_embedding.py
+++ b/src/ingest/embedding/nodes/visual_embedding.py
@@ -186,6 +186,18 @@ def _run_visual_embedding(
     minio_client = runtime.db_client  # Optional[Any]; None if not configured
     weaviate_client = runtime.weaviate_client
     document_id: str = state.get("document_id", "")
+    if not document_id:
+        logger.error(
+            "visual_embedding_node: document_id is empty — skipping MinIO operations"
+        )
+        return {
+            "visual_stored_count": 0,
+            "page_images": None,
+            "errors": [*(state.get("errors") or []), "visual_embedding:missing_document_id"],
+            "processing_log": append_processing_log(
+                state, "visual_embedding:error:no_document_id"
+            ),
+        }
     source_key: str = state.get("source_key", "")
     total_pages = len(page_data)
 

--- a/src/knowledge_graph/extraction/regex_extractor.py
+++ b/src/knowledge_graph/extraction/regex_extractor.py
@@ -172,18 +172,26 @@ class RegexEntityExtractor:
             for e in raw_entities
         ]
 
-        # raw_relations already returns List[Triple] from extract_relations
-        for triple in raw_relations:
-            triple.source = source
-            triple.extractor_source = self.extractor_name
+        # Construct new Triple objects to avoid mutating shared references.
+        triples: List[Triple] = [
+            Triple(
+                subject=t.subject,
+                predicate=t.predicate,
+                object=t.object,
+                source=source,
+                weight=t.weight,
+                extractor_source=self.extractor_name,
+            )
+            for t in raw_relations
+        ]
 
         logger.debug(
             "RegexEntityExtractor.extract: source=%r entities=%d triples=%d",
             source,
             len(entity_list),
-            len(raw_relations),
+            len(triples),
         )
-        return ExtractionResult(entities=entity_list, triples=raw_relations)
+        return ExtractionResult(entities=entity_list, triples=triples)
 
     # ------------------------------------------------------------------
     # Entity extraction


### PR DESCRIPTION
## Summary
- **regex_extractor.py**: Replace in-place Triple mutation with new object construction to prevent shared-reference corruption when Triple objects are cached or reused across extractors.
- **visual_embedding.py**: Add early-return guard when `document_id` is empty, preventing invalid MinIO delete/store calls with empty keys.

## Test plan
- [x] All 81 knowledge_graph tests pass
- [x] Syntax verified for both changed files
- [x] Import verification for regex_extractor module

🤖 Generated with [Claude Code](https://claude.com/claude-code)