### PR TITLE
fix(confidence): bounded internal re-retrieval loop (option B, REQ-706)

### DIFF
--- a/src/retrieval/common/schemas.py
+++ b/src/retrieval/common/schemas.py
@@ -1,6 +1,7 @@
 # @summary
 # Pipeline boundary contracts: input/output schemas and the cross-cutting wire type.
 # Exports: RAGRequest, RAGResponse, RankedResult, VisualPageResult
+# RAGResponse includes first_composite (initial confidence before internal re-retrieval loop).
 # Deps: dataclasses, typing
 # @end-summary
 """Pipeline-level schema contracts — what enters and exits the RAG pipeline."""
@@ -99,6 +100,7 @@ class RAGResponse:
     retrieval_quality_note: Optional[str] = None
     re_retrieval_suggested: bool = False
     re_retrieval_params: Optional[dict[str, Any]] = None
+    first_composite: Optional[float] = None
     visual_results: Optional[list["VisualPageResult"]] = None  # FR-503
     generation_source: Optional[str] = None       # "retrieval" | "memory" | "retrieval+memory" | None (REQ-1209)
     llm_confidence: Optional[str] = None            # "high" | "medium" | "low" | None — LLM self-reported confidence (REQ-604)

--- a/src/retrieval/generation/confidence/README.md
+++ b/src/retrieval/generation/confidence/README.md
@@ -2,14 +2,15 @@
 Post-generation confidence scoring and routing for the RAG pipeline. Combines three independent
 signals — retrieval quality, LLM self-reported confidence, and citation coverage — into a single
 weighted composite score, then routes the answer to RETURN, RE_RETRIEVE, FLAG, or BLOCK.
+The RE_RETRIEVE action drives a real bounded internal loop inside rag_chain.run() (option B).
 @end-summary -->
 
 # retrieval/generation/confidence
 
 This package implements the 3-signal composite confidence model used after answer generation.
 The composite score drives post-guardrail routing decisions defined in REQ-706: high-confidence
-answers are returned immediately, medium-confidence answers trigger a re-retrieval attempt, and
-low-confidence answers are flagged or blocked after retries are exhausted.
+answers are returned immediately, medium-confidence answers trigger a bounded internal re-retrieval
+loop, and low-confidence answers are flagged or blocked after retries are exhausted.
 
 ## Contents
 
@@ -57,3 +58,53 @@ now also allows scoring when `generation_source == "memory"`.  On this path:
 - `reranker_scores=[]` → `retrieval_score=0.0` (no retrieval signal, by design)
 - `retrieved_texts=[]` → `citation_score` reflects only citation-marker presence
 - The composite still provides meaningful signal via the LLM self-report weight
