### PR TITLE
fix(ci): clone KGWeave sibling repo before uv sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      # pyproject.toml declares `kgweave = { path = "../KGWeave", editable = true }`
+      # — uv resolves the editable dep against a sibling clone. CI must materialise
+      # one before `uv sync`, otherwise the lockfile entry fails to install.
+      # KGWeave is public; no auth required. Pinning is by-main today; promote to
+      # a tagged ref once KGWeave starts cutting releases.
+      - name: Clone KGWeave (sibling editable dep)
+        run: git clone --depth 1 https://github.com/JuanSync7/KGWeave.git ../KGWeave
       - name: Install locked dependencies
         run: uv sync --locked --extra dev
       - name: Run tests


### PR DESCRIPTION
## Summary

- Adds a `git clone --depth 1 https://github.com/JuanSync7/KGWeave.git ../KGWeave` step to the `ci` workflow, before `uv sync`.
- Restores test signal on every PR against `develop`.

## Why

`pyproject.toml` declares `kgweave = { path = "../KGWeave", editable = true }`. `uv sync --locked` fails when that sibling directory does not exist:

```
error: Failed to generate package metadata for `kgweave==0.1.0 @ editable+../KGWeave`
  Caused by: Distribution not found at: file:///home/runner/work/RagWeave/KGWeave
```

This has been failing **every PR against `develop`** since the KGWeave extraction commit (`0932959`) — both PR #83 (deep-research per-topic rerank) and PR #84 (console remote-view, just merged) landed without test-signal coverage.

KGWeave was made public for this fix (was previously private — no IP rationale to keep it private during early development). No CI secret is required.

## Pinning

Today CI pulls `main` of KGWeave with `--depth 1`. This is fragile: a breaking change on KGWeave's main lands silently and breaks every RagWeave PR. Acceptable short-term because:
- KGWeave is co-developed by the same author (single point of coordination).
- The lockfile entry is `editable = "../KGWeave"`, so the lock contract is "whatever main says", which already matches CI behaviour.

**Follow-up:** once KGWeave starts cutting tagged releases, change the clone step to `--branch v<X.Y.Z>` and update `uv.lock` in lockstep. Filed informally — open an issue if a tracker is preferred.

## Test plan

- [ ] PR triggers `ci` workflow; `Install locked dependencies` step succeeds (was failing before this PR).
- [ ] `Run tests` step executes (signal that the regression in test gating is fixed).
- [ ] Build console TypeScript UI step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)