### PR TITLE
fix(memory): fall back to no-op when Redis is unreachable

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -339,6 +339,12 @@ MEMORY_ENABLED = os.environ.get("RAG_MEMORY_ENABLED", "true").lower() in ("true"
 MEMORY_PROVIDER = os.environ.get("RAG_MEMORY_PROVIDER", "redis").strip().lower()
 MEMORY_REDIS_URL = os.environ.get("RAG_MEMORY_REDIS_URL", CACHE_REDIS_URL)
 MEMORY_REDIS_PREFIX = os.environ.get("RAG_MEMORY_REDIS_PREFIX", "rag:memory")
+# Timeout (seconds) for the connectivity ping issued when constructing the
+# Redis-backed memory provider. If the ping fails or times out, the factory
+# falls back to the no-op provider so request handlers do not 500.
+MEMORY_REDIS_CONNECT_TIMEOUT_S = float(
+    os.environ.get("RAG_MEMORY_REDIS_CONNECT_TIMEOUT_S", "1.0")
+)
 MEMORY_MAX_RECENT_TURNS = int(os.environ.get("RAG_MEMORY_MAX_RECENT_TURNS", "8"))
 MEMORY_MAX_CONTEXT_TOKENS_ESTIMATE = int(
     os.environ.get("RAG_MEMORY_MAX_CONTEXT_TOKENS_ESTIMATE", "1400")

--- a/src/platform/memory/provider.py
+++ b/src/platform/memory/provider.py
@@ -24,6 +24,7 @@ from config.settings import (
     MEMORY_MAX_CONTEXT_TOKENS_ESTIMATE,
     MEMORY_MAX_RECENT_TURNS,
     MEMORY_PROVIDER,
+    MEMORY_REDIS_CONNECT_TIMEOUT_S,
     MEMORY_REDIS_PREFIX,
     MEMORY_REDIS_URL,
     MEMORY_SUMMARY_MAX_SOURCE_TURNS,
@@ -301,16 +302,29 @@ class NoopConversationMemory(ConversationMemoryProvider):
 class RedisConversationMemory(ConversationMemoryProvider):
     """Redis-backed canonical conversation memory."""
 
-    def __init__(self, redis_url: str, key_prefix: str) -> None:
+    def __init__(
+        self,
+        redis_url: str,
+        key_prefix: str,
+        *,
+        connect_timeout_s: float = MEMORY_REDIS_CONNECT_TIMEOUT_S,
+    ) -> None:
         """Create a Redis-backed memory provider.
 
         Args:
             redis_url: Redis connection URL.
             key_prefix: Key prefix namespace for stored data.
+            connect_timeout_s: Socket connect/read timeout used for both the
+                eager connectivity ping in the factory and subsequent
+                operations. Configurable via ``RAG_MEMORY_REDIS_CONNECT_TIMEOUT_S``.
         """
         import redis  # type: ignore
 
-        self._client = redis.from_url(redis_url, decode_responses=True)
+        self._client = redis.from_url(
+            redis_url,
+            decode_responses=True,
+            socket_connect_timeout=connect_timeout_s,
+        )
         self._prefix = key_prefix.strip() or "rag:memory"
         self._llm_provider = get_llm_provider()
 
@@ -632,7 +646,12 @@ def get_conversation_memory() -> ConversationMemoryProvider:
     provider = MEMORY_PROVIDER.strip().lower()
     if provider == "redis":
         try:
-            _MEMORY = RedisConversationMemory(MEMORY_REDIS_URL, MEMORY_REDIS_PREFIX)
+            candidate = RedisConversationMemory(MEMORY_REDIS_URL, MEMORY_REDIS_PREFIX)
+            # `redis.from_url()` is lazy — connection errors only surface on
+            # first command. Eagerly ping so we can fall back to the no-op
+            # provider here rather than 500ing later inside a request handler.
+            candidate._client.ping()
+            _MEMORY = candidate
             return _MEMORY
         except Exception as exc:
             logger.warning("Memory Redis unavailable, falling back to no-op memory: %s", exc)

--- a/tests/test_conversation_memory_api.py
+++ b/tests/test_conversation_memory_api.py
@@ -180,7 +180,7 @@ class _FakeRedisModule:
     def __init__(self, client):
         self._client = client
 
-    def from_url(self, _url, decode_responses=True):
+    def from_url(self, _url, decode_responses=True, **_kwargs):
         return self._client
 
 

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -49,7 +49,7 @@ class _FakeRedisModule:
     def __init__(self, client):
         self._client = client
 
-    def from_url(self, _url, decode_responses=True):
+    def from_url(self, _url, decode_responses=True, **_kwargs):
         assert decode_responses is True
         return self._client
 


### PR DESCRIPTION
## Summary
- `get_conversation_memory()` advertises a fallback to `NoopConversationMemory` when Redis is down, but `redis.from_url()` is lazy — the connection error surfaced inside the `/query` handler instead, returning 500 and reddening CI (which has no Redis service).
- Add a configurable `socket_connect_timeout` (`RAG_MEMORY_REDIS_CONNECT_TIMEOUT_S`, default 1.0s) and eagerly `ping()` in the factory so connection failures resolve to no-op cleanly.
- Update the fake-redis test doubles to accept the new kwarg.

This unblocks the long-red `tests/test_api_error_envelope.py::test_success_response_has_ok_true` on develop.

## Test plan
- [x] `pytest tests/test_api_error_envelope.py` — 9 passed
- [x] `RAG_MEMORY_REDIS_URL=redis://127.0.0.1:1/0 RAG_MEMORY_REDIS_CONNECT_TIMEOUT_S=0.5 pytest tests/test_api_error_envelope.py::test_success_response_has_ok_true` — passes (verifies the fallback path)
- [x] `pytest tests/test_memory_provider.py tests/test_conversation_memory_api.py` — 22 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)