+
+## Re-retrieval semantics (option B — bounded internal loop)
+
+When `route_by_confidence` returns `RE_RETRIEVE`, the loop lives **inside** `rag_chain.run()`,
+not in the caller. The caller does not need to re-invoke the pipeline to trigger a second pass.
+
+### Loop contract
+
+| Composite | retry budget | Outcome |
+| --- | --- | --- |
+| >= `high_threshold` (0.70) | any | `RETURN` — answer returned immediately, no retry |
+| < `high_threshold`, retries available | > 0 | internal loop fires: search + rerank + generate + rescore |
+| < `high_threshold`, retries exhausted | 0 | `FLAG` or `BLOCK` based on `low_threshold` |
+| NaN | any | `BLOCK` (safe-fail, no retry) |
+
+### Internal loop behaviour
+
+When the loop fires on a `RE_RETRIEVE` decision:
+
+1. **Re-search** — hybrid search with broader params (`alpha -= 0.15`, `search_limit += 5`).
+   Uses the already-embedded query vector — no re-embed, no re-PII-gate, no re-input-rails.
+2. **Re-rank** — cross-encoder reranker on broader candidate set.
+3. **Re-generate** — LLM generation on broader context. Memory context is omitted on the retry
+   to keep the re-retrieval focused on document evidence.
+4. **Rescore** — composite confidence computed on retry answer.
+5. **Pick best** — whichever attempt (first or second) has the higher composite score is
+   returned. Both scores are surfaced: `first_composite` holds the initial score,
+   `composite_confidence` holds the winning score.
+
+### Response fields
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `composite_confidence` | `float \| None` | Winning composite score (best of all attempts) |
+| `first_composite` | `float \| None` | Initial composite score before any retry; `None` if no retry was attempted |
+| `post_guardrail_action` | `str \| None` | Final action after all retries: `"return"`, `"flag"`, or `"block"` |
+| `re_retrieval_suggested` | `bool` | `True` when retries are exhausted and composite is still in the medium band — caller may request a third pass with even-broader params |
+| `re_retrieval_params` | `dict \| None` | Suggested params for a caller-driven third pass when `re_retrieval_suggested=True` |
+
+### Memory-path exception
+
+Re-retrieval is not applicable when `generation_source == "memory"` — there are no documents
+to broaden. In that case the `RE_RETRIEVE` decision is re-routed to `FLAG` without an internal
+loop, and a verification warning is attached to the answer.
+
+### Hard cap
+
+The loop is capped at `RAG_CONFIDENCE_RE_RETRIEVE_MAX_RETRIES` (default `1`, env-configurable).
+Set this to `0` to disable the internal loop entirely — the chain will then fall through to
+`FLAG`/`BLOCK` directly from the first attempt.

--- a/src/retrieval/pipeline/rag_chain.py
+++ b/src/retrieval/pipeline/rag_chain.py
@@ -3,6 +3,10 @@
 # visual retrieval, and LLM generation.  KG graph_context (REQ-KG-794, REQ-KG-796) is
 # threaded from expansion to the generator prompt, placed before document chunks when
 # non-empty and omitted entirely when empty.
+# Stage 7.5 implements a bounded internal re-retrieval loop (REQ-706 option B): when
+# composite confidence is below the high threshold and retry budget remains, the chain
+# re-runs search+rerank+generate+score with broader params (alpha-=0.15, limit+=5) and
+# returns whichever attempt scores higher. Surfaces both scores in RAGResponse.
 # Main classes: RAGChain, RAGResponse. Deps: src.vector_db, src.guardrails, src.retrieval.generation.nodes.generator, src.retrieval.query.nodes.query_processor, src.retrieval.common.schemas, src.core, src.platform
 # @end-summary
 """Main RAG chain that orchestrates the full retrieval pipeline."""
@@ -1135,6 +1139,7 @@ class RAGChain:
             verification_warning = None
             re_retrieval_suggested = False
             re_retrieval_params = None
+            first_composite = None
 
             if (
                 RAG_CONFIDENCE_ROUTING_ENABLED
@@ -1202,28 +1207,108 @@ class RAGChain:
                     breakdown.citation_score,
                 )
 
-                # Act on routing decision (non-blocking: return first response
-                # immediately, suggest re-retrieval for caller to request)
+                # Act on routing decision.
                 re_retrieval_suggested = False
                 re_retrieval_params = None
 
                 if action == PostGuardrailAction.RE_RETRIEVE and generation_source != "memory":
