### PR TITLE
ci: fix all 39 CI failures on frontend branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      - name: Install locked dependencies
+        run: uv sync --locked --extra dev
       - name: Run tests
-        run: uv run --with pytest --with numpy python -m pytest tests/ingest tests/test_rate_limiter.py tests/test_cache_provider.py tests/test_security_auth.py tests/test_api_key_store.py tests/test_quota_store.py tests/test_query_processor.py tests/test_generator.py tests/test_validation.py tests/test_query_filters.py tests/test_rag_chain_budget.py tests/test_rag_chain_integration.py tests/test_api_schemas.py tests/test_mcp_adapter.py tests/test_api_error_envelope.py
+        run: uv run --no-sync python -m pytest tests/ingest tests/test_rate_limiter.py tests/test_cache_provider.py tests/test_security_auth.py tests/test_api_key_store.py tests/test_quota_store.py tests/test_query_processor.py tests/test_generator.py tests/test_validation.py tests/test_query_filters.py tests/test_rag_chain_budget.py tests/test_rag_chain_integration.py tests/test_api_schemas.py tests/test_mcp_adapter.py tests/test_api_error_envelope.py
       - name: Build console TypeScript UI
         run: npm --prefix server/console/web ci && npm --prefix server/console/web run check && npm --prefix server/console/web run build
       - name: Compile checks
-        run: uv run python -m py_compile server/api.py server/activities.py src/retrieval/pipeline/rag_chain.py
+        run: uv run --no-sync python -m py_compile server/api.py server/activities.py src/retrieval/pipeline/rag_chain.py
 

--- a/containers/requirements-api.txt
+++ b/containers/requirements-api.txt
@@ -3,7 +3,7 @@
 fastapi
 uvicorn[standard]
 pydantic>=2.0
-temporalio
+temporalio>=1.23,<2
 redis
 pyjwt[crypto]
 prometheus-client

--- a/containers/requirements-worker.txt
+++ b/containers/requirements-worker.txt
@@ -23,7 +23,7 @@ nemoguardrails>=0.21.0
 tree-sitter
 tree-sitter-verilog
 pyverilog
-temporalio
+temporalio>=1.23,<2
 redis
 langfuse
 pyyaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "langchain-text-splitters",
   "langgraph",
   "numpy",
-  "temporalio",
+  "temporalio>=1.23,<2",
   "langfuse",
   "fastapi",
   "uvicorn[standard]",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -261,7 +261,19 @@ def _install_stub_modules() -> None:
         sys.modules["PIL"] = pil
         sys.modules["PIL.Image"] = pil_image
 
-    if "temporalio" not in sys.modules:
+    # Only stub temporalio when the real package can't be imported. Tests that
+    # exercise sandbox/workflow code (e.g. test_temporal_worker.py) need the
+    # real `temporalio.worker.workflow_sandbox` submodule, which the stubs
+    # below don't provide. With temporalio pinned as a regular dependency the
+    # real package is always available, so this branch is mostly defensive.
+    _temporalio_available = "temporalio" in sys.modules
+    if not _temporalio_available:
+        try:
+            import temporalio as _real_temporalio  # noqa: F401
+            _temporalio_available = True
+        except ImportError:
+            pass
+    if not _temporalio_available:
         temporalio = types.ModuleType("temporalio")
 
         activity_mod = types.ModuleType("temporalio.activity")

--- a/tests/ingest/test_temporal_activities.py
+++ b/tests/ingest/test_temporal_activities.py
@@ -218,14 +218,17 @@ class TestPrewarmDoclingEnabled:
 
 
 class TestDocumentProcessingActivity:
-    def test_mock_document_processing_activity_returns_result(self, monkeypatch):
+    def test_mock_document_processing_activity_returns_result(self, monkeypatch, tmp_path):
         """document_processing_activity should call run_document_processing and return DocProcessingResult."""
         import asyncio
         import dataclasses
+        import hashlib
         acts = _import_activities()
         from src.ingest.common import IngestionConfig
 
