### PR TITLE
refactor(console-ui): harden escHtml + add format.ts shared utils

### DIFF
--- a/server/console/web/src/dom.ts
+++ b/server/console/web/src/dom.ts
@@ -15,7 +15,9 @@ export function escHtml(s: string): string {
         .replace(/&/g, "&amp;")
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;");
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;")
+        .replace(/\//g, "&#x2F;");
 }
 
 export function fmtTime(ms: number): string {

--- a/server/console/web/src/format.ts
+++ b/server/console/web/src/format.ts
@@ -1,0 +1,19 @@
+/**
+ * @summary
+ * Display formatting helpers for primitive values rendered in the console UI.
+ * Exports: fmtSize
+ * Deps: (none)
+ * @end-summary
+ */
+
+/**
+ * Humanize a byte count into B / KB / MB / GB using base-1024 units.
+ * Negative or non-finite inputs return "0 B".
+ */
+export function fmtSize(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}


### PR DESCRIPTION
## Summary
- Expand `escHtml` in `dom.ts` to escape `'` and `/` (OWASP-recommended set).
- Add new `format.ts` with `fmtSize(bytes)` for humanized byte counts.
- Existing call sites in `ingest.ts` and `main.ts` left untouched to avoid conflicts with parallel split PRs in this batch.

## Test plan
- [x] `tsc --noEmit` clean.
- [ ] esbuild build (skipped — node_modules not installed in worktree; verified types in main repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)