### PR TITLE
chore: remove dead imports and unused function

### DIFF
--- a/server/api.py
+++ b/server/api.py
@@ -63,7 +63,6 @@ from server.schemas import (
     QueryRequest,
 )
 import src.db as _db
-import src.vector_db as _vector_db
 
 # Use uvicorn's logger/formatter so API logs match server output
 # (INFO prefix + colorized level formatting).

--- a/server/cli_client.py
+++ b/server/cli_client.py
@@ -292,30 +292,6 @@ def _truncate(text: str, max_len: int) -> str:
     return text[:max_len - 3] + "..." if len(text) > max_len else text
 
 
-def send_query(server: str, query: str, filters: dict) -> dict:
-    """Send a non-streaming query to the RAG API."""
-    payload = {
-        "query": query,
-        **filters,
-        "conversation_id": _CURRENT_CONVERSATION_ID,
-        "memory_enabled": _MEMORY_ENABLED,
-    }
-    data = orjson.dumps(payload)
-    headers = {"Content-Type": "application/json"}
-    if API_KEY:
-        headers["X-API-Key"] = API_KEY
-    elif BEARER_TOKEN:
-        headers["Authorization"] = f"Bearer {BEARER_TOKEN}"
-    req = urllib.request.Request(
-        f"{server}/query",
-        data=data,
-        headers=headers,
-        method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=120) as resp:
-        return orjson.loads(resp.read())
-
-
 def send_query_stream(server: str, query: str, filters: dict):
     """Stream a query via SSE. Yields (event_type, data_dict) tuples."""
     payload = {

--- a/src/guardrails/shared/faithfulness.py
+++ b/src/guardrails/shared/faithfulness.py
@@ -20,7 +20,7 @@ import orjson
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import Optional
 
 from src.guardrails.common import RailVerdict
 

--- a/src/ingest/impl.py
+++ b/src/ingest/impl.py
@@ -62,7 +62,6 @@ from src.ingest.common import (
     save_manifest,
     sha256_path,
 )
-from src.ingest.common import extract_keywords_fallback
 from src.ingest.common import (
     IngestFileResult,
     IngestionConfig,

--- a/src/ingest/support/llm.py
+++ b/src/ingest/support/llm.py
@@ -8,7 +8,6 @@
 
 from __future__ import annotations
 
-import orjson
 import logging
 
 from src.ingest.common import IngestionConfig

--- a/src/ingest/support/vision.py
+++ b/src/ingest/support/vision.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import base64
 import binascii
-import orjson
 import logging
 import mimetypes
 import re

--- a/src/knowledge_graph/common/schemas.py
+++ b/src/knowledge_graph/common/schemas.py
@@ -12,7 +12,7 @@ shared interchange format between extractors, backends, and query layers.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 
 __all__ = [

--- a/src/retrieval/generation/nodes/generator.py
+++ b/src/retrieval/generation/nodes/generator.py
@@ -6,7 +6,6 @@
 """LLM generator for RAG answer synthesis, backed by LiteLLM Router."""
 
 import logging
-import re
 from typing import List, Optional, Tuple
 
 from config.settings import (


### PR DESCRIPTION
## Summary
- Remove 7 unused imports across 7 files (`orjson` x2, `re`, `extract_keywords_fallback`, `_vector_db`, `Any`/`Callable` from typing)
- Remove dead `send_query()` function in `cli_client.py` (replaced by `send_query_stream()`)
- All verified by grep — zero references beyond the definition

## Test plan
- [x] All affected files still parse as valid Python
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)