-        config_dict = dataclasses.asdict(IngestionConfig())
+        config = IngestionConfig()
+        config.clean_store_dir = str(tmp_path)
+        config_dict = dataclasses.asdict(config)
         source_args = acts.SourceArgs(
             source_path="/tmp/doc.pdf",
             source_name="doc.pdf",
@@ -237,10 +240,11 @@ class TestDocumentProcessingActivity:
         )
         args = acts.ActivityArgs(source=source_args, config=config_dict)
 
+        cleaned_text = "Hello widgets."
         fake_result = {
             "errors": [],
             "source_hash": "abc123",
-            "clean_hash": "def456",
+            "cleaned_text": cleaned_text,
             "processing_log": ["step1", "step2"],
         }
 
@@ -255,7 +259,9 @@ class TestDocumentProcessingActivity:
 
         assert isinstance(result, acts.DocProcessingResult)
         assert result.source_hash == "abc123"
-        assert result.clean_hash == "def456"
+        # clean_hash is now derived from the cleaned_text written to CleanDocumentStore,
+        # not echoed from the run_document_processing result.
+        assert result.clean_hash == hashlib.sha256(cleaned_text.encode("utf-8")).hexdigest()
         assert result.errors == []
         assert result.processing_log == ["step1", "step2"]
 
@@ -341,15 +347,19 @@ class TestDocumentProcessingActivity:
 
 
 class TestEmbeddingPipelineActivity:
-    def test_mock_embedding_pipeline_activity_returns_result(self, monkeypatch):
+    def test_mock_embedding_pipeline_activity_returns_result(self, monkeypatch, tmp_path):
         """embedding_pipeline_activity should call run_embedding_pipeline and return EmbeddingResult."""
         import asyncio
         import dataclasses
         from contextlib import contextmanager
+        from pathlib import Path
         acts = _import_activities()
         from src.ingest.common import IngestionConfig
+        from src.ingest.common.clean_store import CleanDocumentStore
 
-        config_dict = dataclasses.asdict(IngestionConfig())
+        config = IngestionConfig()
+        config.clean_store_dir = str(tmp_path)
+        config_dict = dataclasses.asdict(config)
         source_args = acts.SourceArgs(
             source_path="/tmp/doc.pdf",
             source_name="doc.pdf",
@@ -360,6 +370,11 @@ class TestEmbeddingPipelineActivity:
             source_version="v1",
         )
         args = acts.ActivityArgs(source=source_args, config=config_dict)
+
+        # Phase 2 reads cleaned text from CleanDocumentStore; seed it.
+        CleanDocumentStore(Path(config.clean_store_dir)).write(
+            source_args.source_key, "doc body", {"source_key": source_args.source_key},
+        )
 
         fake_wv_client = MagicMock()
 
@@ -393,15 +408,19 @@ class TestEmbeddingPipelineActivity:
         assert result.metadata_keywords == ["widget", "foo"]
         assert result.errors == []
 
-    def test_mock_embedding_pipeline_activity_errors_propagated(self, monkeypatch):
+    def test_mock_embedding_pipeline_activity_errors_propagated(self, monkeypatch, tmp_path):
         """embedding_pipeline_activity propagates errors from run_embedding_pipeline."""
         import asyncio
         import dataclasses
         from contextlib import contextmanager
+        from pathlib import Path
         acts = _import_activities()
         from src.ingest.common import IngestionConfig
+        from src.ingest.common.clean_store import CleanDocumentStore
 
-        config_dict = dataclasses.asdict(IngestionConfig())
+        config = IngestionConfig()
+        config.clean_store_dir = str(tmp_path)
+        config_dict = dataclasses.asdict(config)
         source_args = acts.SourceArgs(
             source_path="/tmp/bad.pdf",
             source_name="bad.pdf",
@@ -412,6 +431,10 @@ class TestEmbeddingPipelineActivity:
             source_version="v1",
         )
         args = acts.ActivityArgs(source=source_args, config=config_dict)
+
+        CleanDocumentStore(Path(config.clean_store_dir)).write(
+            source_args.source_key, "doc body", {"source_key": source_args.source_key},
+        )
 
         @contextmanager
         def fake_get_client():