-                    # Don't block — return the first answer and suggest re-retrieval.
-                    # The caller (UI/API) can request a second attempt with these
-                    # broader params. The user sees both side-by-side and chooses.
-                    # Skip when generation_source is "memory" — no docs to re-retrieve.
-                    re_retrieval_suggested = True
-                    re_retrieval_params = {
-                        "alpha": max(0.0, alpha - 0.15),
-                        "search_limit": search_limit + 5,
-                        "rerank_top_k": rerank_top_k,
-                        "fast_path": True,
-                    }
-                    verification_warning = (
-                        "This answer has moderate confidence. A broader search "
-                        "may yield better results — re-retrieval is available."
+                    # Bounded internal re-retrieval loop (REQ-706, option B).
+                    # Re-run search + rerank + generate + score with broader params.
+                    # Reuses already-embedded query to avoid redundant model calls.
+                    # Input-rails and PII gate are NOT re-run (query is already clean).
+                    first_composite = breakdown.composite
+                    retry_alpha = max(0.0, alpha - 0.15)
+                    retry_search_limit = search_limit + 5
+                    retry_bm25_query = bm25_query
+
+                    with self.tracer.span("rag_chain.re_retrieval", parent=root_span) as rr_span:
+                        rr_span.set_attribute("retry_alpha", retry_alpha)
+                        rr_span.set_attribute("retry_search_limit", retry_search_limit)
+
+                        retry_search_results = self.retry_provider.execute(
+                            operation_name="weaviate_hybrid_search_re_retrieval",
+                            fn=lambda: self._do_search(
+                                retry_bm25_query,
+                                query_embedding,
+                                retry_alpha,
+                                retry_search_limit,
+                                filters or None,
+                            ),
+                            policy=self.retry_policy,
+                            idempotency_key=(
+                                f"re_retrieve:{processed_query}:{source_filter}:"
+                                f"{heading_filter}:{retry_search_limit}"
+                            ),
+                        )
+
+                        if retry_search_results:
+                            retry_reranked = self.reranker.rerank(
+                                query=processed_query,
+                                documents=retry_search_results,
+                                top_k=rerank_top_k,
+                            )
+                        else:
+                            retry_reranked = []
+
+                        retry_answer = generated_answer
+                        if retry_reranked and self._generator:
+                            retry_answer = self._generator.generate(
+                                query=processed_query,
+                                context_chunks=[r.text for r in retry_reranked],
+                                scores=[r.score for r in retry_reranked],
+                                memory_context=None,
+                                recent_turns=None,
+                                graph_context=graph_context,
+                            )
+
+                        retry_breakdown = None
+                        if retry_reranked and retry_answer:
+                            retry_breakdown = compute_composite_confidence(
+                                reranker_scores=[r.score for r in retry_reranked],
+                                llm_confidence_text=(
+                                    self._generator._last_llm_confidence
+                                    if self._generator
+                                    else "medium"
+                                ),
+                                answer=retry_answer,
+                                retrieved_texts=[r.text for r in retry_reranked],
+                                retrieval_weight=RAG_CONFIDENCE_RETRIEVAL_WEIGHT,
+                                llm_weight=RAG_CONFIDENCE_LLM_WEIGHT,
+                                citation_weight=RAG_CONFIDENCE_CITATION_WEIGHT,
+                            )
+
+                    if retry_breakdown is not None and retry_breakdown.composite >= breakdown.composite:
+                        reranked = retry_reranked
+                        generated_answer = retry_answer
+                        breakdown = retry_breakdown
+                        composite_confidence = retry_breakdown.composite
+                        confidence_breakdown_dict = {
+                            "retrieval_score": retry_breakdown.retrieval_score,
+                            "llm_score": retry_breakdown.llm_score,
+                            "citation_score": retry_breakdown.citation_score,
+                            "composite": retry_breakdown.composite,
+                            "retrieval_weight": retry_breakdown.retrieval_weight,
+                            "llm_weight": retry_breakdown.llm_weight,
+                            "citation_weight": retry_breakdown.citation_weight,
+                        }
+
+                    action = route_by_confidence(
+                        composite=breakdown.composite,
+                        retry_count=retry_count + 1,
+                        high_threshold=RAG_CONFIDENCE_HIGH_THRESHOLD,
+                        low_threshold=RAG_CONFIDENCE_LOW_THRESHOLD,
+                        max_retries=RAG_CONFIDENCE_RE_RETRIEVE_MAX_RETRIES,
                     )
-                elif action == PostGuardrailAction.RE_RETRIEVE and generation_source == "memory":
+                    post_guardrail_action = action.value
+
+                    logger.info(
+                        "Re-retrieval loop: first=%.2f second=%.2f final_action=%s",
+                        first_composite,
+                        breakdown.composite,
+                        action.value,
+                    )
+
+                if action == PostGuardrailAction.RE_RETRIEVE and generation_source == "memory":
                     # REQ-1203: Re-retrieval not applicable on memory path — re-route to FLAG
                     verification_warning = (
                         "This answer was generated from conversation history and has limited confidence. "
@@ -1235,6 +1320,19 @@ class RAGChain:
                         f"⚠️ {verification_warning}"
                     )
                     post_guardrail_action = PostGuardrailAction.FLAG.value
+                elif action == PostGuardrailAction.RE_RETRIEVE:
+                    # Retries exhausted — advisory flag for caller-driven broader pass.
+                    re_retrieval_suggested = True
+                    re_retrieval_params = {
+                        "alpha": max(0.0, alpha - 0.15),
+                        "search_limit": search_limit + 5,
+                        "rerank_top_k": rerank_top_k,
+                        "fast_path": True,
+                    }
+                    verification_warning = (
+                        "This answer has moderate confidence. A broader search "
+                        "may yield better results — re-retrieval is available."
+                    )
                 elif action == PostGuardrailAction.BLOCK:
                     generated_answer = (
                         "Insufficient documentation found to provide a reliable answer. "
@@ -1250,6 +1348,14 @@ class RAGChain:
                         f"---\n"
                         f"⚠️ {verification_warning}"
                     )
+                    if first_composite is not None:
+                        re_retrieval_suggested = True
+                        re_retrieval_params = {
+                            "alpha": max(0.0, alpha - 0.15),
+                            "search_limit": search_limit + 5,
+                            "rerank_top_k": rerank_top_k,
+                            "fast_path": True,
+                        }
 
             # Extract LLM self-reported confidence as structured data.
             # Display formatting is the UI/console layer's responsibility.
@@ -1292,6 +1398,7 @@ class RAGChain:
                 retrieval_quality_note=retrieval_quality_note,
                 re_retrieval_suggested=re_retrieval_suggested if RAG_CONFIDENCE_ROUTING_ENABLED else False,
                 re_retrieval_params=re_retrieval_params,
+                first_composite=first_composite if RAG_CONFIDENCE_ROUTING_ENABLED else None,
                 visual_results=visual_results,
                 generation_source=generation_source,
                 llm_confidence=llm_confidence,

--- a/src/retrieval/pipeline/rag_chain.py
+++ b/src/retrieval/pipeline/rag_chain.py
@@ -1252,7 +1252,7 @@ class RAGChain:
 
                         retry_answer = generated_answer
                         if retry_reranked and self._generator:
-                            retry_answer = self._generator.generate(
+                            retry_gen_result = self._generator.generate(
                                 query=processed_query,
                                 context_chunks=[r.text for r in retry_reranked],
                                 scores=[r.score for r in retry_reranked],
@@ -1260,16 +1260,16 @@ class RAGChain:
                                 recent_turns=None,
                                 graph_context=graph_context,
                             )
+                            retry_answer = retry_gen_result.answer or None
+                            retry_confidence = retry_gen_result.confidence
+                        else:
+                            retry_confidence = "medium"
 
                         retry_breakdown = None
                         if retry_reranked and retry_answer:
                             retry_breakdown = compute_composite_confidence(
                                 reranker_scores=[r.score for r in retry_reranked],
-                                llm_confidence_text=(
-                                    self._generator._last_llm_confidence
-                                    if self._generator
-                                    else "medium"
-                                ),
+                                llm_confidence_text=retry_confidence,
                                 answer=retry_answer,
                                 retrieved_texts=[r.text for r in retry_reranked],
                                 retrieval_weight=RAG_CONFIDENCE_RETRIEVAL_WEIGHT,

--- a/tests/retrieval/generation/confidence/test_re_retrieval_loop.py
+++ b/tests/retrieval/generation/confidence/test_re_retrieval_loop.py
@@ -1,0 +1,298 @@
+"""Tests for re-retrieval loop semantics (option B, REQ-706).
+
+Covers:
+- High composite → no re-retrieval, immediate return.
+- Medium composite with retry budget → second attempt runs, higher-scoring result returned.
+- Medium composite with retry budget exhausted → FLAG with verification_warning.
+- Low composite with retry budget exhausted → BLOCK.
+- NaN composite → BLOCK (regression).
+
+These tests drive the real bounded internal loop added to rag_chain.run() in
+the fix/gen-rerouting-loop branch.
+"""
+from __future__ import annotations
+
+import math
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.retrieval.generation.confidence.routing import route_by_confidence
+from src.retrieval.generation.confidence.schemas import PostGuardrailAction
+
+
+class TestRouteByConfidenceLoopContract:
+    """Unit tests for route_by_confidence re-retrieval loop semantics."""
+
+    def test_high_composite_returns_immediately(self):
+        """composite >= high_threshold → RETURN, no retry budget consumed."""
+        action = route_by_confidence(0.80, retry_count=0, max_retries=1)
+        assert action == PostGuardrailAction.RETURN
+
+    def test_medium_composite_with_budget_triggers_re_retrieve(self):
+        """composite in medium band with budget → RE_RETRIEVE."""
+        action = route_by_confidence(0.60, retry_count=0, max_retries=1)
+        assert action == PostGuardrailAction.RE_RETRIEVE
+
+    def test_medium_composite_budget_exhausted_flags(self):
+        """composite in medium band after retry exhausted → FLAG (not BLOCK)."""
+        action = route_by_confidence(0.60, retry_count=1, max_retries=1)
+        assert action == PostGuardrailAction.FLAG
+
+    def test_low_composite_budget_exhausted_blocks(self):
+        """composite below low_threshold after retry exhausted → BLOCK."""
+        action = route_by_confidence(0.30, retry_count=1, max_retries=1)
+        assert action == PostGuardrailAction.BLOCK
+
+    def test_nan_composite_blocks(self):
+        """NaN composite must always BLOCK — regression guard."""
+        action = route_by_confidence(math.nan, retry_count=0)
+        assert action == PostGuardrailAction.BLOCK
+
+    def test_nan_composite_ignores_retry_budget(self):
+        """NaN composite BLOCK even when retry budget is available."""
+        action = route_by_confidence(math.nan, retry_count=0, max_retries=5)
+        assert action == PostGuardrailAction.BLOCK
+
+    def test_medium_composite_multi_retry_budget(self):
+        """With max_retries=2, retry_count=1 should still re-retrieve."""
+        action = route_by_confidence(0.60, retry_count=1, max_retries=2)
+        assert action == PostGuardrailAction.RE_RETRIEVE
+
+    def test_medium_composite_multi_retry_exhausted(self):
+        """With max_retries=2, retry_count=2 should FLAG (medium composite)."""
+        action = route_by_confidence(0.60, retry_count=2, max_retries=2)
+        assert action == PostGuardrailAction.FLAG
+
+
+def _make_ranked_result(score: float, text: str = "sample text"):
+    from src.retrieval.common import RankedResult
+    return RankedResult(text=text, score=score, metadata={"source": "doc.pdf"})
+
+
+def _make_chain():
+    """Build a RAGChain with all external deps stubbed out and a mock generator."""
+    from src.retrieval.pipeline.rag_chain import RAGChain
+
+    with patch("src.retrieval.pipeline.rag_chain.create_persistent_client"), \
+         patch("src.retrieval.pipeline.rag_chain.ensure_collection"), \
+         patch("src.retrieval.pipeline.rag_chain.get_embedding_provider"), \
+         patch("src.retrieval.pipeline.rag_chain.get_reranker_provider"), \
+         patch("src.retrieval.pipeline.rag_chain.OllamaGenerator"), \
+         patch("src.retrieval.pipeline.rag_chain.GraphQueryExpander"), \
+         patch("src.retrieval.pipeline.rag_chain.KnowledgeGraphBuilder"):
+        chain = RAGChain(persistent_weaviate=False)
+
+    chain.embeddings = MagicMock()
+    chain.embeddings.embed_query.return_value = [0.1] * 768
+
+    chain.reranker = MagicMock()
+
+    span_cm = MagicMock()
+    span_cm.__enter__ = MagicMock(return_value=MagicMock())
+    span_cm.__exit__ = MagicMock(return_value=False)
+    chain.tracer = MagicMock()
+    chain.tracer.span.return_value = span_cm
+
+    chain.retry_provider = MagicMock()
+    chain._kg_expander = None
+    chain._weaviate_client = None
+    chain._persistent_weaviate = False
+
+    mock_gen = MagicMock()
+    mock_gen.is_available.return_value = True
+    mock_gen._last_llm_confidence = "medium"
+    mock_gen._last_response = None
+    mock_gen.generate.return_value = "Generated answer."
+    chain._generator = mock_gen
+
+    return chain
+
+
+def _make_query_result():
+    from src.retrieval.query import QueryAction, QueryResult
+    mock_qr = MagicMock(spec=QueryResult)
+    mock_qr.action = QueryAction.SEARCH
+    mock_qr.processed_query = "test query"
+    mock_qr.confidence = 0.9
+    mock_qr.clarification_message = None
+    mock_qr.has_backward_reference = False
+    mock_qr.suppress_memory = False
+    mock_qr.standalone_query = None
+    mock_qr.history_decision = None
+    mock_qr.history_turns_used = 0
+    return mock_qr
+
+
+_BASE_PATCHES = [
+    ("src.retrieval.pipeline.rag_chain.RAG_CONFIDENCE_ROUTING_ENABLED", True),
+    ("src.retrieval.pipeline.rag_chain.RAG_CONFIDENCE_HIGH_THRESHOLD", 0.70),
+    ("src.retrieval.pipeline.rag_chain.RAG_CONFIDENCE_LOW_THRESHOLD", 0.50),
+    ("src.retrieval.pipeline.rag_chain.RAG_CONFIDENCE_RE_RETRIEVE_MAX_RETRIES", 1),
+    ("src.retrieval.pipeline.rag_chain.GUARDRAIL_BACKEND", None),
+    ("src.retrieval.pipeline.rag_chain.KG_ENABLED", False),
+    ("src.retrieval.pipeline.rag_chain.GENERATION_ENABLED", True),
+    ("src.retrieval.pipeline.rag_chain.RAG_DOCUMENT_FORMATTING_ENABLED", False),
+    ("src.retrieval.pipeline.rag_chain.RAG_VISUAL_RETRIEVAL_ENABLED", False),
+]
+
+
+class TestRagChainReRetrievalLoop(unittest.TestCase):
+    """Integration-style tests for the re-retrieval loop inside RAGChain.run().
+
+    These tests mock the external I/O (search, reranker, generator) to verify
+    that the loop logic inside rag_chain is correct without requiring real
+    infrastructure.
+    """
+
+    def _run(self, chain, *, composite_sequence, search_results_sequence):
+        """Run chain.run() with patched confidence routing and search."""
+        composite_iter = iter(composite_sequence)
+        search_iter = iter(search_results_sequence)
+
+        def fake_composite(**kwargs):
+            from src.retrieval.generation.confidence.schemas import ConfidenceBreakdown
+            score = next(composite_iter)
+            return ConfidenceBreakdown(
+                retrieval_score=score, llm_score=score, citation_score=score, composite=score
+            )
+
+        def fake_search(*args, **kwargs):
+            try:
+                return next(search_iter)
+            except StopIteration:
+                return []
+
+        chain.retry_provider.execute.side_effect = fake_search
+        chain.reranker.rerank.side_effect = lambda query, documents, top_k: documents
+
+        patches = {name: val for name, val in _BASE_PATCHES}
+
+        with patch("src.retrieval.pipeline.rag_chain.RAG_CONFIDENCE_ROUTING_ENABLED", True), \
+             patch("src.retrieval.pipeline.rag_chain.RAG_CONFIDENCE_HIGH_THRESHOLD", 0.70), \
+             patch("src.retrieval.pipeline.rag_chain.RAG_CONFIDENCE_LOW_THRESHOLD", 0.50), \
+             patch("src.retrieval.pipeline.rag_chain.RAG_CONFIDENCE_RE_RETRIEVE_MAX_RETRIES", 1), \
+             patch("src.retrieval.pipeline.rag_chain.GUARDRAIL_BACKEND", None), \
+             patch("src.retrieval.pipeline.rag_chain.KG_ENABLED", False), \
+             patch("src.retrieval.pipeline.rag_chain.GENERATION_ENABLED", True), \
+             patch("src.retrieval.pipeline.rag_chain.RAG_DOCUMENT_FORMATTING_ENABLED", False), \
+             patch("src.retrieval.pipeline.rag_chain.RAG_VISUAL_RETRIEVAL_ENABLED", False), \
+             patch("src.retrieval.pipeline.rag_chain.process_query", return_value=_make_query_result()), \
+             patch("src.retrieval.generation.confidence.compute_composite_confidence", side_effect=fake_composite):
+            response = chain.run("test query")
+
+        return response
+
+    def test_high_composite_no_reretrieval(self):
+        """composite=0.80 → RETURN immediately, search called exactly once."""
+        chain = _make_chain()
+        result1 = [_make_ranked_result(0.9, "good doc")]
+
+        response = self._run(
+            chain,
+            composite_sequence=[0.85],
+            search_results_sequence=[result1],
+        )
+
+        assert response.post_guardrail_action == "return", (
+            f"Expected 'return', got {response.post_guardrail_action}"
+        )
+        assert response.re_retrieval_suggested is False
+        assert chain.retry_provider.execute.call_count == 1, (
+            f"Search should be called once for high-confidence answers, "
+            f"got {chain.retry_provider.execute.call_count}"
+        )
+
+    def test_medium_composite_with_budget_triggers_loop(self):
+        """composite=0.60 (medium) with retry budget → loop fires, search called twice.
+
+        The second attempt scores 0.80 (above threshold) → returned as RETURN.
+        Both composite scores must be surfaced: first_composite=0.60, composite_confidence=0.80.
+        """
+        chain = _make_chain()
+        result1 = [_make_ranked_result(0.5, "weak doc")]
+        result2 = [_make_ranked_result(0.8, "stronger doc")]
+
+        response = self._run(
+            chain,
+            composite_sequence=[0.60, 0.80],
+            search_results_sequence=[result1, result2],
+        )
+
+        assert chain.retry_provider.execute.call_count == 2, (
+            f"Search should be called twice (initial + retry), "
+            f"got {chain.retry_provider.execute.call_count}"
+        )
+        assert response.post_guardrail_action == "return", (
+            f"Second attempt scored 0.80 (above threshold), expected RETURN, "
+            f"got {response.post_guardrail_action}"
+        )
+        assert response.first_composite == 0.60, (
+            f"first_composite should be 0.60, got {response.first_composite}"
+        )
+        assert response.composite_confidence == 0.80, (
+            f"composite_confidence should be the higher second score 0.80, "
+            f"got {response.composite_confidence}"
+        )
+
+    def test_medium_composite_retry_exhausted_flags(self):
+        """composite=0.60 on both attempts with max_retries=1 → FLAG with verification_warning.
+
+        When retries are exhausted and composite is still in the medium band,
+        re_retrieval_suggested must be True so the caller can request a broader pass.
+        """
+        chain = _make_chain()
+        result1 = [_make_ranked_result(0.5, "weak doc")]
+        result2 = [_make_ranked_result(0.5, "still weak doc")]
+
+        response = self._run(
+            chain,
+            composite_sequence=[0.60, 0.60],
+            search_results_sequence=[result1, result2],
+        )
+
+        assert response.post_guardrail_action == "flag", (
+            f"Exhausted retries with medium composite → FLAG, "
+            f"got {response.post_guardrail_action}"
+        )
+        assert response.re_retrieval_suggested is True, (
+            "re_retrieval_suggested must be True when retries exhausted "
+            "but composite is in medium band (caller can request broader pass)"
+        )
+        assert response.verification_warning is not None, (
+            "verification_warning must be set when action is FLAG"
+        )
+
+    def test_low_composite_retry_exhausted_blocks(self):
+        """composite=0.30 on both attempts with max_retries=1 → BLOCK."""
+        chain = _make_chain()
+        result1 = [_make_ranked_result(0.1, "irrelevant doc")]
+        result2 = [_make_ranked_result(0.1, "still irrelevant doc")]
+
+        response = self._run(
+            chain,
+            composite_sequence=[0.30, 0.30],
+            search_results_sequence=[result1, result2],
+        )
+
+        assert response.post_guardrail_action == "block", (
+            f"Low composite exhausted retries → BLOCK, got {response.post_guardrail_action}"
+        )
+
+    def test_nan_composite_blocks_without_retry(self):
+        """NaN composite → BLOCK immediately, search called exactly once (no retry)."""
+        chain = _make_chain()
+        result1 = [_make_ranked_result(0.5, "some doc")]
+
+        response = self._run(
+            chain,
+            composite_sequence=[float("nan")],
+            search_results_sequence=[result1],
+        )
+
+        assert response.post_guardrail_action == "block", (
+            f"NaN composite → BLOCK, got {response.post_guardrail_action}"
+        )
+        assert chain.retry_provider.execute.call_count == 1, (
+            f"NaN should BLOCK without retrying — search must be called once, "
+            f"got {chain.retry_provider.execute.call_count}"
+        )

--- a/tests/retrieval/generation/confidence/test_re_retrieval_loop.py
+++ b/tests/retrieval/generation/confidence/test_re_retrieval_loop.py
@@ -98,11 +98,16 @@ def _make_chain():
     chain._weaviate_client = None
     chain._persistent_weaviate = False
 
+    from src.retrieval.generation.nodes import GenerationResult
+
     mock_gen = MagicMock()
     mock_gen.is_available.return_value = True
-    mock_gen._last_llm_confidence = "medium"
-    mock_gen._last_response = None
-    mock_gen.generate.return_value = "Generated answer."
+    mock_gen.generate.return_value = GenerationResult(
+        answer="Generated answer.",
+        confidence="medium",
+        raw_response=None,
+        error=None,
+    )
     chain._generator = mock_gen
 
     return chain


### PR DESCRIPTION
## Summary
Implements REQ-706 option B — a real bounded internal re-retrieval loop inside `rag_chain.run()` instead of leaving `RE_RETRIEVE` as a caller-driven hint.

- **Internal loop**: on `RE_RETRIEVE`, the chain re-searches with broader params (`alpha -= 0.15`, `search_limit += 5`), reuses the cached query embedding (no re-embed, no re-PII-gate), re-ranks, re-generates, and rescores.
- **Pick best**: whichever attempt has the higher composite score is returned. Both scores surfaced via `composite_confidence` (winner) and `first_composite` (initial).
- **Memory-path exception**: `RE_RETRIEVE` re-routes to `FLAG` when `generation_source == \"memory\"` (no documents to broaden).
- **Hard cap**: env-configurable `RAG_CONFIDENCE_RE_RETRIEVE_MAX_RETRIES` (default 1; set 0 to disable).
- Adapts retry path to the `GenerationResult` contract (#77) — second commit on the branch.

Replaces the now-closed #80 (its base branch was deleted on merge of #77). Rebased onto current `develop`.

## Test plan
- [x] `tests/retrieval/generation/confidence/test_re_retrieval_loop.py` (13 tests)