### PR TITLE
ci: pin temporalio and use uv sync --locked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      - name: Install locked dependencies
+        run: uv sync --locked --extra dev
       - name: Run tests
-        run: uv run --with pytest --with numpy python -m pytest tests/ingest tests/test_rate_limiter.py tests/test_cache_provider.py tests/test_security_auth.py tests/test_api_key_store.py tests/test_quota_store.py tests/test_query_processor.py tests/test_generator.py tests/test_validation.py tests/test_query_filters.py tests/test_rag_chain_budget.py tests/test_rag_chain_integration.py tests/test_api_schemas.py tests/test_mcp_adapter.py tests/test_api_error_envelope.py
+        run: uv run --no-sync python -m pytest tests/ingest tests/test_rate_limiter.py tests/test_cache_provider.py tests/test_security_auth.py tests/test_api_key_store.py tests/test_quota_store.py tests/test_query_processor.py tests/test_generator.py tests/test_validation.py tests/test_query_filters.py tests/test_rag_chain_budget.py tests/test_rag_chain_integration.py tests/test_api_schemas.py tests/test_mcp_adapter.py tests/test_api_error_envelope.py
       - name: Build console TypeScript UI
         run: npm --prefix server/console/web ci && npm --prefix server/console/web run check && npm --prefix server/console/web run build
       - name: Compile checks
-        run: uv run python -m py_compile server/api.py server/activities.py src/retrieval/pipeline/rag_chain.py
+        run: uv run --no-sync python -m py_compile server/api.py server/activities.py src/retrieval/pipeline/rag_chain.py
 

--- a/containers/requirements-api.txt
+++ b/containers/requirements-api.txt
@@ -3,7 +3,7 @@
 fastapi
 uvicorn[standard]
 pydantic>=2.0
-temporalio
+temporalio>=1.23,<2
 redis
 pyjwt[crypto]
 prometheus-client

--- a/containers/requirements-worker.txt
+++ b/containers/requirements-worker.txt
@@ -23,7 +23,7 @@ nemoguardrails>=0.21.0
 tree-sitter
 tree-sitter-verilog
 pyverilog
-temporalio
+temporalio>=1.23,<2
 redis
 langfuse
 pyyaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "langchain-text-splitters",
   "langgraph",
   "numpy",
-  "temporalio",
+  "temporalio>=1.23,<2",
   "langfuse",
   "fastapi",
   "uvicorn[standard]",

--- a/uv.lock
+++ b/uv.lock
@@ -5690,7 +5690,7 @@ requires-dist = [
     { name = "redis" },
     { name = "sentence-transformers", marker = "extra == 'local-embed'" },
     { name = "spacy", marker = "extra == 'pii'" },
-    { name = "temporalio" },
+    { name = "temporalio", specifier = ">=1.23,<2" },
     { name = "torch", marker = "extra == 'local-embed'", index = "https://download.pytorch.org/whl/cu124" },
     { name = "transformers", marker = "extra == 'local-embed'" },
     { name = "tree-sitter", marker = "extra == 'kg'" },


### PR DESCRIPTION
## Summary
- Pins `temporalio` to `>=1.23,<2` in `pyproject.toml`, `containers/requirements-worker.txt`, `containers/requirements-api.txt` so resolves can't drift away from the version `uv.lock` knows about.
- Switches CI from `uv run --with pytest --with numpy …` (which does a fresh resolve outside the lock) to `uv sync --locked --extra dev` followed by `uv run --no-sync …`, making CI installs deterministic and identical to local development.

## Why
PR #29 (`frontend/console-modularize-pr1`) failed CI with ~30 errors of the form:
```
ModuleNotFoundError: No module named 'temporalio.worker.workflow_sandbox';
'temporalio.worker' is not a package
```
The cause was `uv run --with X` resolving outside `uv.lock` and pulling a `temporalio` version where `worker` is a single module (not a package). `temporalio` was already a project dependency — just unpinned, with the `--with` flag bypassing the lock. Pinning + `uv sync --locked` removes the entire class of failure.

## Test plan
- [x] Full CI test set runs locally with the new install path (1214 passed, 5 skipped)
- [x] `uv sync --locked --extra dev` resolves cleanly
- [x] `from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner, SandboxRestrictions` works
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)