@@ -437,17 +460,20 @@ class TestEmbeddingPipelineActivity:
         assert result.errors == ["weaviate timeout"]
         assert result.stored_count == 0
 
-    def test_mock_embedding_pipeline_activity_with_kg_builder(self, monkeypatch):
+    def test_mock_embedding_pipeline_activity_with_kg_builder(self, monkeypatch, tmp_path):
         """embedding_pipeline_activity creates KnowledgeGraphBuilder when build_kg=True."""
         import asyncio
         import dataclasses
         from contextlib import contextmanager
+        from pathlib import Path
         acts = _import_activities()
         from src.ingest.common import IngestionConfig
+        from src.ingest.common.clean_store import CleanDocumentStore
 
         config = IngestionConfig()
         config.build_kg = True
         config.store_documents = False
+        config.clean_store_dir = str(tmp_path)
         config_dict = dataclasses.asdict(config)
 
         source_args = acts.SourceArgs(
@@ -460,6 +486,10 @@ class TestEmbeddingPipelineActivity:
             source_version="v1",
         )
         args = acts.ActivityArgs(source=source_args, config=config_dict)
+
+        CleanDocumentStore(Path(config.clean_store_dir)).write(
+            source_args.source_key, "doc body", {"source_key": source_args.source_key},
+        )
 
         @contextmanager
         def fake_get_client():

