### PR TITLE
fix(memory): eager-ping Redis so unreachable host falls back to Noop

### DIFF
--- a/src/platform/memory/provider.py
+++ b/src/platform/memory/provider.py
@@ -310,7 +310,14 @@ class RedisConversationMemory(ConversationMemoryProvider):
         """
         import redis  # type: ignore
 
-        self._client = redis.from_url(redis_url, decode_responses=True)
+        # redis-py's from_url is lazy — no socket dial until the first
+        # command. Ping eagerly so get_conversation_memory's try/except
+        # can actually catch unreachable-Redis and fall back to Noop,
+        # instead of ConnectionError surfacing from inside a request.
+        self._client = redis.from_url(
+            redis_url, decode_responses=True, socket_connect_timeout=1
+        )
+        self._client.ping()
         self._prefix = key_prefix.strip() or "rag:memory"
         self._llm_provider = get_llm_provider()
 

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -44,12 +44,15 @@ class _FakeRedis:
         cur.append(value)
         self.lists[key] = cur
 
+    def ping(self):
+        return True
+
 
 class _FakeRedisModule:
     def __init__(self, client):
         self._client = client
 
-    def from_url(self, _url, decode_responses=True):
+    def from_url(self, _url, decode_responses=True, **_kwargs):
         assert decode_responses is True
         return self._client
 
@@ -113,6 +116,40 @@ def test_redis_memory_roundtrip(monkeypatch):
         force=True,
     )
     assert compact.text == "summary updated"
+
+
+def test_unreachable_redis_falls_back_to_noop(monkeypatch):
+    """Regression for #52: lazy from_url must not hide an unreachable Redis.
+
+    Constructor should ping eagerly so that get_conversation_memory's
+    try/except can catch ConnectionError and return NoopConversationMemory
+    instead of letting the error surface from a request handler.
+    """
+    import pytest
+
+    class _UnreachableClient:
+        def ping(self):
+            raise ConnectionError("Error 111 connecting to localhost:6379")
+
+    class _UnreachableModule:
+        def from_url(self, _url, decode_responses=True, **_kwargs):
+            return _UnreachableClient()
+
+    monkeypatch.setitem(__import__("sys").modules, "redis", _UnreachableModule())
+
+    with pytest.raises(ConnectionError):
+        RedisConversationMemory("redis://unreachable:6379", "rag:test:memory")
+
+    # Factory wraps construction in try/except; the same unreachable Redis
+    # should produce a NoopConversationMemory rather than propagate.
+    from src.platform.memory import provider as provider_mod
+
+    monkeypatch.setattr(provider_mod, "_MEMORY", None)
+    monkeypatch.setattr(provider_mod, "MEMORY_ENABLED", True)
+    monkeypatch.setattr(provider_mod, "MEMORY_PROVIDER", "redis")
+    monkeypatch.setattr(provider_mod, "MEMORY_REDIS_URL", "redis://unreachable:6379")
+    memory = provider_mod.get_conversation_memory()
+    assert isinstance(memory, NoopConversationMemory)
 
 
 def _make_provider(monkeypatch):


### PR DESCRIPTION
## Summary
- `RedisConversationMemory.__init__` now calls `client.ping()` with `socket_connect_timeout=1` so unreachable Redis fails fast at construction.
- `get_conversation_memory()`'s existing try/except now actually catches the `ConnectionError` and returns `NoopConversationMemory` as intended.
- Adds regression test `test_unreachable_redis_falls_back_to_noop` covering both the construction-time raise and the factory-level fallback.

Closes #52.

## Test plan
- [x] `pytest tests/test_memory_provider.py` — 7 passed
- [x] `pytest tests/test_api_error_envelope.py` — 9 passed
- [ ] CI green

## Notes
- `socket_connect_timeout=1`: snappy startup; Redis on localhost/compose responds well under 1s. If users deploy across regions we can revisit.
- Worker + API both call this factory. With Redis down at boot, both will degrade to Noop until process restart — documented in the issue's "Re-init policy" note; not adding periodic re-attempt in this PR.
- Test fakes (`_FakeRedis`, `_FakeRedisModule`) updated: `ping()` returns True, `from_url` accepts `**kwargs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)