### PR TITLE
docs(console-ui): refresh static/ READMEs to reflect bundled output

### DIFF
--- a/server/console/static/README.md
+++ b/server/console/static/README.md
@@ -1,17 +1,39 @@
 <!-- @summary
-Compiled browser assets for the operator console and user console UIs. Contains the HTML entry points, TypeScript-compiled JavaScript modules, and the user-facing subdirectory.
+Browser-ready assets for the dual web console: HTML entry points plus the bundled JavaScript outputs produced by esbuild from `../web/src/`. The admin console (`console.html`) loads `main.js`; the user console (`user/index.html`) loads `user-console.js`.
 @end-summary -->
 
 # server/console/static
 
-Browser-ready assets served by the console server. The TypeScript sources live in `../web/src/` and are compiled into this directory. The operator console (`console.html` + `main.js`) and the user console (`user/`) are kept at separate paths so the server can route them independently.
+Static assets served by the console server. The TypeScript sources live in `../web/src/` and are bundled into this directory by esbuild — see `../web/build.mjs`. Each entry point is bundled (with all its sibling modules inlined) into a single ES module per surface; the per-feature `.ts` files under `../web/src/` are not emitted as individual `.js` files here.
+
+## Bundle wiring
+
+| HTML | Bundle | Surface |
+| --- | --- | --- |
+| `console.html` | `main.js` | Admin / operator console (tabbed debug & ops UI) |
+| `user/index.html` | `user-console.js` | User chat console |
+
+Both bundles are emitted as native ES modules (`format: "esm"`, `target: "es2021"`). `marked` and `dompurify` are marked external in `build.mjs` and provided by the page itself: `user/index.html` declares them in a `<script type="importmap">`, and `console.html` loads them as plain `<script src="…cdn…">` tags before the module bundle.
 
 ## Contents
 
 | Path | Purpose |
 | --- | --- |
-| `console.html` | Operator console HTML entry point — tabbed UI for query, ingest, health, and admin |
-| `main.js` | Compiled operator console logic — typed fetch helpers, tab management, conversation management, markdown rendering, and timing display |
-| `types.js` | Compiled shared type stubs (no runtime exports; TypeScript-only) |
-| `user-console.js` | Compiled user console logic — sidebar, streaming chat, slash commands, settings, and citation rendering |
-| `user/` | User-facing console: HTML shell and CSS for the chat UI |
+| `console.html` | Admin console HTML entry point. Loads `main.js` as `<script type="module">`. |
+| `user/` | User console HTML shell + stylesheet (see `user/README.md`). |
+| `main.js` | esbuild bundle of `../web/src/main.ts` and its imports — admin console runtime. |
+| `user-console.js` | esbuild bundle of `../web/src/user-console.ts` and its 20+ sibling feature modules — user console runtime. |
+| `user-console.js.map` | Sourcemap for `user-console.js` (emitted by esbuild via `sourcemap: true`). A matching `main.js.map` is produced on every build. |
+| `types.js` | Empty/legacy artifact left over from the previous `tsc`-based per-file emit. Not loaded by either HTML page; can be removed once nothing references it. |
+
+## Rebuilding
+
+From the repo root:
+
+```bash
+npm --prefix server/console/web install
+npm --prefix server/console/web run build      # one-shot bundle via build.mjs
+npm --prefix server/console/web run watch      # rebuild on change
+```
+
+Or via the make targets: `make console-install && make console-build`.

--- a/server/console/static/user/README.md
+++ b/server/console/static/user/README.md
@@ -1,16 +1,18 @@
 <!-- @summary
-HTML shell and stylesheet for the end-user chat console. Provides the full single-page application layout — sidebar, message thread, input bar, settings panel, and context window indicator.
+Served HTML shell and stylesheet for the user-facing chat console. The runtime bundle (`user-console.js`) is loaded from the parent `static/` directory; it is produced by esbuild from `../../web/src/user-console.ts` (a thin orchestrator) plus 20+ sibling feature modules under `../../web/src/`.
 @end-summary -->
 
 # server/console/static/user
 
-Static assets for the user-facing RagWeave chat UI, served at `/console/user/`. The page is a single-page application: `index.html` defines all DOM structure and `styles.css` supplies the full visual design including dark/light themes, responsive layout, and component styles.
+Static assets for the user-facing RagWeave chat UI, served at `/console`. The page is a single-page application: `index.html` defines the DOM and `styles.css` supplies the visual design (themes, layout, components).
 
-The compiled JavaScript (`user-console.js`) is loaded from the parent `static/` directory and handles all runtime logic.
+The runtime JavaScript is **not** in this directory. `index.html` loads `/console/static/user-console.js` from the sibling `static/` directory — that bundle is emitted by esbuild from `../../web/src/user-console.ts`. The `.ts` entry point is a ~50-line orchestrator: the actual logic lives in 20+ sibling `.ts` modules under `../../web/src/` (for example `streaming.ts`, `sidebar.ts`, `slash.ts`, `attachments.ts`, `citations.ts`, `conversations.ts`, `settings.ts`, `thread.ts`, `input.ts`, `markdown.ts`, `state.ts`, `dom.ts`, `api.ts`, `toast.ts`, `refs.ts`, `scrollFab.ts`, `contextWindow.ts`, `user-types.ts`, …). esbuild bundles all of them into a single ES module before serving.
+
+`marked` and `dompurify` are not bundled — they are declared in the `<script type="importmap">` block at the bottom of `index.html` and loaded directly from a CDN by the browser.
 
 ## Contents
 
 | Path | Purpose |
 | --- | --- |
-| `index.html` | SPA shell — sidebar navigation, message thread, input bar with attachment toolbar, settings panel overlay, slash-command dropdown, and command picker |
-| `styles.css` | Full UI stylesheet — CSS custom properties for theming (dark/light/system), sidebar layout, message bubbles, citation cards, context window indicator, and responsive breakpoints |
+| `index.html` | SPA shell — sidebar navigation, message thread, input bar with attachment toolbar, settings panel overlay, slash-command dropdown, command picker, and the importmap + `<script type="module">` tag that boots `user-console.js`. |
+| `styles.css` | Full UI stylesheet — CSS custom properties for theming (dark/light/system), sidebar layout, message bubbles, citation cards, context window indicator, and responsive breakpoints. |


### PR DESCRIPTION
## Summary
- Rewrite `server/console/static/README.md` to describe the actual esbuild output (`main.js` for admin via `console.html`, `user-console.js` for user via `user/index.html`, plus sourcemaps) instead of the stale per-file `tsc` model.
- Rewrite `server/console/static/user/README.md` to clarify that the runtime bundle lives in the parent `static/` dir and that the real logic lives in 20+ sibling `.ts` modules under `../../web/src/` — the `user-console.ts` entry point is just a ~50-line orchestrator.
- Document bundle wiring per HTML entry point, the external `marked` / `dompurify` resolution (importmap on user, plain CDN script on admin), and the rebuild commands.

## Test plan
- [ ] Skim both READMEs against `server/console/static/`, `server/console/static/user/`, and `server/console/web/build.mjs` to confirm filenames, bundle outputs, and HTML entry-point claims still match.

Unit 6 of 9 in the `frontend/console-modularize-pr1` documentation refresh.

Generated with [Claude Code](https://claude.com/claude-code)