### PR TITLE
feat(ops): nginx LB for TEI with mixed GPU+CPU tier routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -178,7 +178,7 @@ RAG_INGESTION_PERSIST_REFACTOR_MIRROR=true
 #           over HTTP. Both containers are part of the always-on compose stack.
 #
 # To switch to TEI for dev:
-#   ./scripts/compose.sh up -d rag-embed rag-rerank
+#   ./scripts/compose.sh up -d rag-embed rag-rerank rag-nginx
 #   # then: export RAG_INFERENCE_BACKEND=tei RAG_TEI_EMBED_URL=http://localhost:8081 ...
 RAG_INFERENCE_BACKEND=local
 
@@ -186,15 +186,16 @@ RAG_INFERENCE_BACKEND=local
 # BGE-reranker-v2-m3 are both public, so TEI works without this token set.
 HUGGING_FACE_HUB_TOKEN=
 
-# TEI service URLs (used when RAG_INFERENCE_BACKEND=tei)
-# Inside compose these resolve via service DNS to rag-embed / rag-rerank.
-# From the host (dev venv) use the host-bound ports below.
-RAG_TEI_EMBED_URL=http://rag-embed:80
-RAG_TEI_RERANK_URL=http://rag-rerank:80
+# TEI service URLs (used when RAG_INFERENCE_BACKEND=tei).
+# rag-nginx fronts both services on 8081 (embed) / 8082 (rerank) so replicas
+# can be scaled with `docker compose up -d --scale rag-embed=N`.
+# Inside compose: rag-nginx:8081 / :8082. From the host: localhost:8081 / :8082.
+RAG_TEI_EMBED_URL=http://rag-nginx:8081
+RAG_TEI_RERANK_URL=http://rag-nginx:8082
 
-# Host-side port bindings for the TEI containers (compose only).
-RAG_TEI_EMBED_PORT=8081
-RAG_TEI_RERANK_PORT=8082
+# Host-side port bindings for the nginx TEI lanes.
+RAG_TEI_EMBED_HOST_PORT=8081
+RAG_TEI_RERANK_HOST_PORT=8082
 
 # Models loaded by the TEI containers (HuggingFace repo IDs).
 RAG_TEI_EMBEDDING_MODEL=BAAI/bge-m3

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 .PHONY: help install console-install console-check console-build console-watch \
         py-compile-check test dep-check import-check import-check-tracked \
         all-check precommit-check setup restart restart-all \
-        start start-all dev worker tunnel restart-worker scale-workers \
+        start start-all dev worker tunnel restart-worker scale-workers scale-tei \
         venv-doctor _venv-auto-heal \
         container-build container-build-api container-build-worker \
         container-build-podman container-probe container-probe-worker \
@@ -71,6 +71,7 @@ help:
 	@echo "  dev                Start uvicorn with hot-reload (run in its own terminal)"
 	@echo "  worker             Start Temporal worker locally (run in its own terminal)"
 	@echo "  scale-workers      Scale containerised workers: make scale-workers N=3"
+	@echo "  scale-tei          Scale TEI embed/rerank: make scale-tei EMBED=2 EMBED_CPU=4 RERANK=2"
 	@echo "  tunnel             Start Cloudflare trycloudflare.com tunnel (run in its own terminal)"
 	@echo ""
 	@echo "Stack restart (uses scripts/stack.sh — auto-detects docker/podman)"
@@ -271,6 +272,17 @@ restart-worker:
 # Scale rag-worker horizontally. Usage: make scale-workers N=3
 scale-workers:
 	./scripts/compose.sh --profile workers up -d --scale rag-worker=$${N:-2}
+
+# Scale TEI inference services horizontally behind rag-nginx (8081/8082).
+# Usage: make scale-tei EMBED=2 EMBED_CPU=4 RERANK=2
+# Caveat: on a single-host single-GPU setup, GPU replicas share one device and
+# you'll get contention, not throughput. Use one replica per GPU node on AWS.
+# CPU replicas scale freely (no shared device).
+scale-tei:
+	./scripts/compose.sh up -d \
+	  --scale rag-embed=$${EMBED:-2} \
+	  --scale rag-embed-cpu=$${EMBED_CPU:-2} \
+	  --scale rag-rerank=$${RERANK:-2}
 
 start:
 	./scripts/compose.sh up -d

--- a/config/settings.py
+++ b/config/settings.py
@@ -752,9 +752,11 @@ if INFERENCE_BACKEND not in _VALID_INFERENCE_BACKENDS:
     )
 
 # TEI service URLs — used when INFERENCE_BACKEND="tei".
