### PR TITLE
feat: add multi-worker uvicorn support and Docker resource limits

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -200,6 +200,7 @@ TEMPORAL_TASK_QUEUE = os.environ.get("RAG_TEMPORAL_TASK_QUEUE", "rag-reliability
 
 # --- Server ---
 RAG_API_PORT = int(os.environ.get("RAG_API_PORT", "8000"))
+RAG_API_WORKERS = int(os.environ.get("RAG_API_WORKERS", "1"))
 RAG_API_URL = os.environ.get("RAG_API_URL", f"http://localhost:{RAG_API_PORT}")
 RAG_WORKER_CONCURRENCY = int(os.environ.get("RAG_WORKER_CONCURRENCY", "4"))
 RAG_API_MAX_INFLIGHT_REQUESTS = int(os.environ.get("RAG_API_MAX_INFLIGHT_REQUESTS", "64"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,11 +111,12 @@ services:
       args:
         RAG_API_PORT: ${RAG_API_PORT:-8000}
     container_name: rag-api
-    command: uvicorn server.api:app --host 0.0.0.0 --port ${RAG_API_PORT:-8000} --proxy-headers --forwarded-allow-ips='*'
+    command: uvicorn server.api:app --host 0.0.0.0 --port ${RAG_API_PORT:-8000} --workers ${RAG_API_WORKERS:-1} --proxy-headers --forwarded-allow-ips='*'
     ports:
       - "${RAG_API_HOST_PORT:-8000}:${RAG_API_PORT:-8000}"
     environment:
       - RAG_API_PORT=${RAG_API_PORT:-8000}
+      - RAG_API_WORKERS=${RAG_API_WORKERS:-1}
       - RAG_TEMPORAL_TARGET_HOST=temporal:${RAG_TEMPORAL_PORT:-7233}
       # API stream-generation needs Ollama access too.
       - RAG_OLLAMA_URL=http://host.docker.internal:${RAG_OLLAMA_PROXY_PORT:-11435}
@@ -147,6 +148,11 @@ services:
     restart: unless-stopped
     volumes:
       - ./.runtime:/app/.runtime
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 1G
     healthcheck:
       # Uses Python stdlib (curl was removed from the image in the 2026-04-10 optimization).
       # Works identically under docker-compose and podman-compose.
@@ -196,6 +202,11 @@ services:
       - ./.weaviate_data:/seed_weaviate:ro
       # Host model cache (read-only) for containerized worker startup.
       - ${RAG_MODEL_ROOT:-./models}:/models:ro
+    deploy:
+      resources:
+        limits:
+          cpus: "4.0"
+          memory: 8G
     # GPU note: if needed, run with NVIDIA container runtime enabled.
     # Example: set `gpus: all` here when your Docker setup supports it.
 

--- a/server/api.py
+++ b/server/api.py
@@ -35,6 +35,7 @@ from config.settings import (
     RAG_API_MAX_INFLIGHT_REQUESTS,
     RAG_API_OVERLOAD_QUEUE_TIMEOUT_MS,
     RAG_API_CORS_ORIGINS,
+    RAG_API_WORKERS,
     RAG_WORKFLOW_DEFAULT_TIMEOUT_MS,
     RATE_LIMIT_ENABLED,
     RATE_LIMIT_REQUESTS_PER_MINUTE,
@@ -151,6 +152,7 @@ def _release_request_slot(acquired: bool) -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     _validate_startup_config()
+    logger.info("API starting with %d uvicorn worker(s)", RAG_API_WORKERS)
     global _temporal_client
     logger.info("Connecting to Temporal at %s", TEMPORAL_TARGET_HOST)
     _temporal_client = await Client.connect(TEMPORAL_TARGET_HOST)


### PR DESCRIPTION
## Summary
- Add `RAG_API_WORKERS` config setting (default 1) to control uvicorn worker count for production throughput scaling
- Add `--workers` flag to the rag-api uvicorn command in docker-compose.yml
- Add `deploy.resources.limits` to rag-api (2 CPU / 1G RAM) and rag-worker (4 CPU / 8G RAM) to prevent runaway containers
- Log worker count at API startup for operational visibility

## Test plan
- [x] `python3 -c "from config.settings import RAG_API_WORKERS"` imports cleanly
- [x] `docker compose config` validates without errors
- [ ] Manual: start with `RAG_API_WORKERS=4` and verify uvicorn spawns 4 workers
- [ ] Manual: verify container respects memory/CPU limits under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)