### PR TITLE
fix(output-sanitizer): token-level matching, no regex/substring

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ Ingestion runs as a separate Temporal workflow that writes content + embeddings 
 > it walks every prerequisite install command and the exact gaps in this
 > Quick Start (cloudflared install, nvm/PATH issues, profile combinations).
 
+### Run modes
+
+There are two supported ways to run RagWeave:
+
+| Mode | When to use | What you need | What you skip |
+| --- | --- | --- | --- |
+| **Containers only** (fastest start) | Just trying it out, or running without modifying the API/worker code | Docker + Docker Compose | `make setup`, Python, Node — `rag-api` and `rag-worker` pull from `ghcr.io/juansync7/ragweave-{api,worker}:latest` |
+| **Local dev** (default below) | Iterating on Python or TypeScript code | All prerequisites listed above | Nothing — full local toolchain |
+
+For containers-only:
+
+```bash
+git clone <repo-url> RagWeave && cd RagWeave
+cp .env.example .env
+./scripts/compose.sh --profile app --profile workers up -d
+```
+
+To rebuild app images locally instead of pulling: `./scripts/compose.sh build rag-api rag-worker`. Pin to a specific image tag by setting `RAG_API_IMAGE_TAG` / `RAG_WORKER_IMAGE_TAG` in `.env` (defaults to `latest`).
+
 ### 1. Clone and set up the project
 
 ```bash

--- a/src/retrieval/generation/nodes/output_sanitizer.py
+++ b/src/retrieval/generation/nodes/output_sanitizer.py
@@ -2,7 +2,7 @@
 # Output sanitization for generated answers: removes system prompt leakage,
 # document boundary markers, and template artifacts.
 # Exports: sanitize_answer
-# Deps: logging
+# Deps: logging, string
 # @end-summary
 """Output sanitization for generated answers (REQ-704).
 
@@ -17,9 +17,23 @@ All functions are deterministic and side-effect-free.
 from __future__ import annotations
 
 import logging
+import string
 from typing import Optional
 
 logger = logging.getLogger("rag.output_sanitizer")
+
+# Characters stripped from the edges of each token during normalisation.
+# Includes all ASCII punctuation plus common Unicode smart-quote / ellipsis
+# characters that may surround words in LLM output. Hyphens that appear
+# *inside* a token (e.g. "well-formed") survive because str.strip only
+# removes characters from the leading/trailing edge.
+_EDGE_PUNCT = (
+    string.punctuation
+    + "\u201c\u201d"  # left/right double quotation marks
+    + "\u2018\u2019"  # left/right single quotation marks
+    + "\u2026"         # horizontal ellipsis
+    + "\u00ab\u00bb"  # guillemets
+)
 
 # Document boundary markers used by the pipeline's formatting stages.
 # If any of these appear in the generated answer, they are artifacts
@@ -94,6 +108,28 @@ def sanitize_answer(
     return result
 
 
+def _tokenize(text: str) -> list[str]:
+    """Split text into lowercase tokens with leading/trailing punctuation stripped.
+
+    Punctuation is removed from the edges of each whitespace-delimited word
+    only, so intra-word punctuation (hyphens in "well-formed", apostrophes in
+    contractions) is preserved as part of the token identity.
+
+    Args:
+        text: Raw text to tokenize.
+
+    Returns:
+        List of normalised tokens; empty tokens produced by stripping are
+        discarded.
+    """
+    tokens = []
+    for word in text.lower().split():
+        token = word.strip(_EDGE_PUNCT)
+        if token:
+            tokens.append(token)
+    return tokens
+
+
 def _is_boundary_marker(line: str) -> bool:
     """Check if a line is a document boundary marker."""
     return any(marker in line for marker in _BOUNDARY_MARKERS)
@@ -111,11 +147,11 @@ def _is_prompt_fragment(
 ) -> bool:
     """Check if a line is a leaked fragment of the system prompt.
 
-    Uses word-level contiguous sequence matching: the line must be an
-    exact run of consecutive words from the prompt to be flagged. This
-    avoids the false-positive risk of character-level substring matching,
-    where a legitimate answer containing any 40-character span that happens
-    to appear in a long system prompt would be incorrectly stripped.
+    Uses word-level contiguous sequence matching after stripping edge
+    punctuation from each token. This means a line like "Answer the question."
+    matches the prompt phrase "Answer the question" even though the raw words
+    differ. Intra-word punctuation (hyphens, apostrophes) is preserved so that
+    "well-formed" only matches "well-formed" and not "well formed".
 
     Args:
         line: A single line from the answer.
@@ -124,23 +160,23 @@ def _is_prompt_fragment(
             Lines shorter than this are never flagged.
 
     Returns:
-        True if the line's words form a verbatim contiguous run within
-        the prompt's word sequence.
+        True if the line's tokens form a verbatim contiguous run within
+        the prompt's token sequence.
     """
     if len(line) < min_fragment_length:
         return False
 
-    line_words = line.lower().split()
-    if not line_words:
+    line_tokens = _tokenize(line)
+    if not line_tokens:
         return False
 
-    prompt_words = system_prompt.lower().split()
-    line_len = len(line_words)
+    prompt_tokens = _tokenize(system_prompt)
+    line_len = len(line_tokens)
 
-    # Slide a window of len(line_words) across prompt_words looking for
+    # Slide a window of len(line_tokens) across prompt_tokens looking for
     # an exact contiguous match. O(n * m) but prompt and line are both
     # short in practice (< 500 words / < 30 words respectively).
-    for i in range(len(prompt_words) - line_len + 1):
-        if prompt_words[i : i + line_len] == line_words:
+    for i in range(len(prompt_tokens) - line_len + 1):
+        if prompt_tokens[i : i + line_len] == line_tokens:
             return True
     return False

--- a/src/retrieval/generation/nodes/output_sanitizer.py
+++ b/src/retrieval/generation/nodes/output_sanitizer.py
@@ -131,13 +131,46 @@ def _tokenize(text: str) -> list[str]:
 
 
 def _is_boundary_marker(line: str) -> bool:
-    """Check if a line is a document boundary marker."""
-    return any(marker in line for marker in _BOUNDARY_MARKERS)
+    """Check if a line is a document boundary marker.
+
+    Requires the marker to appear at column 0 (line starts with the marker
+    prefix). For the '--- Document N ---' format, additionally validates that
+    the numeric portion consists only of digits and that the line ends with
+    ' ---', so embedded mentions in legitimate prose are not flagged.
+    """
+    if not line.startswith("--- Document "):
+        for marker in ("--- VERSION CONFLICT WARNING ---", "[CONTENT_FILTERED]"):
+            if line == marker:
+                return True
+        return False
+
+    # Shape check for '--- Document N ---': everything between the prefix and
+    # the trailing ' ---' must be digits.
+    prefix = "--- Document "
+    suffix = " ---"
+    if not line.endswith(suffix):
+        return False
+    middle = line[len(prefix) : len(line) - len(suffix)]
+    return bool(middle) and middle.isdigit()
 
 
 def _is_template_artifact(line: str) -> bool:
-    """Check if a line contains unreplaced template variables."""
-    return any(artifact in line for artifact in _TEMPLATE_ARTIFACTS)
+    """Check if a line is an unreplaced template variable placeholder.
+
+    A line is flagged only when it consists of nothing but the placeholder
+    token (plus optional surrounding punctuation). Legitimate prose that
+    references a placeholder by name is not flagged.
+
+    Braces are not stripped so that '{context}' is preserved as-is for
+    comparison against _TEMPLATE_ARTIFACTS. Only edge whitespace and
+    non-brace punctuation are removed.
+    """
+    words = line.split()
+    if len(words) != 1:
+        return False
+    brace_safe_strip = _EDGE_PUNCT.replace("{", "").replace("}", "")
+    candidate = words[0].strip(brace_safe_strip)
+    return candidate in _TEMPLATE_ARTIFACTS
 
 
 def _is_prompt_fragment(

--- a/tests/retrieval/generation/nodes/test_output_sanitizer.py
+++ b/tests/retrieval/generation/nodes/test_output_sanitizer.py
@@ -1,0 +1,196 @@
+"""Unit tests for output_sanitizer.
+
+Tests are organised by issue:
+- Issue #4  — punctuation-insensitive prompt-fragment matching (_is_prompt_fragment)
+- Issue #15 — word-boundary checks for boundary markers and template artifacts
+"""
+
+import pytest
+
+from src.retrieval.generation.nodes.output_sanitizer import (
+    sanitize_answer,
+    _is_boundary_marker,
+    _is_prompt_fragment,
+    _is_template_artifact,
+)
+
+
+# ---------------------------------------------------------------------------
+# Issue #4 — punctuation-insensitive _is_prompt_fragment
+# ---------------------------------------------------------------------------
+
+
+class TestIsPromptFragmentPunctuation:
+    """_is_prompt_fragment must strip punctuation before word comparison."""
+
+    PROMPT = (
+        "You are a helpful assistant. Answer the question based on the provided context. "
+        "Always cite your sources and provide well-formed responses."
+    )
+
+    def test_line_with_trailing_period_matches(self):
+        """'answer the question.' (line) should match 'answer the question' in prompt."""
+        line = "Answer the question based on the provided context."
+        assert _is_prompt_fragment(line, self.PROMPT) is True
+
+    def test_line_without_punctuation_still_matches(self):
+        """Baseline: clean words already matched before the fix."""
+        line = "Answer the question based on the provided context"
+        assert _is_prompt_fragment(line, self.PROMPT) is True
+
+    def test_hyphenated_word_preserved_as_single_token(self):
+        """'well-formed' must NOT be split into 'well' and 'formed'."""
+        prompt = (
+            "You are a helpful assistant that produces well-formed structured answers "
+            "and always includes detailed citations for every claim it makes."
+        )
+        line = "that produces well-formed structured answers and always includes detailed"
+        assert _is_prompt_fragment(line, prompt) is True
+
+    def test_hyphenated_word_split_does_not_produce_false_positive(self):
+        """A line with 'well formed' (space) must NOT match a prompt with 'well-formed'."""
+        prompt = (
+            "You are a helpful assistant that produces well-formed structured answers "
+            "and always includes detailed citations for every claim it makes."
+        )
+        line = "that produces well formed structured answers and always includes detailed"
+        assert _is_prompt_fragment(line, prompt) is False
+
+    def test_unicode_smart_quotes_stripped(self):
+        """Smart quotes around a phrase should not prevent matching."""
+        prompt = (
+            "You are a helpful assistant. Always answer the question accurately "
+            "and concisely given the retrieved context documents."
+        )
+        line = "“Always answer the question accurately and concisely given”"
+        assert _is_prompt_fragment(line, prompt) is True
+
+    def test_short_line_below_min_length_never_flagged(self):
+        """Lines shorter than min_fragment_length are skipped regardless."""
+        line = "Answer."
+        assert _is_prompt_fragment(line, self.PROMPT) is False
+
+    def test_legitimate_answer_not_flagged(self):
+        """An answer that shares a few incidental words is NOT flagged."""
+        line = "The answer to this question is forty-two and it is well-known."
+        assert _is_prompt_fragment(line, self.PROMPT) is False
+
+    def test_sanitize_answer_removes_punctuated_prompt_fragment(self):
+        """sanitize_answer must strip a line that is a punctuated prompt fragment."""
+        prompt = (
+            "You are a helpful assistant. Answer the question based on the provided "
+            "context documents. Always cite your sources when making claims."
+        )
+        leaked_line = "Answer the question based on the provided context documents."
+        answer = f"The capital of France is Paris.\n{leaked_line}\nSee the sources above."
+        result = sanitize_answer(answer, system_prompt=prompt)
+        assert leaked_line not in result
+        assert "The capital of France is Paris." in result
+
+
+# ---------------------------------------------------------------------------
+# Issue #15 — word-boundary checks for _is_boundary_marker
+# ---------------------------------------------------------------------------
+
+
+class TestIsBoundaryMarker:
+    """_is_boundary_marker must require column-0 start + structural shape."""
+
+    # True positives — real pipeline artifacts
+    def test_document_boundary_exact(self):
+        assert _is_boundary_marker("--- Document 1 ---") is True
+
+    def test_document_boundary_double_digit(self):
+        assert _is_boundary_marker("--- Document 12 ---") is True
+
+    def test_version_conflict_warning_exact(self):
+        assert _is_boundary_marker("--- VERSION CONFLICT WARNING ---") is True
+
+    def test_content_filtered_exact(self):
+        assert _is_boundary_marker("[CONTENT_FILTERED]") is True
+
+    # False positives — legitimate prose that embeds these strings
+    def test_prose_mentioning_document_boundary_not_flagged(self):
+        """A bullet that happens to contain '--- Document ' mid-sentence is NOT a marker."""
+        line = "The pipeline inserts --- Document 1 --- separators between chunks."
+        assert _is_boundary_marker(line) is False
+
+    def test_indented_document_boundary_not_flagged(self):
+        """A line starting with whitespace (column > 0) is not a boundary marker."""
+        line = "  --- Document 3 ---"
+        assert _is_boundary_marker(line) is False
+
+    def test_document_marker_without_trailing_dashes_not_flagged(self):
+        """'--- Document 5' without closing ' ---' is not the real pipeline format."""
+        line = "--- Document 5 is the most relevant one."
+        assert _is_boundary_marker(line) is False
+
+    def test_document_marker_non_digit_number_not_flagged(self):
+        """'--- Document X ---' (non-digit) is not the pipeline format."""
+        line = "--- Document X ---"
+        assert _is_boundary_marker(line) is False
+
+    def test_sanitize_answer_strips_real_boundary(self):
+        answer = "Good answer here.\n--- Document 1 ---\nMore text."
+        result = sanitize_answer(answer)
+        assert "--- Document 1 ---" not in result
+        assert "Good answer here." in result
+
+    def test_sanitize_answer_preserves_prose_with_embedded_marker_text(self):
+        """Prose mentioning '--- Document N ---' format must survive sanitization."""
+        answer = (
+            "The pipeline inserts --- Document 1 --- separators between chunks.\n"
+            "This is normal behaviour."
+        )
+        result = sanitize_answer(answer)
+        assert "The pipeline inserts" in result
+
+
+# ---------------------------------------------------------------------------
+# Issue #15 — word-boundary checks for _is_template_artifact
+# ---------------------------------------------------------------------------
+
+
+class TestIsTemplateArtifact:
+    """_is_template_artifact must only flag lines that ARE the placeholder."""
+
+    # True positives — lines that are just the unreplaced placeholder
+    def test_bare_context_placeholder(self):
+        assert _is_template_artifact("{context}") is True
+
+    def test_bare_question_placeholder(self):
+        assert _is_template_artifact("{question}") is True
+
+    def test_bare_documents_placeholder(self):
+        assert _is_template_artifact("{documents}") is True
+
+    def test_bare_query_placeholder(self):
+        assert _is_template_artifact("{query}") is True
+
+    # False positives — legitimate prose that contains the token embedded in text
+    def test_prose_mentioning_context_placeholder_not_flagged(self):
+        """A bullet explaining that {context} is a variable must NOT be stripped."""
+        line = "The system fills in {context} with the retrieved document chunks."
+        assert _is_template_artifact(line) is False
+
+    def test_prose_mentioning_question_placeholder_not_flagged(self):
+        line = "Replace {question} with the user's actual query before sending."
+        assert _is_template_artifact(line) is False
+
+    def test_placeholder_with_surrounding_punctuation_flagged(self):
+        """A line that IS just the placeholder plus minimal punctuation is still an artifact."""
+        assert _is_template_artifact("{context}.") is True
+
+    def test_sanitize_answer_strips_bare_placeholder(self):
+        answer = "The answer is here.\n{context}\nEnd of answer."
+        result = sanitize_answer(answer)
+        assert "{context}" not in result
+        assert "The answer is here." in result
+
+    def test_sanitize_answer_preserves_prose_with_embedded_placeholder(self):
+        answer = (
+            "Note: the template uses {context} to inject retrieved passages.\n"
+            "This is documented behaviour."
+        )
+        result = sanitize_answer(answer)
+        assert "the template uses {context}" in result


### PR DESCRIPTION
## Summary
Replaces fragile substring/regex checks in the output sanitizer with explicit token-level word-boundary matching.

- **#4 Punctuation-insensitive prompt-fragment match**: tokenize via `str.strip(_EDGE_PUNCT)` (ASCII punctuation + smart quotes + ellipsis + guillemets), preserving intra-word punctuation (\"well-formed\" still matches \"well-formed\"). Sliding-window contiguous match against tokenized prompt — no regex.
- **#15 Word-boundary marker checks**: `--- Document N ---` requires startswith prefix + digit middle + endswith suffix; template artifacts only flagged when the entire line is a single placeholder token. Legitimate prose mentioning markers no longer false-positives.

## Test plan
- [x] `tests/retrieval/generation/test_output_sanitizer.py`