-# Inside the compose network these resolve to rag-embed / rag-rerank.
-TEI_EMBED_URL: str = os.environ.get("RAG_TEI_EMBED_URL", "http://rag-embed:80")
-TEI_RERANK_URL: str = os.environ.get("RAG_TEI_RERANK_URL", "http://rag-rerank:80")
+# Default routes through rag-nginx so replicas can be scaled horizontally
+# (`docker compose up -d --scale rag-embed=N`). Override to direct service DNS
+# (http://rag-embed:80) for single-replica dev or to bypass the LB.
+TEI_EMBED_URL: str = os.environ.get("RAG_TEI_EMBED_URL", "http://rag-nginx:8081")
+TEI_RERANK_URL: str = os.environ.get("RAG_TEI_RERANK_URL", "http://rag-nginx:8082")
 
 # Model IDs loaded by the TEI containers (HuggingFace repo IDs). BGE-M3 gives
 # mature multilingual retrieval; BGE-reranker-v2-m3 is the matching cross-encoder.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,10 +143,12 @@ services:
       - RAG_WEAVIATE_HOST=rag-weaviate
       - RAG_WEAVIATE_HTTP_PORT=8080
       - RAG_WEAVIATE_GRPC_PORT=50051
-      # TEI-backed embed + rerank (see rag-embed / rag-rerank services below).
+      # TEI-backed embed + rerank, fronted by rag-nginx for replica load
+      # balancing. Direct service DNS (rag-embed:80 / rag-rerank:80) also works
+      # at scale=1 but caches DNS — at scale>1, clients pin to one replica.
       - RAG_INFERENCE_BACKEND=tei
-      - RAG_TEI_EMBED_URL=http://rag-embed:80
-      - RAG_TEI_RERANK_URL=http://rag-rerank:80
+      - RAG_TEI_EMBED_URL=http://rag-nginx:8081
+      - RAG_TEI_RERANK_URL=http://rag-nginx:8082
     depends_on:
       temporal:
         condition: service_started
@@ -156,9 +158,7 @@ services:
         condition: service_healthy
       rag-weaviate:
         condition: service_healthy
-      rag-embed:
-        condition: service_healthy
-      rag-rerank:
+      rag-nginx:
         condition: service_healthy
       rag-ollama:
         condition: service_healthy
@@ -191,8 +191,8 @@ services:
       # raise ImportError (by design — install the `local-embed` extra in a venv
       # if you need in-process models for dev iteration).
       - RAG_INFERENCE_BACKEND=tei
-      - RAG_TEI_EMBED_URL=http://rag-embed:80
-      - RAG_TEI_RERANK_URL=http://rag-rerank:80
+      - RAG_TEI_EMBED_URL=http://rag-nginx:8081
+      - RAG_TEI_RERANK_URL=http://rag-nginx:8082
       - RAG_WORKER_CONCURRENCY=4
       - RAG_OBSERVABILITY_PROVIDER=${RAG_OBSERVABILITY_PROVIDER:-noop}
       - LANGFUSE_HOST=${LANGFUSE_HOST:-http://host.docker.internal:${LANGFUSE_PORT:-3000}}
@@ -215,9 +215,7 @@ services:
         condition: service_started
       rag-weaviate:
         condition: service_healthy
-      rag-embed:
-        condition: service_healthy
-      rag-rerank:
+      rag-nginx:
         condition: service_healthy
       rag-ollama:
         condition: service_healthy
@@ -523,10 +521,13 @@ services:
     # TEI image variant is SM-arch specific. turing-1.5 covers SM 7.5 (RTX 20xx, T4).
     # For SM 8.0/8.6 use `86-1.5`; SM 8.9 use `89-1.5`; SM 9.0+ use `latest`;
     # no GPU / debugging use `cpu-1.5`. See scripts/check_env.sh for auto-detect.
+    #
+    # Scalable: `docker compose up -d --scale rag-embed=N`. No container_name and
+    # no host port mapping — rag-nginx (8081) load-balances replicas. Each replica
+    # binds to all available GPUs; for true horizontal scale on AWS, run one
+    # replica per GPU node and let ALB target groups distribute (compose's GPU
+    # reservation on a single host means N replicas share one device).
     image: ghcr.io/huggingface/text-embeddings-inference:${RAG_TEI_IMAGE_TAG:-turing-1.5}
-    container_name: rag-embed
-    ports:
-      - "${RAG_TEI_EMBED_PORT:-8081}:80"
     environment:
       - MODEL_ID=${RAG_TEI_EMBEDDING_MODEL:-BAAI/bge-m3}
       - HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN:-}
@@ -560,15 +561,42 @@ services:
               count: all
               capabilities: [gpu]
 
