### PR TITLE
feat(ingest): page/section provenance on chunks + tables (PR4/4)

### DIFF
--- a/src/ingest/embedding/nodes/chunking.py
+++ b/src/ingest/embedding/nodes/chunking.py
@@ -175,10 +175,18 @@ def chunking_node(state: EmbeddingPipelineState) -> dict[str, Any]:
                     "section_path": c.section_path,
                     "heading": c.heading,
                     "heading_level": c.heading_level,
+                    "heading_path": list(getattr(c, "heading_path", []) or []),
                     "chunk_index": c.chunk_index,
                     "total_chunks": total,
                     **c.extra_metadata,
                 }
+                page_ref = getattr(c, "page_ref", None)
+                if page_ref is not None:
+                    meta["page_no"] = page_ref.page_no
+                    if page_ref.page_label:
+                        meta["page_label"] = page_ref.page_label
+                    if page_ref.bbox is not None:
+                        meta["page_bbox"] = list(page_ref.bbox)
                 table_match = _match_table_artifact(norm_text, tables)
                 if table_match is not None:
                     meta["chunk_type"] = "table"
@@ -189,6 +197,8 @@ def chunking_node(state: EmbeddingPipelineState) -> dict[str, Any]:
                     meta["table_has_header"] = table_match.has_header
                     if table_match.caption:
                         meta["table_caption"] = table_match.caption
+                    if table_match.page_ref is not None and "page_no" not in meta:
+                        meta["page_no"] = table_match.page_ref.page_no
                 else:
                     meta.setdefault("chunk_type", "text")
                 chunks.append(ProcessedChunk(text=norm_text, metadata=meta))
@@ -255,16 +265,24 @@ def _chunk_with_markdown_legacy(
         )
 
     total_chunks = len(raw_chunks)
-    chunks = [
-        ProcessedChunk(
-            text=_normalize_chunk_text(chunk["text"]),
-            metadata={
-                **base_metadata,
-                **_build_section_metadata(chunk.get("header_metadata", {})),
-                "chunk_index": idx,
-                "total_chunks": total_chunks,
-            },
+    chunks: list[ProcessedChunk] = []
+    for idx, chunk in enumerate(raw_chunks):
+        section_meta = _build_section_metadata(chunk.get("header_metadata", {}))
+        section_path = section_meta.get("section_path", "")
+        heading_path = (
+            [h for h in section_path.split(" > ") if h] if section_path else []
         )
-        for idx, chunk in enumerate(raw_chunks)
-    ]
+        chunks.append(
+            ProcessedChunk(
+                text=_normalize_chunk_text(chunk["text"]),
+                metadata={
+                    **base_metadata,
+                    **section_meta,
+                    "heading_path": heading_path,
+                    "chunk_index": idx,
+                    "total_chunks": total_chunks,
+                    "chunk_type": "text",
+                },
+            )
+        )
     return chunks

--- a/src/ingest/support/docling.py
+++ b/src/ingest/support/docling.py
@@ -474,6 +474,8 @@ def chunk_markdown_via_docling(
                 heading_level=len(headings),
                 chunk_index=idx,
                 extra_metadata=extra,
+                heading_path=list(headings),
+                page_ref=_page_ref_from_chunk_meta(meta),
             )
         )
     return chunks
