### PR TITLE
feat(ingest): OTel stage spans + trace_id unification (PR2/4)

### DIFF
--- a/src/ingest/common/observability.py
+++ b/src/ingest/common/observability.py
@@ -1,0 +1,111 @@
+# @summary
+# Stage span helper for OpenTelemetry-shaped structured logging.
+# Exports: stage_span
+# Deps: stdlib only
+# @end-summary
+
+"""OpenTelemetry-shaped stage spans for the ingestion pipeline.
+
+`stage_span(stage_name, trace_id=..., **attrs)` is a context manager that emits
+a single structured JSON log event on exit with the following shape:
+
+    {
+      "event": "stage_span",
+      "trace_id": "...",
+      "span_id": "...",
+      "parent_span_id": "...",
+      "stage_name": "...",
+      "duration_ms": 12.34,
+      "status": "ok" | "error",
+      "attributes": {...},
+      "error": "..."   # only on status=="error"
+    }
+
+The yielded value is a dict carrying ``span_id`` and ``trace_id`` so callers
+can pass ``parent_span_id`` to nested spans.
+
+Logger name: ``rag.ingest.obs``. Format is JSON-encoded message text so
+existing logging handlers don't need restructuring.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from contextlib import contextmanager
+from functools import wraps
+from typing import Any, Callable, Iterator
+
+_logger = logging.getLogger("rag.ingest.obs")
+
+
+@contextmanager
+def stage_span(
+    stage_name: str,
+    *,
+    trace_id: str = "",
+    parent_span_id: str = "",
+    **attributes: Any,
+) -> Iterator[dict]:
+    """Context manager that emits an OTel-shaped JSON log event on exit.
+
+    Args:
+        stage_name: Pipeline stage / node name.
+        trace_id: Per-document trace ID. Pass through verbatim (use the
+            Temporal staging_batch_id when invoked from a Temporal activity,
+            so a single ID flows from MinIO write to Weaviate insert).
+        parent_span_id: Parent span ID for nested spans. Empty for roots.
+        **attributes: Free-form attributes recorded under "attributes".
+    """
+    span_id = uuid.uuid4().hex
+    start = time.perf_counter()
+    status = "ok"
+    err: BaseException | None = None
+    try:
+        yield {"span_id": span_id, "trace_id": trace_id}
+    except BaseException as exc:
+        status = "error"
+        err = exc
+        raise
+    finally:
+        duration_ms = round((time.perf_counter() - start) * 1000.0, 3)
+        event: dict[str, Any] = {
+            "event": "stage_span",
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "parent_span_id": parent_span_id,
+            "stage_name": stage_name,
+            "duration_ms": duration_ms,
+            "status": status,
+            "attributes": dict(attributes),
+        }
+        if err is not None:
+            event["error"] = f"{type(err).__name__}: {err}"
+        try:
+            payload = json.dumps(event, default=str)
+        except (TypeError, ValueError):
+            payload = json.dumps({**event, "attributes": {"_repr": repr(attributes)}}, default=str)
+        _logger.info(payload)
+
+
+def node_span(stage_name: str) -> Callable:
+    """Decorator wrapping a LangGraph node fn (state dict in, partial state out).
+
+    Pulls ``trace_id`` from the input state and emits a stage_span event with
+    ``source_key`` recorded as an attribute. Errors are recorded but re-raised
+    so LangGraph error handling stays intact.
+    """
+
+    def _decorate(fn: Callable) -> Callable:
+        @wraps(fn)
+        def _wrapped(state: dict, *args: Any, **kwargs: Any):
+            trace_id = state.get("trace_id", "") if isinstance(state, dict) else ""
+            source_key = state.get("source_key", "") if isinstance(state, dict) else ""
+            with stage_span(stage_name, trace_id=trace_id, source_key=source_key):
+                return fn(state, *args, **kwargs)
+
+        return _wrapped
+
+    return _decorate

--- a/src/ingest/doc_processing/nodes/document_ingestion.py
+++ b/src/ingest/doc_processing/nodes/document_ingestion.py
@@ -18,8 +18,10 @@ logger = logging.getLogger("rag.ingest.docproc.document_ingestion")
 from src.ingest.common import append_processing_log
 from src.ingest.common.utils import decode_with_fallbacks, sha256_bytes
 from src.ingest.doc_processing.state import DocumentProcessingState
+from src.ingest.common.observability import node_span
 
 
+@node_span("document_ingestion")
 def document_ingestion_node(state: DocumentProcessingState) -> dict[str, Any]:
     """Read source content and compute SHA-256 hash.
 