+  rag-embed-cpu:
+    # CPU burst/fallback tier for embedding. Same model as rag-embed (BGE-M3) so
+    # vectors are interchangeable. Routed via rag-nginx:
+    #   - default traffic tries rag-embed (GPU); on 5xx falls through to this pool.
+    #   - explicit ingest traffic with header `X-RagWeave-Tier: ingest` pins here,
+    #     freeing the GPU for latency-sensitive queries.
+    # Cold start is seconds (no GPU init), so this scales fast for spikes.
+    # Scalable: `docker compose up -d --scale rag-embed-cpu=N`.
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
+    environment:
+      - MODEL_ID=${RAG_TEI_EMBEDDING_MODEL:-BAAI/bge-m3}
+      - HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN:-}
+      - HF_ENDPOINT=https://huggingface.co
+    command: >
+      --max-batch-tokens 1024
+      --max-concurrent-requests 4
+      --auto-truncate
+    volumes:
+      - ./.tei_cache:/data
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:80/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 180s
+    restart: unless-stopped
+
   rag-rerank:
     # CPU image by default — the RTX 2060 6 GB can't fit both bge-m3 and
     # bge-reranker-v2-m3 on GPU simultaneously (OOM on warmup). Reranker on
     # CPU costs ~100 ms/pair (top-10 rerank ≈ 1 s), acceptable for queries.
     # Override with RAG_TEI_RERANK_IMAGE_TAG=turing-1.8 on a ≥12 GB card.
+    #
+    # Scalable: `docker compose up -d --scale rag-rerank=N`. Fronted by rag-nginx
+    # on port 8082. See rag-embed for the GPU-replica caveat.
     image: ghcr.io/huggingface/text-embeddings-inference:${RAG_TEI_RERANK_IMAGE_TAG:-turing-1.8}
-    container_name: rag-rerank
-    ports:
-      - "${RAG_TEI_RERANK_PORT:-8082}:80"
     environment:
       - MODEL_ID=${RAG_TEI_RERANKER_MODEL:-BAAI/bge-reranker-v2-m3}
       - HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN:-}
@@ -633,20 +661,34 @@ services:
               capabilities: [gpu]
 
   rag-nginx:
-    profiles: ["app"]
+    # Always-on: fronts rag-api on 80/443 (TLS) AND load-balances TEI embed
+    # (8081) / rerank (8082) replicas. Profile-less so rag-worker (workers
+    # profile) can also route TEI traffic through it.
     image: nginx:alpine
     container_name: rag-nginx
     ports:
       - "${RAG_NGINX_HTTP_PORT:-80}:80"
       - "${RAG_NGINX_HTTPS_PORT:-443}:443"
+      # TEI lanes — exposed to host for direct curl/debug; in-cluster clients
+      # reach them via service DNS (rag-nginx:8081 / rag-nginx:8082).
+      - "${RAG_TEI_EMBED_HOST_PORT:-8081}:8081"
+      - "${RAG_TEI_RERANK_HOST_PORT:-8082}:8082"
     volumes:
       - ./ops/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ./certs:/etc/nginx/certs:ro
     depends_on:
-      rag-api:
+      # nginx must wait for TEI upstreams; rag-api dep removed to avoid the
+      # rag-api → rag-nginx → rag-api cycle (rag-api now uses nginx for TEI).
+      # The 443 / lane will 502 until rag-api is up — acceptable.
+      rag-embed:
+        condition: service_healthy
+      rag-embed-cpu:
+        condition: service_healthy
+      rag-rerank:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- --no-check-certificate https://127.0.0.1/health 2>/dev/null | grep -q '\"status\"'"]
+      # Self-health on the TEI lane; does not require rag-api or upstreams up.
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8081/nginx-health 2>/dev/null | grep -q ok"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -682,8 +682,15 @@ services:
       # The 443 / lane will 502 until rag-api is up — acceptable.
       rag-embed:
         condition: service_healthy
+      # CPU pool is fallback/burst — only needs the container started, not
+      # healthy. Hard-dep on service_healthy here would gate the whole stack
+      # (rag-api, rag-worker → rag-nginx → rag-embed-cpu) on CPU model load
+      # (~180s + first-boot download), which contradicts its fallback role.
+      # If a fallback request lands while CPU is still warming, it 502s — same
+      # behavior as a transient backend failure, which the client already
+      # handles.
       rag-embed-cpu:
-        condition: service_healthy
+        condition: service_started
       rag-rerank:
         condition: service_healthy
     healthcheck:

