### PR TITLE
release: pin high-churn images + GHCR publish workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -229,3 +229,17 @@ RAG_TEI_TIMEOUT_SECONDS=30
 # Default covers docs/ and documents/ which are mounted automatically.
 # Add extra dirs here if you ingest from other locations:
 # RAG_CONSOLE_SOURCE_ROOTS=${PWD}/documents:${PWD}/docs:/path/to/other/dir
+
+# --- Container image tags ---
+# App images are published to GHCR by .github/workflows/publish-images.yml.
+# Default 'latest' tracks main; pin to a SHA or version tag for reproducibility.
+# To build locally instead of pulling: `docker compose build rag-api rag-worker`.
+# RAG_API_IMAGE_TAG=latest
+# RAG_WORKER_IMAGE_TAG=latest
+
+# Pinned versions for high-churn third-party images. Override only when you
+# know the new version is compatible (Temporal in particular has breaking
+# workflow-task-queue changes between minor releases).
+# TEMPORAL_IMAGE_TAG=1.25.2
+# TEMPORAL_UI_IMAGE_TAG=2.31.2
+# RAG_MINIO_IMAGE_TAG=RELEASE.2025-04-22T22-12-26Z

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,52 @@
+name: publish-images
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ragweave-api
+            dockerfile: containers/Dockerfile.api
+          - image: ragweave-worker
+            dockerfile: containers/Dockerfile.runtime
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/juansync7/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     restart: unless-stopped
 
   temporal:
-    image: temporalio/auto-setup:latest
+    image: temporalio/auto-setup:${TEMPORAL_IMAGE_TAG:-1.25.2}
     container_name: rag-temporal
     ports:
       - "${RAG_TEMPORAL_PORT:-7233}:7233"
@@ -95,7 +95,7 @@ services:
     restart: unless-stopped
 
   temporal-ui:
-    image: temporalio/ui:latest
+    image: temporalio/ui:${TEMPORAL_UI_IMAGE_TAG:-2.31.2}
     container_name: rag-temporal-ui
     ports:
       - "${RAG_TEMPORAL_UI_PORT:-8080}:8080"
@@ -108,6 +108,7 @@ services:
 
   rag-api:
     profiles: ["app"]
+    image: ghcr.io/juansync7/ragweave-api:${RAG_API_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: containers/Dockerfile.api
@@ -186,6 +187,7 @@ services:
 
   rag-worker:
     profiles: ["workers"]
+    image: ghcr.io/juansync7/ragweave-worker:${RAG_WORKER_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: containers/Dockerfile.runtime
@@ -254,7 +256,7 @@ services:
     restart: unless-stopped
 
   rag-minio:
-    image: minio/minio:latest
+    image: minio/minio:${RAG_MINIO_IMAGE_TAG:-RELEASE.2025-04-22T22-12-26Z}
     container_name: rag-minio
     command: server /data --console-address ":9001"
     environment:


### PR DESCRIPTION
## Summary
- Pin temporal/temporal-ui/minio to specific versions (env-overridable) to avoid silent breakage from \`:latest\`
- Add \`image:\` refs alongside \`build:\` for rag-api/rag-worker pointing at \`ghcr.io/juansync7/ragweave-{api,worker}\`
- New GHA workflow (\`.github/workflows/publish-images.yml\`) publishes both app images to GHCR on push-to-main, version tags, or manual dispatch

## Test plan
- [ ] Merge to main so \`workflow_dispatch\` becomes available
- [ ] Run \`gh workflow run publish-images.yml\` (or wait for the merge-push trigger)
- [ ] Flip the two GHCR packages to public visibility (one-time)
- [ ] Verify \`docker compose pull rag-api rag-worker\` succeeds