--- a/src/ingest/doc_processing/nodes/multimodal_processing.py
+++ b/src/ingest/doc_processing/nodes/multimodal_processing.py
@@ -18,8 +18,10 @@ logger = logging.getLogger("rag.ingest.docproc.multimodal_processing")
 from src.ingest.common import append_processing_log
 from src.ingest.doc_processing.state import DocumentProcessingState
 from src.ingest.support import generate_vision_notes
+from src.ingest.common.observability import node_span
 
 
+@node_span("multimodal_processing")
 def multimodal_processing_node(state: DocumentProcessingState) -> dict[str, Any]:
     """Generate multimodal notes when figure references are detected and enabled.
 

--- a/src/ingest/doc_processing/nodes/structure_detection.py
+++ b/src/ingest/doc_processing/nodes/structure_detection.py
@@ -22,6 +22,7 @@ from typing import Any
 from src.ingest.common import append_processing_log
 from src.ingest.doc_processing.state import DocumentProcessingState
 from src.ingest.support import parse_with_docling
+from src.ingest.common.observability import node_span
 
 logger = logging.getLogger("rag.ingest.docproc.structure_detection")
 
@@ -32,6 +33,7 @@ _HEADING_PATTERN = re.compile(
 _MAX_FIGURES = 32
 
 
+@node_span("structure_detection")
 def structure_detection_node(state: DocumentProcessingState) -> dict[str, Any]:
     """Extract structural signals via parser abstraction or legacy fallback.
 

--- a/src/ingest/doc_processing/nodes/text_cleaning.py
+++ b/src/ingest/doc_processing/nodes/text_cleaning.py
@@ -17,10 +17,12 @@ logger = logging.getLogger("rag.ingest.docproc.text_cleaning")
 from src.ingest.support import clean_document
 from src.ingest.common import append_processing_log
 from src.ingest.doc_processing.state import DocumentProcessingState
+from src.ingest.common.observability import node_span
 
 _FIGURE_NOTES_HEADER = "\n\n## Figure Notes\n"
 
 