--- a/tests/ingest/test_temporal_worker.py
+++ b/tests/ingest/test_temporal_worker.py
@@ -351,7 +351,7 @@ class TestRunWorkerIntegration:
 
         class FakeWorker:
             def __init__(self, client, *, task_queue, max_concurrent_activities,
-                         workflows, activities):
+                         workflows, activities, **kwargs):
                 workers_created.append({
                     "queue": task_queue,
                     "slots": max_concurrent_activities,
@@ -400,7 +400,7 @@ class TestRunWorkerIntegration:
 
         class FakeWorker:
             def __init__(self, client, *, task_queue, max_concurrent_activities,
-                         workflows, activities):
+                         workflows, activities, **kwargs):
                 workers_created.append({
                     "queue": task_queue,
                     "slots": max_concurrent_activities,

--- a/tests/ingest/test_temporal_workflows.py
+++ b/tests/ingest/test_temporal_workflows.py
@@ -72,11 +72,16 @@ def _run(coro):
 
 
 def _ensure_workflow_sandbox_attrs(wf_mod):
-    """Ensure sandbox-only attributes exist on workflow module for testing."""
+    """Ensure sandbox-only attributes exist on workflow module for testing.
+
+    With real temporalio installed, ``workflow.logger`` exists but raises
+    ``_NotInWorkflowEventLoopError`` when called outside a workflow runtime.
+    These tests run workflow code directly (no Temporal harness), so we
+    unconditionally replace it with a stdlib logger.
+    """
     wf = wf_mod.workflow
-    if not hasattr(wf, 'logger'):
-        import logging
-        wf.logger = logging.getLogger("temporalio.workflow.test")
+    import logging
+    wf.logger = logging.getLogger("temporalio.workflow.test")
     if not hasattr(wf, 'execute_activity'):
         async def _noop(*a, **kw):
             raise NotImplementedError("execute_activity not patched")

--- a/tests/test_api_error_envelope.py
+++ b/tests/test_api_error_envelope.py
@@ -1,12 +1,49 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
 
 from server import api
+from src.platform.memory.schemas import ConversationMeta
 from src.platform.security import auth
 from src.platform.security.auth import authenticate_request, Principal
+
+
+@dataclass
+class _FakeMemory:
+    """In-memory conversation memory; avoids Redis dependency in CI."""
+
+    relevant: dict[str, list[str]] = field(default_factory=dict)
+    ignored: dict[str, list[str]] = field(default_factory=dict)
+
+    def _meta(self, conversation_id: str) -> ConversationMeta:
+        return ConversationMeta(
+            conversation_id=conversation_id or "conv_test",
+            tenant_id="t",
+            subject="s",
+            project_id="",
+        )
+
+    def ensure_conversation(self, *, tenant_id, subject, project_id, conversation_id=None, title=""):
+        return self._meta(conversation_id or "conv_test")
+
+    def build_context(self, **_kwargs):  # pragma: no cover - trivial stub
+        ctx = MagicMock()
+        ctx.context_text = ""
+        ctx.recent_turns = []
+        return ctx
+
+    def append_turn(self, **_kwargs):  # pragma: no cover - trivial stub
+        return None
+
+    def update_conversation_title(self, **_kwargs):  # pragma: no cover - trivial stub
+        return None
+
+    def compact_if_needed(self, **_kwargs):  # pragma: no cover - trivial stub
+        return None
 
 
 class _DummyWorkflowService:
@@ -166,13 +203,15 @@ def test_503_overload_uses_standard_envelope(monkeypatch):
 
 
 def _patched_client(monkeypatch, *, fail_query: bool = False):
-    """Return a TestClient with a stubbed Temporal connection."""
+    """Return a TestClient with stubbed Temporal + in-memory conversation memory."""
     _set_auth_defaults()
 
     async def _fake_connect(_target: str):
         return _DummyTemporalClient(fail_query=fail_query)
 
     monkeypatch.setattr(api.Client, "connect", _fake_connect)
+    fake = _FakeMemory()
+    monkeypatch.setattr("server.routes.query.get_conversation_memory", lambda: fake)
     return TestClient(api.app, raise_server_exceptions=False)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -5690,7 +5690,7 @@ requires-dist = [
     { name = "redis" },
     { name = "sentence-transformers", marker = "extra == 'local-embed'" },
     { name = "spacy", marker = "extra == 'pii'" },
-    { name = "temporalio" },
+    { name = "temporalio", specifier = ">=1.23,<2" },
     { name = "torch", marker = "extra == 'local-embed'", index = "https://download.pytorch.org/whl/cu124" },
     { name = "transformers", marker = "extra == 'local-embed'" },
     { name = "tree-sitter", marker = "extra == 'kg'" },


### PR DESCRIPTION
## Summary
Greens the CI on \`frontend/console-modularize-pr1\`. PR #29 currently has 39 test failures; this brings them all to zero (verified locally: **1982 passed, 5 skipped, 0 failed**).

## What changed
Five distinct fixes:

1. **Pin temporalio + lock-respecting CI** — `uv run --with pytest --with numpy` did fresh resolves outside `uv.lock`; the resolved \`temporalio\` sometimes lacked the \`worker.workflow_sandbox\` submodule. Pinned \`>=1.23,<2\` and switched CI to \`uv sync --locked --extra dev\` so installs are deterministic. (Mirrors PR #46 against develop.)
2. **Conftest stubs prefer real temporalio** — \`tests/conftest.py:264\` registered a flat \`temporalio.worker\` module. Now that temporalio is a hard dep, those stubs shadowed the real package. Conftest now skips stubbing when the real package can be imported.
3. **Seed CleanDocumentStore in \`test_temporal_activities.py\`** — Phase 2 reads from the store. Tests now point \`clean_store_dir\` at \`tmp_path\` and seed the entry before invoking the embedding activity. The Phase 1 \`clean_hash\` assertion was updated to compute \`sha256(cleaned_text)\` since the activity derives the hash from the actual content rather than echoing the result dict.
4. **Accept \`**kwargs\` in two FakeWorker classes** — \`test_temporal_worker.py\` integration tests had a strict signature that broke when the real worker started passing \`workflow_runner\`.
5. **Always swap \`workflow.logger\` in \`test_temporal_workflows.py\`** — real \`workflow.logger\` raises \`_NotInWorkflowEventLoopError\` outside a workflow runtime. \`_ensure_workflow_sandbox_attrs\` now unconditionally replaces it with a stdlib logger.

## Test plan
- [x] \`uv sync --locked --extra dev && uv run --no-sync python -m pytest <CI test set>\` → 1982 passed, 5 skipped, 0 failed
- [ ] CI green on this PR
- [ ] After merge into PR #29, PR #29's CI also green

🤖 Generated with [Claude Code](https://claude.com/claude-code)