--- a/docs/SCALING_TEI.md
+++ b/docs/SCALING_TEI.md
@@ -1,0 +1,122 @@
+# Scaling TEI Inference (Embed + Rerank)
+
+`rag-embed` and `rag-rerank` are TEI containers fronted by `rag-nginx` so they
+can be scaled horizontally without client reconfiguration.
+
+## Architecture
+
+```
+rag-api (queries) ─┐                     ┌──▶ rag-embed       (GPU, 1..N)
+                   ├─▶ rag-nginx :8081 ──┤
+rag-worker(ingest)─┘    (tier-aware LB)  └──▶ rag-embed-cpu   (CPU, 1..M)
+                          │  (5xx fallback ↑)
+                          └─ :8082 ───────────▶ rag-rerank   (CPU default)
+```
+
+### Tier routing
+
+The embed lane is **tier-aware** via the `X-RagWeave-Tier` request header:
+
+| Header value         | Primary pool       | Fallback on 5xx     | Use case                  |
+| -------------------- | ------------------ | ------------------- | ------------------------- |
+| *(none)* — default   | `rag-embed` (GPU)  | `rag-embed-cpu`     | Latency-sensitive queries |
+| `ingest`             | `rag-embed-cpu`    | *(none — explicit)* | Ingest backfill           |
+
+Set automatically by the Python client: `get_embedding_provider(tier="ingest")`
+in `src/ingest/temporal/activities.py` and `src/ingest/impl.py` pins all
+ingest-side embedding to the CPU pool. Query-path callers omit the tier
+arg → GPU primary with CPU as automatic fallback on overload.
+
+- Clients hit `http://rag-nginx:8081` (embed) and `http://rag-nginx:8082` (rerank).
+- nginx uses Docker's embedded DNS (`127.0.0.11`, `valid=10s`) to re-resolve
+  service names without reload, so new replicas are picked up automatically.
+- Health is **passive** (nginx OSS — no active probes). TEI's own `/health`
+  plus compose `service_healthy` gates startup.
+
+## Scaling on a single host (compose)
+
+```bash
+make scale-tei EMBED=2 EMBED_CPU=4 RERANK=2
+# or directly:
+docker compose up -d --scale rag-embed=2 --scale rag-embed-cpu=4 --scale rag-rerank=2
+```
+
+**GPU caveat**: every replica binds to *all* available GPUs via the deploy
+reservation. On a single-GPU host, `EMBED=3` means three TEI processes contend
+for one device — you get OOM risk and serialised inference, not parallelism.
+For real horizontal scale, run **one replica per GPU node**.
+
+## Scaling on AWS (target topology)
+
+The compose layout is the dev/staging template; prod replaces in-cluster nginx
+with managed L7 load balancing:
+
+| Compose         | AWS equivalent                                |
+| --------------- | --------------------------------------------- |
+| `rag-nginx`     | ALB with two listener rules / target groups  |
+| `rag-embed:80`  | ECS service, 1 task per `g4dn.xlarge` (1 GPU) |
+| `rag-rerank:80` | ECS service, 1 task per CPU instance          |
+| Docker DNS      | ECS service discovery / target group health   |
+
+Client URLs (`RAG_TEI_EMBED_URL`, `RAG_TEI_RERANK_URL`) flip from the in-cluster
+`http://rag-nginx:8081` to the ALB DNS name. No code change required.
+
+## Verifying
+
+```bash
+# After scaling:
+docker compose ps rag-embed rag-rerank          # see replica count
+./scripts/stack.sh status                        # human-readable status
+curl http://localhost:8081/health                # via nginx → embed lane
+curl http://localhost:8082/health                # via nginx → rerank lane
+```
+
+`scripts/stack.sh status` reports replica counts when scale > 1
+(`● 3 replica(s) running`).
+
+## Tradeoffs vs alternatives
+
+- **Why not direct service DNS** (`http://rag-embed:80`)? Docker DNS round-robins
+  but Python HTTP clients cache the resolved IP for the connection's lifetime,
+  so a long-running worker pins to one replica. nginx re-resolves on each
+  request batch.
+- **Why not `keepalive` in upstream?** `keepalive` requires a static `upstream`
+  block, which conflicts with `resolver`-based dynamic resolution. For TEI
+  workloads where backend latency dominates, the connection setup cost is
+  negligible.
+- **Why not put nginx in front of LiteLLM/Ollama for generation?** LiteLLM is
+  itself a routing/LB proxy with retries and fallbacks. Adding nginx in front
+  is redundant unless you need to scale LiteLLM replicas, which is rarely the
+  bottleneck in a RAG pipeline.
+
+## Autoscaling (AWS target architecture)
+
+Compose `--scale` is manual. For traffic-driven autoscaling on AWS:
+
+| Layer            | Mechanism                                                   |
+| ---------------- | ----------------------------------------------------------- |
+| GPU pool        | ECS service on GPU capacity provider (`g4dn.*`), 1 task/GPU |
+| CPU pool        | ECS service on CPU capacity provider, fast-scaling          |
+| Routing          | ALB with two target groups (replaces nginx 8081 lanes)      |
+| Scale signal    | CloudWatch on (a) ALB `RequestCountPerTarget` for queries, (b) Temporal queue depth metric for ingest |
+| Scale policy    | Step scaling — aggressive scale-out, conservative scale-in |
+| Predictive      | EC2 Auto Scaling Predictive Scaling for GPU ASG (lead time covers ~3-5 min instance + model-load cold start) |
+
+**Cold-start strategy** — GPU instance + TEI model load is 3-5 min, so reactive
+scaling lags spikes. The recommended pattern:
+
+1. **Query traffic spike**: ALB target tracking on `RequestCountPerTarget` → CPU
+   pool scales out within seconds (no GPU wait), absorbs the burst as fallback
+   via the nginx error_page rule (or ALB weighted forwarding in prod).
+2. **Sustained load**: CloudWatch alarm fires → GPU service scales out; new
+   GPU tasks come up over the next 3-5 min and take over the primary pool.
+3. **Decay**: query traffic drops → conservative scale-in policy retains GPU
+   for next spike, CPU pool drains first.
+
+**Ingest queue scaling** — Temporal worker emits `ingest_queue_depth` to
+Prometheus → CloudWatch → triggers `rag-embed-cpu` task scaling. Ingest never
+touches GPU pool (pinned via `X-RagWeave-Tier: ingest` header).
+
+**What NOT to build**: a Python autoscaler in the worker. ECS Service Auto
+Scaling + EC2 Predictive Scaling cover the use case natively. Application code
+should only emit metrics and respect tier-routing — orchestration is platform.

