### PR TITLE
fix(confidence): robust sentence split, fractional citations, memory-path scoring, ConfidenceWeights

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ Ingestion runs as a separate Temporal workflow that writes content + embeddings 
 > it walks every prerequisite install command and the exact gaps in this
 > Quick Start (cloudflared install, nvm/PATH issues, profile combinations).
 
+### Run modes
+
+There are two supported ways to run RagWeave:
+
+| Mode | When to use | What you need | What you skip |
+| --- | --- | --- | --- |
+| **Containers only** (fastest start) | Just trying it out, or running without modifying the API/worker code | Docker + Docker Compose | `make setup`, Python, Node — `rag-api` and `rag-worker` pull from `ghcr.io/juansync7/ragweave-{api,worker}:latest` |
+| **Local dev** (default below) | Iterating on Python or TypeScript code | All prerequisites listed above | Nothing — full local toolchain |
+
+For containers-only:
+
+```bash
+git clone <repo-url> RagWeave && cd RagWeave
+cp .env.example .env
+./scripts/compose.sh --profile app --profile workers up -d
+```
+
+To rebuild app images locally instead of pulling: `./scripts/compose.sh build rag-api rag-worker`. Pin to a specific image tag by setting `RAG_API_IMAGE_TAG` / `RAG_WORKER_IMAGE_TAG` in `.env` (defaults to `latest`).
+
 ### 1. Clone and set up the project
 
 ```bash

--- a/src/retrieval/generation/confidence/README.md
+++ b/src/retrieval/generation/confidence/README.md
@@ -15,7 +15,45 @@ low-confidence answers are flagged or blocked after retries are exhausted.
 
 | Path | Purpose |
 | --- | --- |
-| `schemas.py` | Typed contracts: `ConfidenceBreakdown` dataclass (three signals + composite) and `PostGuardrailAction` enum (RETURN, RE_RETRIEVE, FLAG, BLOCK) |
+| `schemas.py` | Typed contracts: `ConfidenceBreakdown` dataclass (three signals + composite), `ConfidenceWeights` frozen dataclass (validated sum-to-1 weights), and `PostGuardrailAction` enum (RETURN, RE_RETRIEVE, FLAG, BLOCK) |
 | `scoring.py` | Pure scoring functions: `compute_retrieval_confidence` (top-N reranker average), `parse_llm_confidence` (label-to-float mapping with overconfidence correction), `compute_citation_coverage` (citation markers + n-gram overlap blend), and `compute_composite_confidence` (weighted aggregation) |
 | `routing.py` | `route_by_confidence` — maps a composite score and retry count to a `PostGuardrailAction` using the REQ-706 decision table; NaN inputs are safe-failed to BLOCK |
-| `__init__.py` | Package facade re-exporting `ConfidenceBreakdown`, `PostGuardrailAction`, `compute_composite_confidence`, and `route_by_confidence` |
+| `__init__.py` | Package facade re-exporting `ConfidenceBreakdown`, `ConfidenceWeights`, `PostGuardrailAction`, `compute_composite_confidence`, and `route_by_confidence` |
+
+## Behaviour changes (robustness fixes)
+
+### Sentence splitter (#1)
+`_split_sentences` was replaced with a hand-rolled splitter that handles:
+- Common English abbreviations (Mr., Dr., etc., e.g., i.e., vs.) — not split
+- Decimal numbers (3.14, v2.0) — not split
+- URLs (https://...) — periods inside URL runs not split
+- Ellipses (`...`, `…`) — treated as continuation, not a sentence boundary
+- Single `\n` without trailing space — treated as a sentence boundary
+- Double `\n` — treated as a hard paragraph boundary
+
+### Partial citation credit (#9)
+`compute_citation_coverage` now awards fractional credit per sentence.
+A sentence with citations `[1, 99]` against 1 chunk now scores `0.5`
+(1 valid of 2 cited), not `1.0` (any-valid).  The 70%/30% blend weights
+at the aggregation level are unchanged.
+
+### Short-sentence handling (#10)
+The word-count filter threshold was lowered from `>= 4` to `>= 3` words.
+The splitter also keeps at least one fragment for non-empty input so the list
+is never spuriously empty (which previously returned coverage `1.0`).
+When the answer has no substantive sentences, `compute_citation_coverage`
+returns `0.5` (neutral) instead of `1.0` (vacuously perfect).
+
+### ConfidenceWeights dataclass (#13)
+`ConfidenceWeights(retrieval, llm, citation)` is a frozen dataclass in
+`schemas.py` that validates `sum == 1.0` once at construction.
+`compute_composite_confidence` accepts either the dataclass via the `weights=`
+kwarg or the existing float kwargs (back-compat).
+
+### Memory-path confidence gate (#8)
+The gate condition in `rag_chain.py` previously excluded the scoring block
+entirely when `reranked == []` (memory-only generation path).  The condition
+now also allows scoring when `generation_source == "memory"`.  On this path:
+- `reranker_scores=[]` → `retrieval_score=0.0` (no retrieval signal, by design)
+- `retrieved_texts=[]` → `citation_score` reflects only citation-marker presence
+- The composite still provides meaningful signal via the LLM self-report weight

--- a/src/retrieval/generation/confidence/__init__.py
+++ b/src/retrieval/generation/confidence/__init__.py
@@ -1,6 +1,6 @@
 # @summary
 # Composite confidence scoring for RAG pipeline post-generation evaluation.
-# Exports: ConfidenceBreakdown, PostGuardrailAction, compute_composite_confidence, route_by_confidence
+# Exports: ConfidenceBreakdown, ConfidenceWeights, PostGuardrailAction, compute_composite_confidence, route_by_confidence
 # Deps: src.retrieval.generation.confidence.schemas, src.retrieval.generation.confidence.scoring, src.retrieval.generation.confidence.routing
 # @end-summary
 """Composite confidence scoring package.
@@ -12,6 +12,7 @@ composite score used for post-generation routing decisions.
 
 from src.retrieval.generation.confidence.schemas import (
     ConfidenceBreakdown,
+    ConfidenceWeights,
     PostGuardrailAction,
 )
 from src.retrieval.generation.confidence.scoring import compute_composite_confidence
@@ -19,6 +20,7 @@ from src.retrieval.generation.confidence.routing import route_by_confidence
 
 __all__ = [
     "ConfidenceBreakdown",
+    "ConfidenceWeights",
     "PostGuardrailAction",
     "compute_composite_confidence",
     "route_by_confidence",

--- a/src/retrieval/generation/confidence/schemas.py
+++ b/src/retrieval/generation/confidence/schemas.py
@@ -1,6 +1,6 @@
 # @summary
 # Typed contracts for composite confidence scoring and post-generation routing.
-# Exports: ConfidenceBreakdown, PostGuardrailAction
+# Exports: ConfidenceBreakdown, ConfidenceWeights, PostGuardrailAction
 # Deps: dataclasses, enum
 # @end-summary
 """Typed contracts for confidence scoring."""
@@ -9,6 +9,29 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+
+
+@dataclass(frozen=True)
+class ConfidenceWeights:
+    """Frozen, validated weight triple for composite confidence scoring.
+
+    Validation happens once at construction time (via __post_init__), so
+    compute_composite_confidence pays zero per-call overhead.
+
+    All weights must be in [0.0, 1.0] and sum to exactly 1.0.
+    """
+
+    retrieval: float
+    llm: float
+    citation: float
+
+    def __post_init__(self) -> None:
+        total = self.retrieval + self.llm + self.citation
+        if abs(total - 1.0) > 1e-6:
+            raise ValueError(
+                f"Confidence weights must sum to 1.0, got {total:.6f} "
+                f"(retrieval={self.retrieval}, llm={self.llm}, citation={self.citation})"
+            )
 
 
 @dataclass

--- a/src/retrieval/generation/confidence/scoring.py
+++ b/src/retrieval/generation/confidence/scoring.py
@@ -16,8 +16,9 @@ Default weights: retrieval=0.50, llm=0.25, citation=0.25.
 from __future__ import annotations
 
 import re
+from typing import Optional
 
-from src.retrieval.generation.confidence.schemas import ConfidenceBreakdown
+from src.retrieval.generation.confidence.schemas import ConfidenceBreakdown, ConfidenceWeights
 
 # Downward correction map for LLM overconfidence bias.
 # LLMs tend to report "high" even when evidence is weak,
@@ -28,7 +29,147 @@ LLM_CONFIDENCE_MAP = {
     "low": 0.25,
 }
 
-_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+# ---------------------------------------------------------------------------
+# Sentence splitting — hand-rolled, no heavy deps
+# ---------------------------------------------------------------------------
+
+# Abbreviations that end with a period but are NOT sentence boundaries.
+# Ordered longest-first to avoid prefix shadowing (e.g. "jr" before "j").
+_ABBREVS: frozenset[str] = frozenset(
+    [
+        "mr", "mrs", "ms", "dr", "prof", "sr", "jr", "st",
+        "vs", "etc", "approx", "dept", "est", "govt", "inc",
+        "corp", "ltd", "co", "fig", "vol", "no",
+        "e.g", "i.e", "viz", "cf",
+        "jan", "feb", "mar", "apr", "jun", "jul", "aug",
+        "sep", "oct", "nov", "dec",
+    ]
+)
+
+# Matches a run of digits.digits (decimal) or word.digits (version like v2.0).
+_DECIMAL_RE = re.compile(r"\w\.\d")
+
+# Matches URLs — skip any period inside an http(s):// run.
+_URL_RE = re.compile(r"https?://\S+")
+
+# Terminal punctuation followed by whitespace or newline (the split candidate).
+# We exclude pure ellipsis sequences ("..." or "…") — they indicate continuation,
+# not a sentence boundary, unless followed by a capital letter (handled in loop).
+_TERM_PUNCT_RE = re.compile(r"([.!?…]+)(\s+|\n)")
+
+# Pure ellipsis pattern — "...", "....", "…" — not a sentence boundary.
+_ELLIPSIS_RE = re.compile(r"^\.{2,}$|^…+$")
+
+
+def _is_abbreviation_boundary(text: str, match_start: int) -> bool:
+    """Return True if the period at match_start is an abbreviation, not a sentence end."""
+    # Find the word preceding the period.
+    word_end = match_start
+    word_start = word_end - 1
+    while word_start >= 0 and (text[word_start].isalpha() or text[word_start] == "."):
+        word_start -= 1
+    token = text[word_start + 1 : word_end].lower().rstrip(".")
+    return token in _ABBREVS
+
+
+def _split_sentences(text: str) -> list[str]:
+    """Split text into sentences with a robust hand-rolled splitter.
+
+    Handles:
+      - Common abbreviations (Mr., Dr., etc., e.g., i.e., vs.)
+      - Decimal numbers (3.14, v2.0) — not split
+      - URLs (https://...) — periods inside not split
+      - Ellipses (... or …) — treated as a single boundary
+      - Single newline without trailing space
+      - Double newline as a hard paragraph boundary
+
+    Filters out fragments shorter than 3 words.  If ALL fragments are
+    shorter than 3 words, keeps the longest one to avoid returning an
+    empty list spuriously (a vacuously empty list inflated coverage to
+    1.0 — see #10).
+
+    Args:
+        text: Input text to split.
+
+    Returns:
+        List of sentence strings, each with at least 3 words.
+        Never returns an empty list if the input is non-empty.
+    """
+    if not text or not text.strip():
+        return []
+
+    text = text.strip()
+
+    # Replace URLs with a placeholder to protect periods inside them.
+    url_map: dict[str, str] = {}
+    def _store_url(m: re.Match) -> str:
+        key = f"__URL{len(url_map)}__"
+        url_map[key] = m.group(0)
+        return key
+
+    protected = _URL_RE.sub(_store_url, text)
+
+    # Split on hard paragraph breaks first.
+    paragraphs = re.split(r"\n{2,}", protected)
+
+    raw_sentences: list[str] = []
+    for para in paragraphs:
+        # Within a paragraph, split on terminal punctuation + whitespace/newline.
+        parts: list[str] = []
+        last = 0
+        for m in _TERM_PUNCT_RE.finditer(para):
+            punct = m.group(1)
+            end = m.end()
+            boundary_pos = m.start()
+
+            # Ellipsis check: "..." or "…" indicates continuation, not a sentence end.
+            if _ELLIPSIS_RE.match(punct):
+                continue
+
+            # Decimal / version check: digit.digit — not a boundary.
+            if "." in punct and _DECIMAL_RE.search(para, max(0, boundary_pos - 2)):
+                before_window = para[max(0, boundary_pos - 2): boundary_pos + 2]
+                if _DECIMAL_RE.search(before_window):
+                    continue
+
+            # Abbreviation check (only for single ".").
+            if punct == "." and _is_abbreviation_boundary(para, boundary_pos):
+                continue
+
+            sentence = para[last:end].strip()
+            if sentence:
+                parts.append(sentence)
+            last = end
+
+        tail = para[last:].strip()
+        if tail:
+            parts.append(tail)
+
+        # Also split on single newline within a paragraph (no trailing space needed).
+        expanded: list[str] = []
+        for part in parts:
+            sub = [s.strip() for s in part.split("\n") if s.strip()]
+            expanded.extend(sub)
+
+        raw_sentences.extend(expanded)
+
+    # Restore URLs.
+    restored = []
+    for s in raw_sentences:
+        for key, url in url_map.items():
+            s = s.replace(key, url)
+        restored.append(s)
+
+    # Filter by word count (>= 3).
+    substantive = [s for s in restored if len(s.split()) >= 3]
+    if substantive:
+        return substantive
+
+    # Keep-at-least-one guard: return the longest fragment so the list is
+    # never empty for non-empty input (prevents vacuous coverage=1.0, #10).
+    if restored:
+        return [max(restored, key=lambda s: len(s.split()))]
+    return []
 
 
 def compute_retrieval_confidence(
@@ -118,22 +259,28 @@ def compute_citation_coverage(
     """
     sentences = _split_sentences(answer)
     if not sentences:
-        return 1.0
+        # #10: Return 0.5 (neutral) rather than 1.0 (vacuously perfect).
+        # An answer with no substantive sentences should neither be rewarded
+        # nor penalised — 0.5 keeps the composite in a neutral range while
+        # avoiding the false-confidence of a perfect coverage score.
+        return 0.5
 
     num_chunks = len(retrieved_texts)
     valid_indices = set(range(1, num_chunks + 1))  # 1-based
 
-    # Primary: citation marker checking
-    cited_count = 0
+    # Primary: citation marker checking — fractional credit per sentence (#9).
+    # Previously a sentence got full credit if *any* citation was valid.
+    # Now credit = valid_count / total_count (e.g. [1, 99] with 1 chunk → 0.5).
+    citation_credit_sum = 0.0
     for sentence in sentences:
         citations = _CITATION_RE.findall(sentence)
         if citations:
-            # At least one valid citation index
             cited_indices = {int(c) for c in citations}
-            if cited_indices & valid_indices:
-                cited_count += 1
+            valid_count = len(cited_indices & valid_indices)
+            total_count = len(cited_indices)
+            citation_credit_sum += valid_count / total_count
 
-    citation_score = cited_count / len(sentences) if sentences else 1.0
+    citation_score = citation_credit_sum / len(sentences)
 
     # Secondary: n-gram overlap
     overlap_score = _compute_ngram_overlap(sentences, retrieved_texts, min_overlap_words)
@@ -169,6 +316,9 @@ def _compute_ngram_overlap(
     return grounded_count / len(sentences)
 
 
+_DEFAULT_WEIGHTS = ConfidenceWeights(retrieval=0.50, llm=0.25, citation=0.25)
+
+
 def compute_composite_confidence(
     reranker_scores: list[float],
     llm_confidence_text: str,
@@ -177,11 +327,16 @@ def compute_composite_confidence(
     retrieval_weight: float = 0.50,
     llm_weight: float = 0.25,
     citation_weight: float = 0.25,
+    weights: Optional[ConfidenceWeights] = None,
 ) -> ConfidenceBreakdown:
     """Compute the 3-signal composite confidence score.
 
     Combines retrieval quality (objective), LLM self-report (subjective),
     and citation coverage (structural) into a single weighted composite.
+
+    Accepts weights as either a ConfidenceWeights dataclass (preferred, validated
+    once at construction) or as three float kwargs (back-compat).  If both are
+    provided, the dataclass takes precedence.
 
     Args:
         reranker_scores: Reranker scores for retrieved documents.
@@ -191,15 +346,20 @@ def compute_composite_confidence(
         retrieval_weight: Weight for retrieval signal. Default 0.50.
         llm_weight: Weight for LLM signal. Default 0.25.
         citation_weight: Weight for citation signal. Default 0.25.
+        weights: Optional ConfidenceWeights dataclass (takes precedence over
+            individual float kwargs).
 
     Returns:
         ConfidenceBreakdown with all three signals and the composite score.
     """
-    total_weight = retrieval_weight + llm_weight + citation_weight
-    if abs(total_weight - 1.0) > 1e-6:
-        raise ValueError(
-            f"Confidence weights must sum to 1.0, got {total_weight:.6f} "
-            f"(retrieval={retrieval_weight}, llm={llm_weight}, citation={citation_weight})"
+    if weights is not None:
+        w = weights
+    else:
+        # Build from kwargs — ConfidenceWeights.__post_init__ validates sum.
+        w = ConfidenceWeights(
+            retrieval=retrieval_weight,
+            llm=llm_weight,
+            citation=citation_weight,
         )
 
     retrieval_score = compute_retrieval_confidence(reranker_scores)
@@ -207,9 +367,9 @@ def compute_composite_confidence(
     citation_score = compute_citation_coverage(answer, retrieved_texts)
 
     composite = (
-        retrieval_weight * retrieval_score
-        + llm_weight * llm_score
-        + citation_weight * citation_score
+        w.retrieval * retrieval_score
+        + w.llm * llm_score
+        + w.citation * citation_score
     )
     composite = max(0.0, min(1.0, composite))
 
@@ -218,28 +378,10 @@ def compute_composite_confidence(
         llm_score=llm_score,
         citation_score=citation_score,
         composite=composite,
-        retrieval_weight=retrieval_weight,
-        llm_weight=llm_weight,
-        citation_weight=citation_weight,
+        retrieval_weight=w.retrieval,
+        llm_weight=w.llm,
+        citation_weight=w.citation,
     )
-
-
-def _split_sentences(text: str) -> list[str]:
-    """Split text into sentences using punctuation boundaries.
-
-    Filters out very short fragments (< 4 words) that are likely
-    headings, citations, or formatting artifacts rather than claims.
-
-    Args:
-        text: Input text to split.
-
-    Returns:
-        List of sentence strings with at least 4 words each.
-    """
-    if not text or not text.strip():
-        return []
-    raw = _SENTENCE_SPLIT_RE.split(text.strip())
-    return [s.strip() for s in raw if len(s.strip().split()) >= 4]
 
 
 def _has_substantial_overlap(

--- a/src/retrieval/pipeline/rag_chain.py
+++ b/src/retrieval/pipeline/rag_chain.py
@@ -1133,7 +1133,7 @@ class RAGChain:
             if (
                 RAG_CONFIDENCE_ROUTING_ENABLED
                 and generated_answer
-                and reranked
+                and (reranked or generation_source == "memory")
                 and not tp.budget_exhausted
             ):
                 t0 = time.perf_counter()
@@ -1142,6 +1142,9 @@ class RAGChain:
                     from src.retrieval.generation.confidence import route_by_confidence
                     from src.retrieval.generation.confidence import PostGuardrailAction
 
+                    # #8: Memory path has no retrieval signal — reranker_scores=[] gives
+                    # retrieval_score=0.0 by design.  Composite still provides meaningful
+                    # signal via LLM self-report and citation marker presence/absence.
                     reranker_scores = [r.score for r in reranked]
                     llm_confidence_text = (
                         self._generator._last_llm_confidence

--- a/tests/retrieval/generation/confidence/test_memory_path_confidence.py
+++ b/tests/retrieval/generation/confidence/test_memory_path_confidence.py
@@ -1,0 +1,98 @@
+"""Tests for #8: memory-path confidence gate in rag_chain.
+
+Verifies that composite confidence scoring runs even when generation_source=="memory"
+(i.e. reranked == []), and that retrieval_score is 0 by design on that path.
+"""
+
+import pytest
+
+from src.retrieval.generation.confidence.scoring import compute_composite_confidence
+from src.retrieval.generation.confidence.schemas import ConfidenceBreakdown
+
+
+class TestMemoryPathConfidenceScoring:
+    """Confidence scoring with empty reranker scores (memory-only path)."""
+
+    def test_empty_reranker_scores_gives_zero_retrieval(self):
+        """Memory path: no retrieval signal → retrieval_score = 0.0."""
+        result = compute_composite_confidence(
+            reranker_scores=[],
+            llm_confidence_text="medium",
+            answer="The conversation context indicates the user wants a summary here.",
+            retrieved_texts=[],
+        )
+        assert isinstance(result, ConfidenceBreakdown)
+        assert result.retrieval_score == 0.0
+
+    def test_memory_path_composite_is_nonzero_with_llm_signal(self):
+        """Even with no retrieval, LLM self-report contributes to composite."""
+        result = compute_composite_confidence(
+            reranker_scores=[],
+            llm_confidence_text="high",
+            answer="The conversation shows the user prefers JSON output format here.",
+            retrieved_texts=[],
+        )
+        # LLM weight=0.25, score=0.85 → at least 0.25*0.85 = 0.2125 from LLM alone
+        assert result.composite > 0.0
+        assert result.llm_score == pytest.approx(0.85)
+
+    def test_memory_path_composite_in_valid_range(self):
+        """Composite must be in [0.0, 1.0] even without retrieval docs."""
+        result = compute_composite_confidence(
+            reranker_scores=[],
+            llm_confidence_text="low",
+            answer="Not sure about this at all, just going from memory here.",
+            retrieved_texts=[],
+        )
+        assert 0.0 <= result.composite <= 1.0
+
+    def test_memory_path_no_citation_ngram_overlap(self):
+        """With retrieved_texts=[], n-gram overlap is 0 by design."""
+        result = compute_composite_confidence(
+            reranker_scores=[],
+            llm_confidence_text="medium",
+            answer="This answer comes from conversation memory only, no documents cited.",
+            retrieved_texts=[],
+        )
+        # citation_score: no retrieved text → n-gram overlap = 0
+        # citation markers also have no valid indices (num_chunks=0)
+        # So citation_score should be near 0 or neutral (not 1.0)
+        assert result.citation_score < 1.0
+
+    def test_memory_path_citation_score_not_vacuously_one(self):
+        """Empty retrieved_texts must not yield citation_score=1.0.
+
+        Previously _split_sentences returning [] would give coverage=1.0 (vacuous).
+        With fix #10, empty-answer coverage is 0.5 (neutral) not 1.0.
+        With non-empty answer but no retrieved_texts, coverage should also not be 1.0.
+        """
+        result = compute_composite_confidence(
+            reranker_scores=[],
+            llm_confidence_text="medium",
+            answer="The user asked about the previous conversation context earlier today.",
+            retrieved_texts=[],
+        )
+        assert result.citation_score != 1.0, (
+            f"Memory path should not yield vacuously-perfect citation_score=1.0, "
+            f"got {result.citation_score}"
+        )
+
+    def test_memory_path_lower_composite_than_strong_retrieval(self):
+        """Memory path (retrieval=0) composites lower than strong retrieval path."""
+        text = "The system uses vector search for retrieval of important information here."
+        memory_result = compute_composite_confidence(
+            reranker_scores=[],
+            llm_confidence_text="high",
+            answer=text,
+            retrieved_texts=[],
+        )
+        retrieval_result = compute_composite_confidence(
+            reranker_scores=[0.9, 0.9, 0.9],
+            llm_confidence_text="high",
+            answer=text,
+            retrieved_texts=[text],
+        )
+        assert memory_result.composite < retrieval_result.composite, (
+            f"Memory path ({memory_result.composite:.3f}) should be lower than "
+            f"strong retrieval ({retrieval_result.composite:.3f})"
+        )

--- a/tests/retrieval/generation/confidence/test_scoring_robustness.py
+++ b/tests/retrieval/generation/confidence/test_scoring_robustness.py
@@ -1,0 +1,263 @@
+"""Regression tests for confidence scoring robustness fixes.
+
+Covers:
+  #1  - Sentence splitter fragility (abbreviations, decimals, URLs, ellipses, newlines)
+  #9  - Partial citation credit (fractional score per sentence)
+  #10 - Short-sentence handling (threshold + empty-list guard)
+  #13 - ConfidenceWeights dataclass
+"""
+
+import pytest
+
+from src.retrieval.generation.confidence.scoring import (
+    _split_sentences,
+    compute_citation_coverage,
+    compute_composite_confidence,
+)
+from src.retrieval.generation.confidence.schemas import (
+    ConfidenceBreakdown,
+    ConfidenceWeights,
+)
+
+
+# ---------------------------------------------------------------------------
+# #1 - Sentence splitter robustness
+# ---------------------------------------------------------------------------
+
+
+class TestSplitSentencesRobust:
+    """_split_sentences must handle edge cases the old regex got wrong."""
+
+    def test_abbreviation_mr_not_split(self):
+        text = "Mr. Smith went to the store. He bought milk."
+        sentences = _split_sentences(text)
+        # "Mr. Smith went to the store." should not be split at "Mr."
+        assert any("Mr." in s for s in sentences), f"Got: {sentences}"
+        # Should produce 2 sentences, not 3+
+        assert len(sentences) <= 2, f"Over-split on 'Mr.': {sentences}"
+
+    def test_abbreviation_etc_not_split(self):
+        text = "We need supplies, etc. Please bring them tomorrow."
+        sentences = _split_sentences(text)
+        assert len(sentences) <= 2, f"Over-split on 'etc.': {sentences}"
+
+    def test_abbreviation_ie_not_split(self):
+        text = "Use common formats, i.e. JSON or XML. This is required."
+        sentences = _split_sentences(text)
+        assert len(sentences) <= 2, f"Over-split on 'i.e.': {sentences}"
+
+    def test_abbreviation_eg_not_split(self):
+        text = "Use common formats, e.g. JSON or XML. This is required."
+        sentences = _split_sentences(text)
+        assert len(sentences) <= 2, f"Over-split on 'e.g.': {sentences}"
+
+    def test_decimal_not_split(self):
+        text = "The voltage is 3.14 volts under load. Measure carefully."
+        sentences = _split_sentences(text)
+        assert len(sentences) <= 2, f"Over-split on decimal '3.14': {sentences}"
+
+    def test_version_number_not_split(self):
+        text = "Use version v2.0 of the library. It has better performance."
+        sentences = _split_sentences(text)
+        assert len(sentences) <= 2, f"Over-split on 'v2.0': {sentences}"
+
+    def test_url_not_split(self):
+        text = "Visit https://example.com/path for details. Documentation is there."
+        sentences = _split_sentences(text)
+        assert len(sentences) <= 2, f"Over-split inside URL: {sentences}"
+
+    def test_ellipsis_not_split_into_many(self):
+        text = "The answer is... complicated to explain. Please read the docs."
+        sentences = _split_sentences(text)
+        assert len(sentences) <= 2, f"Over-split on ellipsis: {sentences}"
+
+    def test_newline_boundary_treated_as_sentence_break(self):
+        text = "First sentence has enough words here.\n\nSecond sentence also has words."
+        sentences = _split_sentences(text)
+        assert len(sentences) == 2, f"Should split on double newline: {sentences}"
+
+    def test_single_newline_no_space(self):
+        text = "First long sentence ends here.\nSecond sentence starts here."
+        sentences = _split_sentences(text)
+        # Should split at \n even without trailing space
+        assert len(sentences) == 2, f"Should split on newline without space: {sentences}"
+
+    def test_exclamation_and_question_still_split(self):
+        text = "Is this working correctly? Yes it certainly is working well!"
+        sentences = _split_sentences(text)
+        assert len(sentences) == 2, f"Should split on ? and !: {sentences}"
+
+    def test_dr_abbreviation_not_split(self):
+        text = "Dr. Jones confirmed the results are valid. The test passed."
+        sentences = _split_sentences(text)
+        assert len(sentences) <= 2, f"Over-split on 'Dr.': {sentences}"
+
+    def test_vs_abbreviation_not_split(self):
+        text = "Performance vs. accuracy is a key tradeoff. Both matter greatly."
+        sentences = _split_sentences(text)
+        assert len(sentences) <= 2, f"Over-split on 'vs.': {sentences}"
+
+
+# ---------------------------------------------------------------------------
+# #9 - Partial citation credit
+# ---------------------------------------------------------------------------
+
+
+class TestPartialCitationCredit:
+    """Citation score should use fractional per-sentence credit."""
+
+    def test_fully_valid_citations_score_one(self):
+        """All citations valid → credit = 1.0."""
+        answer = "The result is confirmed by the source [1] for all cases."
+        # 1 chunk → index 1 is valid
+        result = compute_citation_coverage(answer, ["source text about the result"])
+        # citation_score contribution should be 1.0 (70% weight)
+        # n-gram may be 0 → total >= 0.70
+        assert result >= 0.70, f"Expected >= 0.70, got {result}"
+
+    def test_partial_citation_half_valid(self):
+        """[1, 99] with 1 chunk → citation credit = 0.5 (not 1.0 or 0.0)."""
+        answer = "This fact is supported by references [1] and [99] together here."
+        result = compute_citation_coverage(answer, ["fact text for one chunk"])
+        # citation credit per sentence = 0.5 (1 valid out of 2)
+        # citation_score contribution = 0.70 * 0.5 = 0.35
+        # n-gram = 0 → total ≈ 0.35
+        assert 0.30 <= result <= 0.45, f"Expected ~0.35 for half-valid citations, got {result}"
+
+    def test_all_invalid_citations_score_zero_citation(self):
+        """[99, 100] with 1 chunk → citation credit = 0."""
+        answer = "The answer is based on reference [99] and reference [100] always."
+        result = compute_citation_coverage(answer, ["totally different text here"])
+        # citation_score = 0, n-gram ≈ 0 → total ≈ 0
+        assert result < 0.20, f"Expected near 0 for all-invalid citations, got {result}"
+
+    def test_two_sentences_one_fully_cited_one_half(self):
+        """Mixed per-sentence credits average correctly."""
+        # Sentence 1: [1] valid → credit 1.0
+        # Sentence 2: [1, 99] → credit 0.5 (1 valid of 2)
+        # Average citation credit = 0.75 → weighted 0.70 * 0.75 = 0.525
+        answer = (
+            "First claim is backed by reference [1] as clearly shown. "
+            "Second claim uses sources [1] and [99] for its argument here."
+        )
+        result = compute_citation_coverage(answer, ["source text about the claim"])
+        # citation contribution = 0.70 * 0.75 = 0.525; n-gram may vary
+        # Allow a range; the key is it should be between pure 0.5 and pure 0.7
+        assert 0.40 <= result <= 0.80, f"Unexpected result: {result}"
+
+
+# ---------------------------------------------------------------------------
+# #10 - Short-sentence threshold and empty-list guard
+# ---------------------------------------------------------------------------
+
+
+class TestShortSentenceHandling:
+    """Short sentences: threshold >= 3 words, never return empty list spuriously."""
+
+    def test_three_word_sentence_kept(self):
+        """A 3-word sentence should be kept (not filtered)."""
+        sentences = _split_sentences("Limit is 100.")
+        # Should NOT be filtered out — it's >= 3 words
+        assert len(sentences) == 1, f"3-word sentence should be kept, got: {sentences}"
+        assert "Limit is 100" in sentences[0]
+
+    def test_two_word_sentence_may_be_filtered(self):
+        """A 2-word sentence can still be filtered."""
+        sentences = _split_sentences("Done. This is a longer sentence with many words.")
+        # "Done." is 1 word — filtered; keep the longer one
+        longer = [s for s in sentences if "longer sentence" in s]
+        assert len(longer) == 1
+
+    def test_all_short_returns_at_least_one(self):
+        """When all fragments are short, keep at least one (no empty list)."""
+        # All 1-2 word fragments — old code would return []
+        text = "Yes. No. Done. OK."
+        sentences = _split_sentences(text)
+        assert len(sentences) >= 1, "Should return at least one sentence even if all are short"
+
+    def test_empty_sentence_list_yields_neutral_coverage(self):
+        """When splitter returns no substantive sentences, coverage should be 0.5 (neutral).
+
+        Previously returned 1.0 (vacuously perfect), which could inflate scores.
+        The 0.5 neutral value avoids penalising short answers while not rewarding them.
+        """
+        # A 2-word answer — even with the keep-1 guard, this tests the neutral fallback
+        # by feeding an empty retrieved_texts (forces 0 n-gram) and no citation markers
+        # The coverage should NOT be 1.0
+        result = compute_citation_coverage("", [])
+        # Empty answer with no chunks — substantive? No. Should be 0.5 neutral.
+        assert result == 0.5, f"Empty answer+chunks should yield neutral 0.5, got {result}"
+
+    def test_all_short_fragments_neutral_not_perfect(self):
+        """An answer made entirely of < 3-word fragments should yield 0.5, not 1.0."""
+        # "Yes. No." — after splitting, all fragments are 1 word each
+        # keep-1 guard may keep one, but it's still a short non-substantive answer
+        # When _split_sentences returns only very short kept fragments,
+        # coverage shouldn't be vacuously 1.0
+        result = compute_citation_coverage("OK.", ["some retrieved text that is longer"])
+        # Not 1.0 — either 0.5 (neutral when no substantive) or low (no citation/overlap)
+        assert result != 1.0, f"Short-only answer should not be 1.0, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# #13 - ConfidenceWeights dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceWeights:
+    """ConfidenceWeights frozen dataclass with sum-to-1 validation."""
+
+    def test_valid_weights_construct(self):
+        w = ConfidenceWeights(retrieval=0.50, llm=0.25, citation=0.25)
+        assert w.retrieval == 0.50
+        assert w.llm == 0.25
+        assert w.citation == 0.25
+
+    def test_invalid_weights_raise(self):
+        with pytest.raises(ValueError, match="sum to 1.0"):
+            ConfidenceWeights(retrieval=0.5, llm=0.5, citation=0.5)
+
+    def test_frozen(self):
+        w = ConfidenceWeights(retrieval=0.50, llm=0.25, citation=0.25)
+        with pytest.raises((AttributeError, TypeError)):
+            w.retrieval = 0.8  # type: ignore[misc]
+
+    def test_composite_accepts_weights_dataclass(self):
+        """compute_composite_confidence should accept ConfidenceWeights instance."""
+        w = ConfidenceWeights(retrieval=0.50, llm=0.25, citation=0.25)
+        result = compute_composite_confidence(
+            reranker_scores=[0.8],
+            llm_confidence_text="high",
+            answer="The system uses vector search for efficient retrieval here.",
+            retrieved_texts=["The system uses vector search for efficient retrieval here."],
+            weights=w,
+        )
+        assert isinstance(result, ConfidenceBreakdown)
+        assert 0.0 <= result.composite <= 1.0
+
+    def test_composite_kwargs_still_work(self):
+        """Existing float-kwarg call must still work (back-compat)."""
+        result = compute_composite_confidence(
+            reranker_scores=[0.8],
+            llm_confidence_text="high",
+            answer="The system uses vector search for efficient retrieval here.",
+            retrieved_texts=["The system uses vector search for efficient retrieval here."],
+            retrieval_weight=0.50,
+            llm_weight=0.25,
+            citation_weight=0.25,
+        )
+        assert isinstance(result, ConfidenceBreakdown)
+
+    def test_weights_stored_in_breakdown(self):
+        """Breakdown should record actual weights used."""
+        w = ConfidenceWeights(retrieval=0.40, llm=0.40, citation=0.20)
+        result = compute_composite_confidence(
+            reranker_scores=[0.7],
+            llm_confidence_text="medium",
+            answer="Some answer text with enough words for processing.",
+            retrieved_texts=["Some retrieved text with more content here."],
+            weights=w,
+        )
+        assert result.retrieval_weight == pytest.approx(0.40)
+        assert result.llm_weight == pytest.approx(0.40)
+        assert result.citation_weight == pytest.approx(0.20)

--- a/tests/retrieval/test_confidence_scoring.py
+++ b/tests/retrieval/test_confidence_scoring.py
@@ -77,7 +77,8 @@ class TestComputeCitationCoverage:
     """Tests for compute_citation_coverage."""
 
     def test_empty_answer(self):
-        assert compute_citation_coverage("", ["some text"]) == 1.0
+        # #10: Empty answer → 0.5 (neutral), not 1.0 (vacuously perfect).
+        assert compute_citation_coverage("", ["some text"]) == 0.5
 
     def test_empty_chunks(self):
         assert compute_citation_coverage(
@@ -243,18 +244,18 @@ class TestComputeCompositeConfidence:
 
         retrieval = top-1 of [0.8] = 0.8
         llm       = parse_llm_confidence("high") = 0.85
-        citation  = compute_citation_coverage("", [...]) = 1.0  (empty answer → vacuously 1.0)
-        composite = 0.50*0.8 + 0.30*0.85 + 0.20*1.0
-                  = 0.40 + 0.255 + 0.20 = 0.855
+        citation  = compute_citation_coverage("", [...]) = 0.5  (empty answer → neutral 0.5, #10)
+        composite = 0.50*0.8 + 0.30*0.85 + 0.20*0.5
+                  = 0.40 + 0.255 + 0.10 = 0.755
         """
         result = compute_composite_confidence(
             reranker_scores=[0.8],
             llm_confidence_text="high",
-            answer="",           # empty answer → citation_score = 1.0
+            answer="",           # empty answer → citation_score = 0.5 (neutral, #10)
             retrieved_texts=["any text"],
             retrieval_weight=0.50,
             llm_weight=0.30,
             citation_weight=0.20,
         )
-        expected = 0.50 * 0.8 + 0.30 * 0.85 + 0.20 * 1.0
+        expected = 0.50 * 0.8 + 0.30 * 0.85 + 0.20 * 0.5
         assert result.composite == pytest.approx(expected, abs=1e-6)


### PR DESCRIPTION
## Summary
Hardens the 3-signal composite confidence scorer against fragile heuristics.

- **#1 Robust sentence splitter**: replaces the regex splitter with a hand-rolled segmenter that handles English abbreviations (Mr., e.g., i.e.), decimals (3.14), URLs, ellipses, and `\n`/`\n\n` boundaries.
- **#9 Fractional citation credit**: a sentence with citations `[1, 99]` against 1 valid chunk now scores 0.5 (not 1.0).
- **#10 Short-sentence handling**: word threshold lowered 4→3, kept-at-least-one guard, neutral 0.5 fallback when no substantive sentences (instead of vacuous 1.0).
- **#8 Memory-path scoring gate**: confidence block now also runs when `generation_source == \"memory\"` (previously gated on `reranked != []`, excluding the memory-only path).
- **#13 ConfidenceWeights dataclass**: frozen dataclass with sum-to-1 validation; accepted via `weights=` kwarg with float kwargs preserved for back-compat.

## Test plan
- [x] `tests/retrieval/generation/confidence/`