@@ -482,6 +484,54 @@ def chunk_markdown_via_docling(
 # ---------------------------------------------------------------------------
 # DoclingParser — DocumentParser protocol implementation (FR-3221–FR-3224)
 # ---------------------------------------------------------------------------
+
+def _page_ref_from_chunk_meta(meta: Any) -> Any:
+    """Derive a PageRef from a HybridChunker chunk's meta.doc_items provenance.
+
+    Uses the first doc_item's first provenance entry as the chunk's primary
+    page (HybridChunker preserves document order). Returns None when meta is
+    missing or no provenance is attached.
+    """
+    from src.ingest.support.parser_base import PageRef
+
+    if meta is None:
+        return None
+    doc_items = getattr(meta, "doc_items", None) or []
+    for item in doc_items:
+        prov = getattr(item, "prov", None) or []
+        for p in prov:
+            page_no = getattr(p, "page_no", None)
+            if page_no is None:
+                continue
+            bbox_obj = getattr(p, "bbox", None)
+            bbox = None
+            if bbox_obj is not None:
+                # Docling BoundingBox: l, t, r, b OR x0, y0, x1, y1
+                try:
+                    bbox = (
+                        float(getattr(bbox_obj, "l", getattr(bbox_obj, "x0", 0.0))),
+                        float(getattr(bbox_obj, "t", getattr(bbox_obj, "y0", 0.0))),
+                        float(getattr(bbox_obj, "r", getattr(bbox_obj, "x1", 0.0))),
+                        float(getattr(bbox_obj, "b", getattr(bbox_obj, "y1", 0.0))),
+                    )
+                except Exception:
+                    bbox = None
+            return PageRef(page_no=int(page_no), page_label="", bbox=bbox)
+    return None
+
+
+def _page_ref_from_table_item(tbl: Any) -> Any:
+    """Derive a PageRef from a Docling TableItem's provenance, or None."""
+    from src.ingest.support.parser_base import PageRef
+
+    prov = getattr(tbl, "prov", None) or []
+    for p in prov:
+        page_no = getattr(p, "page_no", None)
+        if page_no is None:
+            continue
+        return PageRef(page_no=int(page_no), page_label="", bbox=None)
+    return None
+
 
 def _extract_table_artifacts(docling_document: Any) -> list:
     """Extract structured table artifacts from a DoclingDocument. FR-3211.
@@ -530,6 +580,7 @@ def _extract_table_artifacts(docling_document: Any) -> list:
                     has_header=_detect_header_row(tbl),
                     section_path="",
                     caption=caption.strip(),
+                    page_ref=_page_ref_from_table_item(tbl),
                 )
             )
         except Exception as exc:  # pragma: no cover - defensive
@@ -677,6 +728,7 @@ class DoclingParser:
             heading = headings[-1] if headings else ""
             section_path = " > ".join(headings)
             heading_level = len(headings)
+            page_ref = _page_ref_from_chunk_meta(meta)
 
             chunks.append(
                 Chunk(
@@ -686,6 +738,8 @@ class DoclingParser:
                     heading_level=heading_level,
                     chunk_index=idx,
                     extra_metadata={},
+                    heading_path=headings,
+                    page_ref=page_ref,
                 )
             )
         return chunks

--- a/src/ingest/support/parser_base.py
+++ b/src/ingest/support/parser_base.py
@@ -1,6 +1,6 @@
 # @summary
 # Abstract parser protocol and unified data contracts for the Document Parsing Abstraction.
-# Exports: DocumentParser, ParseResult, Chunk, TableArtifact, chunk_with_markdown, validate_extra_metadata
+# Exports: DocumentParser, ParseResult, Chunk, TableArtifact, PageRef, chunk_with_markdown, validate_extra_metadata
 # Deps: dataclasses, pathlib, typing, src.ingest.support.markdown
 # @end-summary
 
@@ -21,6 +21,26 @@ from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PageRef:
+    """Reference to a single source page. FR-3212.
+
+    Carried by chunks and table artifacts when the parser exposes per-element
+    page provenance (Docling does; regex/text fallback does not). Consumers
+    use this for citation rendering and per-page retrieval filtering.
+
+    Attributes:
+        page_no: 1-based page number within the source document.
+        page_label: Display label (e.g., "iv", "12a"). Empty when unknown.
+        bbox: Optional bounding box ``(x0, y0, x1, y1)`` in PDF coordinates;
+            ``None`` when not available.
+    """
+
+    page_no: int
+    page_label: str = ""
+    bbox: tuple[float, float, float, float] | None = None
 
 
 @dataclass
@@ -57,6 +77,7 @@ class TableArtifact:
     has_header: bool = False
     section_path: str = ""
     caption: str = ""
+    page_ref: PageRef | None = None
 
 
 @dataclass
@@ -110,6 +131,8 @@ class Chunk:
     heading_level: int
     chunk_index: int
     extra_metadata: dict[str, Any] = field(default_factory=dict)
+    heading_path: list[str] = field(default_factory=list)
+    page_ref: PageRef | None = None
 
 
 @runtime_checkable
@@ -220,14 +243,18 @@ def chunk_with_markdown(parse_result: ParseResult, config: Any) -> list[Chunk]:
     chunks: list[Chunk] = []
     for idx, raw in enumerate(raw_chunks):
         section_meta = _build_section_metadata(raw.get("header_metadata", {}))
+        section_path = section_meta["section_path"]
+        heading_path = [h for h in section_path.split(" > ") if h] if section_path else []
         chunks.append(
             Chunk(
                 text=raw["text"],
-                section_path=section_meta["section_path"],
+                section_path=section_path,
                 heading=section_meta["heading"],
                 heading_level=section_meta["heading_level"],
                 chunk_index=idx,
                 extra_metadata={},
+                heading_path=heading_path,
+                page_ref=None,
             )
         )
     return chunks

--- a/tests/ingest/test_page_section_provenance.py
+++ b/tests/ingest/test_page_section_provenance.py
@@ -1,0 +1,215 @@
+"""Tests for page/section provenance on chunks (FR-3212).
+
+Contracts:
+- PageRef dataclass exposes page_no, page_label, optional bbox.
+- Chunk has optional page_ref and heading_path fields with safe defaults.
+- chunk_with_markdown populates heading_path from section_path.
+- Docling chunk meta with provenance produces a populated PageRef.
+- Docling chunk meta without provenance produces page_ref=None.
+- TableArtifact carries optional page_ref derived from TableItem.prov.
+- chunking_node legacy fallback path emits heading_path and degrades to no
+  page_no when the parser does not provide page provenance.
+- chunking_node parser-abstraction path forwards page_no into ProcessedChunk
+  metadata when the parser supplies a page_ref.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.ingest.support.parser_base import (
+    Chunk,
+    PageRef,
+    ParseResult,
+    TableArtifact,
+    chunk_with_markdown,
+)
+
+
+def test_page_ref_defaults():
+    p = PageRef(page_no=3)
+    assert p.page_no == 3
+    assert p.page_label == ""
+    assert p.bbox is None
+
+
+def test_page_ref_with_bbox():
+    p = PageRef(page_no=1, page_label="i", bbox=(0.0, 0.0, 100.0, 200.0))
+    assert p.bbox == (0.0, 0.0, 100.0, 200.0)
+    assert p.page_label == "i"
+
+
+def test_chunk_default_provenance_fields():
+    c = Chunk(
+        text="x", section_path="", heading="", heading_level=0, chunk_index=0,
+    )
+    assert c.heading_path == []
+    assert c.page_ref is None
+
+
+def test_table_artifact_default_page_ref_none():
+    t = TableArtifact(
+        table_id="t1", markdown="| a |", cells=[["a"]], num_rows=1, num_cols=1,
+    )
+    assert t.page_ref is None
+
+
+def test_table_artifact_with_page_ref():
+    t = TableArtifact(
+        table_id="t1", markdown="| a |", cells=[["a"]], num_rows=1, num_cols=1,
+        page_ref=PageRef(page_no=5),
+    )
+    assert t.page_ref.page_no == 5
+
+
+def test_chunk_with_markdown_emits_heading_path_field():
+    """chunk_with_markdown chunks always carry a heading_path list (possibly empty)
+    and never embed the ' > ' separator inside list items."""
+    pr = ParseResult(
+        markdown="# Top\n\nbody text.\n",
+        headings=["Top"],
+        has_figures=False,
+        page_count=0,
+    )
+    cfg = SimpleNamespace(chunk_size=512, chunk_overlap=0)
+    chunks = chunk_with_markdown(pr, cfg)
+    assert chunks
+    for c in chunks:
+        assert isinstance(c.heading_path, list)
+        assert all(isinstance(h, str) and " > " not in h for h in c.heading_path)
+
+
+def test_chunk_with_markdown_page_ref_is_none_for_text_input():
+    pr = ParseResult(markdown="# H\n\nbody", headings=["H"], has_figures=False, page_count=0)
+    cfg = SimpleNamespace(chunk_size=512, chunk_overlap=0)
+    chunks = chunk_with_markdown(pr, cfg)
+    for c in chunks:
+        assert c.page_ref is None
+
+
+def test_page_ref_from_chunk_meta_with_provenance():
+    from src.ingest.support.docling import _page_ref_from_chunk_meta
+
+    bbox = SimpleNamespace(l=10.0, t=20.0, r=110.0, b=220.0)
+    prov = SimpleNamespace(page_no=4, bbox=bbox)
+    item = SimpleNamespace(prov=[prov])
+    meta = SimpleNamespace(doc_items=[item])
+
+    page_ref = _page_ref_from_chunk_meta(meta)
+    assert page_ref is not None
+    assert page_ref.page_no == 4
+    assert page_ref.bbox == (10.0, 20.0, 110.0, 220.0)
+
+
+def test_page_ref_from_chunk_meta_without_provenance():
+    from src.ingest.support.docling import _page_ref_from_chunk_meta
+
+    assert _page_ref_from_chunk_meta(None) is None
+    assert _page_ref_from_chunk_meta(SimpleNamespace(doc_items=[])) is None
+    item = SimpleNamespace(prov=[])
+    assert _page_ref_from_chunk_meta(SimpleNamespace(doc_items=[item])) is None
+
+
+def test_page_ref_from_table_item():
+    from src.ingest.support.docling import _page_ref_from_table_item
+
+    tbl = SimpleNamespace(prov=[SimpleNamespace(page_no=7)])
+    p = _page_ref_from_table_item(tbl)
+    assert p is not None and p.page_no == 7
+
+    assert _page_ref_from_table_item(SimpleNamespace(prov=[])) is None
+
+
+def test_chunking_node_legacy_fallback_emits_heading_path():
+    """Regex-fallback path: no parse_result; chunks still carry heading_path
+    derived from markdown headings, page_no absent (graceful degradation)."""
+    from src.ingest.embedding.nodes.chunking import chunking_node
+
+    runtime = SimpleNamespace(
+        config=SimpleNamespace(
+            chunker="markdown",
+            chunk_size=512,
+            chunk_overlap=0,
+            semantic_chunking=False,
+        ),
+        embedder=None,
+    )
+    state = {
+        "raw_text": "# Top\n\n## Sub\n\nbody text here.\n",
+        "cleaned_text": "# Top\n\n## Sub\n\nbody text here.\n",
+        "source_name": "doc.md",
+        "source_uri": "doc.md",
+        "source_key": "doc.md",
+        "source_id": "x",
+        "connector": "local",
+        "source_version": "1",
+        "runtime": runtime,
+        "processing_log": [],
+        "trace_id": "t",
+    }
+    out = chunking_node(state)
+    assert out.get("chunks"), out
+    # Every legacy-path chunk must carry chunk_type="text" and a heading_path field
+    for c in out["chunks"]:
+        assert c.metadata.get("chunk_type") == "text"
+        assert "heading_path" in c.metadata
+        assert "page_no" not in c.metadata  # graceful degradation
+
+
+def test_chunking_node_parser_path_propagates_page_ref():
+    """When parse_result+parser_instance are present and chunks carry page_ref,
+    page_no flows through to ProcessedChunk metadata."""
+    from src.ingest.embedding.nodes.chunking import chunking_node
+
+    fake_chunks = [
+        Chunk(
+            text="paragraph one",
+            section_path="Top > Sub",
+            heading="Sub",
+            heading_level=2,
+            chunk_index=0,
+            extra_metadata={},
+            heading_path=["Top", "Sub"],
+            page_ref=PageRef(page_no=2, page_label="2"),
+        ),
+    ]
+    pr = ParseResult(markdown="x", headings=["Top", "Sub"], has_figures=False, page_count=3)
+
+    class _FakeParser:
+        def chunk(self, _pr):
+            return fake_chunks
+
+    runtime = SimpleNamespace(
+        config=SimpleNamespace(
+            chunker="native",
+            chunk_size=512,
+            chunk_overlap=0,
+            semantic_chunking=False,
+        ),
+        embedder=None,
+        db_client=None,
+    )
+    state = {
+        "raw_text": "x",
+        "cleaned_text": "x",
+        "source_name": "doc.pdf",
+        "source_uri": "doc.pdf",
+        "source_key": "doc.pdf",
+        "source_id": "x",
+        "connector": "local",
+        "source_version": "1",
+        "runtime": runtime,
+        "parse_result": pr,
+        "parser_instance": _FakeParser(),
+        "processing_log": [],
+        "trace_id": "t",
+    }
+    out = chunking_node(state)
+    assert out.get("chunks"), out
+    c0 = out["chunks"][0]
+    assert c0.metadata["page_no"] == 2
+    assert c0.metadata["page_label"] == "2"
+    assert c0.metadata["heading_path"] == ["Top", "Sub"]
+    assert c0.metadata["chunk_type"] == "text"


### PR DESCRIPTION
## Summary
- `PageRef` dataclass (page_no, page_label, optional bbox)
- `Chunk` gains `page_ref` + explicit `heading_path`; `TableArtifact` gains `page_ref`
- `DoclingParser.chunk()` and `chunk_markdown_via_docling()` populate `page_ref` from HybridChunker `meta.doc_items[*].prov`
- `_extract_table_artifacts()` populates each TableArtifact's `page_ref` from `TableItem.prov`
- `chunking_node` forwards page_no/page_label/page_bbox + heading_path into ProcessedChunk metadata
- Legacy markdown-fallback path emits heading_path and degrades gracefully when no page provenance is available

## Test plan
- [x] 12 contract tests
- [x] Full ingest suite green: 1935 passed

(Reopened against develop after stack rebase — original #71 auto-closed when its base branch was deleted on PR3 merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)