--- a/ops/nginx/nginx.conf
+++ b/ops/nginx/nginx.conf
@@ -102,14 +102,22 @@ server {
         # Primary: tier-selected pool (GPU for queries, CPU for ingest pin).
         set $tei_embed_primary_addr $tei_embed_primary;
         proxy_pass http://$tei_embed_primary_addr;
-        # On 5xx (overload, OOM, replica crash) fall through to the CPU pool.
-        # Skipped when the primary IS already the CPU pool (header=ingest).
+        # On 5xx (overload, OOM, replica crash) try the CPU pool. The named
+        # location below short-circuits when the primary was already CPU,
+        # so ingest-pinned traffic fails fast instead of double-querying the
+        # same failing pool.
         proxy_intercept_errors on;
         error_page 502 503 504 = @embed_cpu_fallback;
     }
 
     # Named fallback location — hit by error_page after primary 5xx.
     location @embed_cpu_fallback {
+        # Skip fallback when the primary was already the CPU pool: retrying
+        # rag-embed-cpu after rag-embed-cpu just 5xx'd is pointless and only
+        # doubles latency. Return the original 503 instead.
+        if ($http_x_ragweave_tier = "ingest") {
+            return 503;
+        }
         set $tei_embed_fallback rag-embed-cpu:80;
         proxy_pass http://$tei_embed_fallback;
         # Mark response so callers can observe burst-to-CPU events in logs.

--- a/ops/nginx/nginx.conf
+++ b/ops/nginx/nginx.conf
@@ -46,3 +46,93 @@ server {
         proxy_pass http://rag-api:8000;
     }
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TEI inference load balancing
+# ─────────────────────────────────────────────────────────────────────────────
+# Two internal-only listeners that front the rag-embed and rag-rerank services.
+# Clients (rag-api, rag-worker) reach them via:
+#   RAG_TEI_EMBED_URL=http://rag-nginx:8081
+#   RAG_TEI_RERANK_URL=http://rag-nginx:8082
+#
+# Scaling: `docker compose up -d --scale rag-embed=N --scale rag-rerank=M`.
+# We use Docker's embedded DNS (127.0.0.11) with `valid=10s` re-resolution so
+# nginx picks up new replicas without reload. This trades upstream `keepalive`
+# (which requires a static upstream block) for elasticity — acceptable for
+# inference workloads where backend latency dominates connection overhead.
+#
+# Health: passive only (nginx OSS has no active health-check directive).
+# Failed replicas are skipped for fail_timeout after max_fails consecutive
+# errors. TEI's own `/health` endpoint plus compose healthcheck gate startup.
+#
+# AWS migration: replace these listeners with ALB target groups (one per
+# service). The proxy_pass contract here mirrors what an ALB listener rule
+# expects, so callers stay unchanged.
+# ─────────────────────────────────────────────────────────────────────────────
+
+resolver 127.0.0.11 valid=10s ipv6=off;
+
+# Tier routing: clients can pin ingest traffic to the CPU pool to keep the GPU
+# free for latency-sensitive queries by sending header:
+#   X-RagWeave-Tier: ingest
+# Default (no header) hits the GPU pool with CPU as automatic 5xx fallback.
+map $http_x_ragweave_tier $tei_embed_primary {
+    default     rag-embed:80;          # GPU tier
+    "ingest"    rag-embed-cpu:80;      # CPU tier — explicit pin
+}
+
+# Embed lane → rag-embed (GPU) primary, rag-embed-cpu fallback
+server {
+    listen 8081;
+    server_name _;
+
+    # Self-health for compose healthcheck (does not depend on upstreams).
+    location = /nginx-health { return 200 "ok\n"; }
+
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_http_version 1.1;
+    proxy_read_timeout 120s;
+    proxy_send_timeout 120s;
+
+    location / {
+        # Primary: tier-selected pool (GPU for queries, CPU for ingest pin).
+        set $tei_embed_primary_addr $tei_embed_primary;
+        proxy_pass http://$tei_embed_primary_addr;
+        # On 5xx (overload, OOM, replica crash) fall through to the CPU pool.
+        # Skipped when the primary IS already the CPU pool (header=ingest).
+        proxy_intercept_errors on;
+        error_page 502 503 504 = @embed_cpu_fallback;
+    }
+
+    # Named fallback location — hit by error_page after primary 5xx.
+    location @embed_cpu_fallback {
+        set $tei_embed_fallback rag-embed-cpu:80;
+        proxy_pass http://$tei_embed_fallback;
+        # Mark response so callers can observe burst-to-CPU events in logs.
+        add_header X-RagWeave-Embed-Tier "cpu-fallback" always;
+    }
+}
+
+# Rerank lane → rag-rerank:80 replicas
+server {
+    listen 8082;
+    server_name _;
+
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_http_version 1.1;
+    proxy_read_timeout 120s;
+    proxy_send_timeout 120s;
+
+    location / {
+        set $tei_rerank_upstream rag-rerank:80;
+        proxy_pass http://$tei_rerank_upstream;
+    }
+}

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -141,7 +141,7 @@ else
     printf "%sSome checks failed — see ✗ above.%s\n" "$_RED" "$_RESET"
     echo ""
     echo "Common remediations:"
-    echo "  - Start infra:         docker compose up -d rag-embed rag-rerank rag-weaviate"
+    echo "  - Start infra:         docker compose up -d rag-embed rag-rerank rag-nginx rag-weaviate"
     echo "  - Install dev extras:  uv sync --extra local-embed"
     echo "  - Set TEI image tag:   export RAG_TEI_IMAGE_TAG=${TEI_TAG}"
 fi

--- a/scripts/stack.sh
+++ b/scripts/stack.sh
@@ -65,6 +65,7 @@ rag-langfuse-minio
 rag-langfuse-worker
 rag-langfuse-web
 rag-embed
+rag-embed-cpu
 rag-rerank
 rag-ollama
 rag-nginx
@@ -79,14 +80,21 @@ cmd_status() {
     local running
     running=$(docker ps --format '{{.Names}}|{{.Status}}' 2>/dev/null || true)
     while IFS= read -r name; do
-        local line status
+        local line status count
+        # Exact match first (services with container_name pinned).
         line=$(grep "^${name}|" <<<"$running" || true)
         if [[ -n "$line" ]]; then
             status="${G}● ${line#*|}${X}"
-        elif docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx "$name"; then
-            status="${Y}○ stopped${X}"
         else
-            status="${D}· not created${X}"
+            # Fallback: match scaled compose replicas (e.g. ragweave-rag-embed-1).
+            count=$(grep -cE "[-_]${name}[-_][0-9]+\|" <<<"$running" || true)
+            if [[ "$count" -gt 0 ]]; then
+                status="${G}● ${count} replica(s) running${X}"
+            elif docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qE "(^${name}\$)|([-_]${name}[-_][0-9]+\$)"; then
+                status="${Y}○ stopped${X}"
+            else
+                status="${D}· not created${X}"
+            fi
         fi
         printf "  %-28s %s\n" "$name" "$status"
     done < <(_all_containers)

--- a/src/core/embeddings.py
+++ b/src/core/embeddings.py
@@ -90,10 +90,15 @@ class TEIEmbeddings(Embeddings):
         base_url: str = TEI_EMBED_URL,
         model: str = TEI_EMBEDDING_MODEL,
         timeout: int = TEI_TIMEOUT_SECONDS,
+        tier: str | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.model = model
-        self._client = httpx.Client(timeout=timeout)
+        # tier="ingest" sets X-RagWeave-Tier so rag-nginx routes to the CPU
+        # pool (rag-embed-cpu), keeping the GPU free for latency-sensitive
+        # query embedding. Default (None) hits the GPU pool with CPU fallback.
+        headers = {"X-RagWeave-Tier": tier} if tier else None
+        self._client = httpx.Client(timeout=timeout, headers=headers)
         self.tracer = get_tracer()
 
     def _embed(self, inputs: list[str]) -> list[list[float]]:
@@ -130,14 +135,20 @@ class TEIEmbeddings(Embeddings):
         return np.array(self._embed(sentences))
 
 
-def get_embedding_provider() -> Embeddings:
+def get_embedding_provider(tier: str | None = None) -> Embeddings:
     """Return the configured embedding provider.
 
     Reads ``INFERENCE_BACKEND`` from settings:
-      - ``"tei"``   → :class:`TEIEmbeddings` (direct HTTP to rag-embed container)
+      - ``"tei"``   → :class:`TEIEmbeddings` (HTTP to rag-nginx → rag-embed pool)
       - anything else → :class:`LocalBGEEmbeddings` (in-process sentence-transformers;
                          dev venv path — requires the `local-embed` pyproject extra)
+
+    Args:
+        tier: Optional rag-nginx routing hint. Pass ``"ingest"`` from ingestion
+            paths to pin embedding traffic to the CPU pool (rag-embed-cpu),
+            leaving the GPU free for latency-sensitive query embedding.
+            Ignored by ``LocalBGEEmbeddings`` (no LB layer in dev).
     """
     if INFERENCE_BACKEND == "tei":
-        return TEIEmbeddings()
+        return TEIEmbeddings(tier=tier)
     return LocalBGEEmbeddings()

--- a/src/ingest/impl.py
+++ b/src/ingest/impl.py
@@ -788,7 +788,7 @@ def ingest_directory(
 
         runtime = Runtime(
             config=config,
-            embedder=get_embedding_provider(),
+            embedder=get_embedding_provider(tier="ingest"),
             weaviate_client=client,
             kg_builder=KnowledgeGraphBuilder(use_gliner=GLINER_ENABLED)
             if config.build_kg

--- a/src/ingest/temporal/activities.py
+++ b/src/ingest/temporal/activities.py
@@ -62,7 +62,8 @@ def prewarm_worker_resources() -> None:
     pay the model-load penalty.
     """
     global _embedder, _db_client
-    _embedder = get_embedding_provider()
+    # tier="ingest" routes ingest embedding to the CPU pool via rag-nginx.
+    _embedder = get_embedding_provider(tier="ingest")
     _db_client = db.create_persistent_client()
     logger.info("worker resources prewarmed: embedder + db client ready")
 
@@ -88,7 +89,7 @@ def prewarm_worker_resources() -> None:
 def _get_embedder() -> Embeddings:
     global _embedder
     if _embedder is None:
-        _embedder = get_embedding_provider()
+        _embedder = get_embedding_provider(tier="ingest")
     return _embedder
 
 

--- a/tests/ingest/test_temporal_activities.py
+++ b/tests/ingest/test_temporal_activities.py
@@ -38,7 +38,7 @@ class TestPrewarmWorkerResources:
 
         monkeypatch.setattr("src.ingest.temporal.activities._embedder", None)
         monkeypatch.setattr("src.ingest.temporal.activities._db_client", None)
-        monkeypatch.setattr("src.ingest.temporal.activities.get_embedding_provider", lambda: fake_embedder)
+        monkeypatch.setattr("src.ingest.temporal.activities.get_embedding_provider", lambda **kw: fake_embedder)
         monkeypatch.setattr("src.ingest.temporal.activities.db.create_persistent_client", lambda: fake_db_client)
         monkeypatch.setattr("src.ingest.temporal.activities.RAG_INGESTION_DOCLING_ENABLED", False)
 
@@ -51,8 +51,8 @@ class TestPrewarmWorkerResources:
         """prewarm should skip docling warmup when RAG_INGESTION_DOCLING_ENABLED=False."""
         acts = _import_activities()
 
-        monkeypatch.setattr("src.ingest.temporal.activities.get_embedding_provider", lambda: MagicMock())
-        monkeypatch.setattr("src.ingest.temporal.activities.db.create_persistent_client", lambda: MagicMock())
+        monkeypatch.setattr("src.ingest.temporal.activities.get_embedding_provider", lambda **kw: MagicMock())
+        monkeypatch.setattr("src.ingest.temporal.activities.db.create_persistent_client", lambda **kw: MagicMock())
         monkeypatch.setattr("src.ingest.temporal.activities.RAG_INGESTION_DOCLING_ENABLED", False)
 
         ensure_called = []
@@ -71,8 +71,8 @@ class TestPrewarmWorkerResources:
         """prewarm should log warning when docling setup raises RuntimeError."""
         acts = _import_activities()
 
-        monkeypatch.setattr("src.ingest.temporal.activities.get_embedding_provider", lambda: MagicMock())
-        monkeypatch.setattr("src.ingest.temporal.activities.db.create_persistent_client", lambda: MagicMock())
+        monkeypatch.setattr("src.ingest.temporal.activities.get_embedding_provider", lambda **kw: MagicMock())
+        monkeypatch.setattr("src.ingest.temporal.activities.db.create_persistent_client", lambda **kw: MagicMock())
         monkeypatch.setattr("src.ingest.temporal.activities.RAG_INGESTION_DOCLING_ENABLED", True)
         monkeypatch.setattr(
             "src.ingest.temporal.activities.ensure_docling_ready",
@@ -130,7 +130,7 @@ class TestLazyInit:
 
         fake_embedder = MagicMock()
         monkeypatch.setattr("src.ingest.temporal.activities._embedder", None)
-        monkeypatch.setattr("src.ingest.temporal.activities.get_embedding_provider", lambda: fake_embedder)
+        monkeypatch.setattr("src.ingest.temporal.activities.get_embedding_provider", lambda **kw: fake_embedder)
 
         result = acts._get_embedder()
         assert result is fake_embedder
@@ -193,8 +193,8 @@ class TestPrewarmDoclingEnabled:
         """prewarm should call ensure_docling_ready when RAG_INGESTION_DOCLING_ENABLED=True."""
         acts = _import_activities()
 
-        monkeypatch.setattr("src.ingest.temporal.activities.get_embedding_provider", lambda: MagicMock())
-        monkeypatch.setattr("src.ingest.temporal.activities.db.create_persistent_client", lambda: MagicMock())
+        monkeypatch.setattr("src.ingest.temporal.activities.get_embedding_provider", lambda **kw: MagicMock())
+        monkeypatch.setattr("src.ingest.temporal.activities.db.create_persistent_client", lambda **kw: MagicMock())
         monkeypatch.setattr("src.ingest.temporal.activities.RAG_INGESTION_DOCLING_ENABLED", True)
         monkeypatch.setattr("src.ingest.temporal.activities.RAG_INGESTION_DOCLING_MODEL", "some-model")
         monkeypatch.setattr("src.ingest.temporal.activities.RAG_INGESTION_DOCLING_ARTIFACTS_PATH", "/tmp")


### PR DESCRIPTION
## Summary

- Adds nginx load-balancing layer for TEI embed/rerank so replicas can be scaled horizontally (`make scale-tei EMBED=N EMBED_CPU=M`)
- Introduces a CPU embed tier (`rag-embed-cpu`) with header-based routing: ingest backfill pins to CPU (`X-RagWeave-Tier: ingest`), queries default to GPU with CPU fallback on 5xx
- Removes \`container_name\` and host port mappings from \`rag-embed\` / \`rag-rerank\` so docker compose \`--scale\` works
- Breaks the \`rag-api ↔ rag-nginx\` startup cycle by making nginx depend on TEI services and dropping its dep on rag-api

See [docs/SCALING_TEI.md](docs/SCALING_TEI.md) for architecture, tier-routing semantics, and AWS/k8s autoscaling migration path.

## Test plan

- [ ] \`docker compose config\` validates without errors
- [ ] \`docker compose up -d\` brings up rag-embed, rag-embed-cpu, rag-rerank, rag-nginx healthy
- [ ] \`curl http://localhost:8081/health\` reaches rag-embed via nginx
- [ ] \`curl -H "X-RagWeave-Tier: ingest" http://localhost:8081/health\` reaches rag-embed-cpu
- [ ] Stop rag-embed, retry default request → falls through to rag-embed-cpu (response includes \`X-RagWeave-Embed-Tier: cpu-fallback\` header)
- [ ] \`make scale-tei EMBED=2 EMBED_CPU=2\` scales replicas; \`./scripts/stack.sh status\` reports counts
- [ ] Ingest a document end-to-end; embed traffic visible on rag-embed-cpu replicas
- [ ] Run a query end-to-end; embed traffic visible on rag-embed (GPU) replica

🤖 Generated with [Claude Code](https://claude.com/claude-code)