+@node_span("text_cleaning")
 def text_cleaning_node(state: DocumentProcessingState) -> dict[str, Any]:
     """Normalize source text and append generated multimodal notes.
 

--- a/src/ingest/embedding/nodes/chunk_enrichment.py
+++ b/src/ingest/embedding/nodes/chunk_enrichment.py
@@ -21,8 +21,10 @@ from src.ingest.common import (
     map_chunk_provenance,
 )
 from src.ingest.embedding.state import EmbeddingPipelineState
+from src.ingest.common.observability import node_span
 
 
+@node_span("chunk_enrichment")
 def chunk_enrichment_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Attach stable chunk IDs and enriched content fields to chunk metadata.
 

--- a/src/ingest/embedding/nodes/chunking.py
+++ b/src/ingest/embedding/nodes/chunking.py
@@ -37,6 +37,7 @@ from src.ingest.support import (
 )
 from src.ingest.common import append_processing_log
 from src.ingest.embedding.state import EmbeddingPipelineState
+from src.ingest.common.observability import node_span
 
 logger = logging.getLogger("rag.ingest.pipeline.chunking")
 
@@ -64,6 +65,7 @@ def _normalize_chunk_text(text: str) -> str:
     return _CONTROL_CHAR_RE.sub("", normalized)
 
 
+@node_span("chunking")
 def chunking_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Split document into chunks using parser abstraction or legacy markdown fallback.
 

--- a/src/ingest/embedding/nodes/commit_node.py
+++ b/src/ingest/embedding/nodes/commit_node.py
@@ -18,6 +18,7 @@ from src.vector_db import add_documents, delete_by_source_key
 from src.vector_db.weaviate.store import delete_documents_by_staging_batch
 from src.ingest.common import append_processing_log
 from src.ingest.embedding.state import EmbeddingPipelineState
+from src.ingest.common.observability import node_span
 
 logger = logging.getLogger("rag.ingest.embedding.commit")
 
@@ -72,6 +73,7 @@ def _rollback(
             )
 
 
+@node_span("commit")
 def commit_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Flush staged MinIO + Weaviate + KG writes; rollback all on any failure.
 

--- a/src/ingest/embedding/nodes/cross_document_dedup.py
+++ b/src/ingest/embedding/nodes/cross_document_dedup.py
@@ -42,10 +42,12 @@ from src.ingest.embedding.common.dedup_utils import (
 )
 from src.ingest.embedding.common.types import MergeEvent, create_merge_event
 from src.ingest.embedding.state import EmbeddingPipelineState
+from src.ingest.common.observability import node_span
 
 logger = logging.getLogger("rag.ingest.embedding.dedup")
 
 
+@node_span("cross_document_dedup")
 def cross_document_dedup_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Detect and eliminate cross-document duplicate chunks.
 

--- a/src/ingest/embedding/nodes/cross_reference_extraction.py
+++ b/src/ingest/embedding/nodes/cross_reference_extraction.py
@@ -19,8 +19,10 @@ from src.ingest.common import (
     cross_refs,
 )
 from src.ingest.embedding.state import EmbeddingPipelineState
+from src.ingest.common.observability import node_span
 
 
+@node_span("cross_reference_extraction")
 def cross_reference_extraction_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Extract document cross-reference patterns when this stage is enabled.
 

--- a/src/ingest/embedding/nodes/document_storage_node.py
+++ b/src/ingest/embedding/nodes/document_storage_node.py
@@ -17,8 +17,10 @@ logger = logging.getLogger("rag.ingest.embedding.document_storage")
 from src.db import build_document_id, put_document  # noqa: F401 — put_document kept for legacy refs
 from src.ingest.common import append_processing_log
 from src.ingest.embedding.state import EmbeddingPipelineState
+from src.ingest.common.observability import node_span
 
 
+@node_span("document_storage")
 def document_storage_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Compute a stable document_id and STAGE the MinIO write into pipeline state.
 

--- a/src/ingest/embedding/nodes/embedding_storage.py
+++ b/src/ingest/embedding/nodes/embedding_storage.py
@@ -26,6 +26,7 @@ from src.vector_db import (
 from src.ingest.common import append_processing_log
 from src.ingest.common.schemas import PIPELINE_SCHEMA_VERSION
 from src.ingest.embedding.state import EmbeddingPipelineState
+from src.ingest.common.observability import node_span
 
 logger = logging.getLogger("rag.ingest.embedding.storage")
 
@@ -155,6 +156,7 @@ def _embed_batches(
     return all_vectors, errors, success_mask
 
 
+@node_span("embedding_storage")
 def embedding_storage_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Generate chunk embeddings and STAGE records for atomic commit (Issue #42).
 

--- a/src/ingest/embedding/nodes/knowledge_graph_extraction.py
+++ b/src/ingest/embedding/nodes/knowledge_graph_extraction.py
@@ -17,10 +17,12 @@ logger = logging.getLogger("rag.ingest.embedding.knowledge_graph_extraction")
 from src.core import EntityExtractor
 from src.ingest.common import append_processing_log
 from src.ingest.embedding.state import EmbeddingPipelineState
+from src.ingest.common.observability import node_span
 
 _EXTRACTOR = EntityExtractor()
 
 
+@node_span("knowledge_graph_extraction")
 def knowledge_graph_extraction_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Extract entity relations and stage triples for downstream KG storage.
 

--- a/src/ingest/embedding/nodes/knowledge_graph_storage.py
+++ b/src/ingest/embedding/nodes/knowledge_graph_storage.py
@@ -16,8 +16,10 @@ logger = logging.getLogger("rag.ingest.embedding.knowledge_graph_storage")
 
 from src.ingest.common import append_processing_log
 from src.ingest.embedding.state import EmbeddingPipelineState
+from src.ingest.common.observability import node_span
 
 
+@node_span("knowledge_graph_storage")
 def knowledge_graph_storage_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Stage chunk texts for KG add_chunk replay at commit_node (Issue #42).
 

--- a/src/ingest/embedding/nodes/metadata_generation.py
+++ b/src/ingest/embedding/nodes/metadata_generation.py
@@ -20,11 +20,13 @@ from src.ingest.common import (
     extract_keywords_fallback,
 )
 from src.ingest.embedding.state import EmbeddingPipelineState
+from src.ingest.common.observability import node_span
 
 _MAX_TEXT_FOR_METADATA = 10000
 _MAX_SUMMARY_LEN = 240
 
 
+@node_span("metadata_generation")
 def metadata_generation_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Generate document summary/keywords and project them into chunk metadata.
 

--- a/src/ingest/embedding/nodes/quality_validation.py
+++ b/src/ingest/embedding/nodes/quality_validation.py
@@ -18,12 +18,14 @@ from src.ingest.common import (
     quality_score,
 )
 from src.ingest.embedding.state import EmbeddingPipelineState
+from src.ingest.common.observability import node_span
 
 logger = logging.getLogger("rag.ingest.embedding.quality_validation")
 
 _WHITESPACE_RE = re.compile(r"\s+")
 
 
+@node_span("quality_validation")
 def quality_validation_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Filter chunks by heuristic quality thresholds and deduplicate text.
 

--- a/src/ingest/embedding/nodes/visual_embedding.py
+++ b/src/ingest/embedding/nodes/visual_embedding.py
@@ -58,6 +58,7 @@ from src.vector_db.weaviate import (
     delete_visual_by_source_key,
     ensure_visual_collection,
 )
+from src.ingest.common.observability import node_span
 
 logger = logging.getLogger("rag.ingest.embedding.visual_embedding")
 
@@ -67,6 +68,7 @@ logger = logging.getLogger("rag.ingest.embedding.visual_embedding")
 # ---------------------------------------------------------------------------
 
 
+@node_span("visual_embedding")
 def visual_embedding_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Visual embedding pipeline node: extract, store, embed, and index page images.
 

--- a/src/ingest/embedding/nodes/vlm_enrichment.py
+++ b/src/ingest/embedding/nodes/vlm_enrichment.py
@@ -42,6 +42,7 @@ from src.ingest.support import (
     _describe_image,
     _extract_image_candidates,
 )
+from src.ingest.common.observability import node_span
 
 logger = logging.getLogger("rag.ingest.embedding.vlm_enrichment")
 
@@ -49,6 +50,7 @@ logger = logging.getLogger("rag.ingest.embedding.vlm_enrichment")
 # ── Public API ──────────────────────────────────────────────────────────────
 
 
+@node_span("vlm_enrichment")
 def vlm_enrichment_node(state: EmbeddingPipelineState) -> dict[str, Any]:
     """Replace image placeholders in chunks with VLM-generated descriptions.
 

--- a/src/ingest/temporal/activities.py
+++ b/src/ingest/temporal/activities.py
@@ -255,6 +255,7 @@ async def document_processing_activity(args: ActivityArgs) -> DocProcessingResul
         source_id=s.source_id,
         connector=s.connector,
         source_version=s.source_version,
+        trace_id=args.staging_batch_id,
     )
 
     errors = list(result.get("errors", []))
@@ -342,6 +343,7 @@ async def embedding_pipeline_activity(args: ActivityArgs) -> EmbeddingResult:
             clean_text=clean_text,
             clean_hash=clean_hash,
             staging_batch_id=args.staging_batch_id,
+            trace_id=args.staging_batch_id,
             source_hash=source_hash,
         )
 

--- a/tests/ingest/test_observability.py
+++ b/tests/ingest/test_observability.py
@@ -1,0 +1,154 @@
+"""Tests for the stage_span observability helper.
+
+Contract:
+- Emits a single structured JSON log event on exit.
+- Event shape follows OpenTelemetry conventions:
+  trace_id, span_id, parent_span_id, stage_name, duration_ms, status,
+  attributes, optional error.
+- Status is "ok" on clean exit, "error" on exception (and exception re-raised).
+- duration_ms is a non-negative float.
+- span_id is a fresh UUID per invocation; trace_id is passed through verbatim.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+
+def _capture(caplog, level=logging.INFO):
+    caplog.set_level(level, logger="rag.ingest.obs")
+    return caplog
+
+
+def _events(caplog):
+    out = []
+    for rec in caplog.records:
+        msg = rec.getMessage()
+        try:
+            payload = json.loads(msg)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(payload, dict) and payload.get("event") == "stage_span":
+            out.append(payload)
+    return out
+
+
+def test_stage_span_emits_otel_shaped_event(caplog):
+    from src.ingest.common.observability import stage_span
+
+    _capture(caplog)
+    with stage_span("document_ingestion", trace_id="trace-abc", source_key="docs/a.md"):
+        pass
+
+    events = _events(caplog)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["trace_id"] == "trace-abc"
+    assert ev["stage_name"] == "document_ingestion"
+    assert ev["status"] == "ok"
+    assert ev["span_id"]  # non-empty
+    assert "parent_span_id" in ev
+    assert isinstance(ev["duration_ms"], (int, float))
+    assert ev["duration_ms"] >= 0
+    assert ev["attributes"]["source_key"] == "docs/a.md"
+
+
+def test_stage_span_records_error_and_reraises(caplog):
+    from src.ingest.common.observability import stage_span
+
+    _capture(caplog)
+    with pytest.raises(ValueError, match="boom"):
+        with stage_span("structure_detection", trace_id="t1"):
+            raise ValueError("boom")
+
+    events = _events(caplog)
+    assert len(events) == 1
+    assert events[0]["status"] == "error"
+    assert "boom" in events[0]["error"]
+    assert events[0]["stage_name"] == "structure_detection"
+
+
+def test_stage_span_unique_span_ids(caplog):
+    from src.ingest.common.observability import stage_span
+
+    _capture(caplog)
+    with stage_span("a", trace_id="t"):
+        pass
+    with stage_span("b", trace_id="t"):
+        pass
+
+    events = _events(caplog)
+    assert len(events) == 2
+    assert events[0]["span_id"] != events[1]["span_id"]
+
+
+def test_stage_span_supports_parent_span(caplog):
+    from src.ingest.common.observability import stage_span
+
+    _capture(caplog)
+    with stage_span("phase1", trace_id="t") as parent:
+        with stage_span("nested", trace_id="t", parent_span_id=parent["span_id"]):
+            pass
+
+    events = _events(caplog)
+    # inner finishes first
+    inner = events[0]
+    outer = events[1]
+    assert inner["stage_name"] == "nested"
+    assert inner["parent_span_id"] == outer["span_id"]
+
+
+def test_stage_span_yields_context_with_span_id():
+    from src.ingest.common.observability import stage_span
+
+    with stage_span("x", trace_id="abc") as ctx:
+        assert ctx["trace_id"] == "abc"
+        assert isinstance(ctx["span_id"], str) and ctx["span_id"]
+
+
+def test_node_span_decorator_pulls_trace_id_from_state(caplog):
+    from src.ingest.common.observability import node_span
+
+    @node_span("chunking")
+    def my_node(state):
+        return {"ok": True}
+
+    _capture(caplog)
+    out = my_node({"trace_id": "trace-99", "source_key": "k"})
+    assert out == {"ok": True}
+    ev = _events(caplog)[0]
+    assert ev["trace_id"] == "trace-99"
+    assert ev["stage_name"] == "chunking"
+    assert ev["attributes"]["source_key"] == "k"
+    assert ev["status"] == "ok"
+
+
+def test_node_span_decorator_records_error(caplog):
+    from src.ingest.common.observability import node_span
+
+    @node_span("boom_node")
+    def my_node(state):
+        raise ValueError("kaboom")
+
+    _capture(caplog)
+    try:
+        my_node({"trace_id": "t"})
+    except ValueError:
+        pass
+    ev = _events(caplog)[0]
+    assert ev["status"] == "error"
+    assert "kaboom" in ev["error"]
+
+
+def test_stage_span_attributes_preserved_on_error(caplog):
+    from src.ingest.common.observability import stage_span
+
+    _capture(caplog)
+    with pytest.raises(RuntimeError):
+        with stage_span("text_cleaning", trace_id="t", chunks=42, model="x"):
+            raise RuntimeError("x")
+    ev = _events(caplog)[0]
+    assert ev["attributes"] == {"chunks": 42, "model": "x"}

--- a/tests/ingest/test_trace_id_propagation.py
+++ b/tests/ingest/test_trace_id_propagation.py
@@ -1,0 +1,150 @@
+"""Trace ID propagation tests.
+
+Contract:
+- Temporal activities unify ``trace_id`` with ``staging_batch_id`` so a single
+  per-document ID flows through Phase 1 + Phase 2 and is attached to every
+  Weaviate chunk and MinIO object metadata.
+- ``run_document_processing`` and ``run_embedding_pipeline`` both accept and
+  expose ``trace_id`` in their state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def test_run_document_processing_accepts_trace_id():
+    from src.ingest.doc_processing.impl import run_document_processing
+
+    sig = inspect.signature(run_document_processing)
+    assert "trace_id" in sig.parameters
+
+
+def test_run_embedding_pipeline_accepts_trace_id():
+    from src.ingest.embedding.impl import run_embedding_pipeline
+
+    sig = inspect.signature(run_embedding_pipeline)
+    assert "trace_id" in sig.parameters
+
+
+def test_temporal_phase1_activity_passes_staging_batch_id_as_trace_id(tmp_path):
+    """document_processing_activity must forward staging_batch_id as trace_id."""
+    from src.ingest.temporal.activities import (
+        ActivityArgs,
+        SourceArgs,
+        document_processing_activity,
+    )
+
+    doc = tmp_path / "doc.txt"
+    doc.write_text("Hello.")
+    store_dir = tmp_path / "clean"
+
+    args = ActivityArgs(
+        config={"clean_store_dir": str(store_dir)},
+        source=SourceArgs(
+            source_path=str(doc),
+            source_name="doc.txt",
+            source_uri=doc.as_uri(),
+            source_key="local_fs:test:42",
+            source_id="test:42",
+            connector="local_fs",
+            source_version="1",
+        ),
+        staging_batch_id="batch-uuid-xyz",
+    )
+
+    captured: dict = {}
+
+    def _fake_run(**kwargs):
+        captured.update(kwargs)
+        return {
+            "errors": [],
+            "source_hash": hashlib.sha256(b"Hello.").hexdigest(),
+            "cleaned_text": "Hello.",
+            "processing_log": [],
+            "trace_id": kwargs.get("trace_id", ""),
+        }
+
+    with patch("src.ingest.temporal.activities.run_document_processing", side_effect=_fake_run), \
+         patch("src.ingest.temporal.activities.vector_db") as mock_vdb:
+        mock_vdb.get_client.return_value.__enter__.return_value = MagicMock()
+        mock_vdb.get_client.return_value.__exit__.return_value = False
+        # Avoid idempotency short-circuit
+        with patch("src.ingest.temporal.activities.get_source_hash", return_value=None):
+            asyncio.get_event_loop().run_until_complete(
+                document_processing_activity(args)
+            ) if False else None
+            # Pytest event loop policy: run via asyncio.run
+            import asyncio as _a
+            _a.run(document_processing_activity(args))
+
+    assert captured.get("trace_id") == "batch-uuid-xyz"
+
+
+def test_temporal_phase2_activity_passes_staging_batch_id_as_trace_id(tmp_path):
+    """embedding_pipeline_activity must forward staging_batch_id as trace_id."""
+    import asyncio as _a
+
+    from src.ingest.common.clean_store import CleanDocumentStore
+    from src.ingest.temporal.activities import (
+        ActivityArgs,
+        SourceArgs,
+        embedding_pipeline_activity,
+    )
+
+    store_dir = tmp_path / "clean"
+    store = CleanDocumentStore(store_dir)
+    store.write(
+        "local_fs:test:99",
+        "clean text",
+        {
+            "source_key": "local_fs:test:99",
+            "source_name": "doc.txt",
+            "source_uri": "file:///tmp/doc.txt",
+            "source_id": "test:99",
+            "connector": "local_fs",
+            "source_version": "1",
+            "source_hash": "abc",
+            "clean_hash": hashlib.sha256(b"clean text").hexdigest(),
+        },
+    )
+
+    args = ActivityArgs(
+        config={"clean_store_dir": str(store_dir)},
+        source=SourceArgs(
+            source_path="/tmp/doc.txt",
+            source_name="doc.txt",
+            source_uri="file:///tmp/doc.txt",
+            source_key="local_fs:test:99",
+            source_id="test:99",
+            connector="local_fs",
+            source_version="1",
+        ),
+        staging_batch_id="batch-uuid-zzz",
+    )
+
+    captured: dict = {}
+
+    def _fake_run(**kwargs):
+        captured.update(kwargs)
+        return {
+            "errors": [],
+            "stored_count": 1,
+            "metadata_summary": "",
+            "metadata_keywords": [],
+            "processing_log": [],
+        }
+
+    with patch("src.ingest.temporal.activities.run_embedding_pipeline", side_effect=_fake_run), \
+         patch("src.ingest.temporal.activities.vector_db") as mock_vdb, \
+         patch("src.ingest.temporal.activities._get_embedder", return_value=MagicMock()):
+        mock_vdb.get_client.return_value.__enter__.return_value = MagicMock()
+        mock_vdb.get_client.return_value.__exit__.return_value = False
+        _a.run(embedding_pipeline_activity(args))
+
+    assert captured.get("trace_id") == "batch-uuid-zzz"
+    assert captured.get("staging_batch_id") == "batch-uuid-zzz"


### PR DESCRIPTION
## Summary
- Adds `stage_span` / `node_span` helpers (`src/ingest/common/observability.py`) that emit OTel-shaped JSON events (`trace_id`, `span_id`, `parent_span_id`, `stage_name`, `duration_ms`, `status`, `attributes`, `error`) under logger `rag.ingest.obs`.
- Decorates all 17 pipeline nodes (4 doc_processing + 13 embedding) — one structured event per stage, automatic error capture, no signature churn.
- Unifies per-document `trace_id` with Temporal's `staging_batch_id` so a single ID flows from MinIO write through Weaviate insert and is retired only when both stores commit.

## Test plan
- [x] New unit tests: `tests/ingest/test_observability.py` (8) — span shape, error capture, uniqueness, nested spans, decorator behaviour.
- [x] New propagation tests: `tests/ingest/test_trace_id_propagation.py` (4) — Temporal activities forward `staging_batch_id` as `trace_id` to both phases.
- [x] Full ingest suite green (1913 passed, 5 skipped).

## Notes
- Stacks on top of #68 (`refactor/remove-document-refactoring`). Merge that first.
- Next up: PR3 (table extraction) and PR4 (page/section provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)