### PR TITLE
chore(build): split local :dev tag from registry :latest for app images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -339,10 +339,25 @@ RAG_QUERY_CONFIDENCE_THRESHOLD=0.0
 
 # --- Container image tags ---
 # App images are published to GHCR by .github/workflows/publish-images.yml.
-# Default 'latest' tracks main; pin to a SHA or version tag for reproducibility.
-# To build locally instead of pulling: `docker compose build rag-api rag-worker`.
-# RAG_API_IMAGE_TAG=latest
-# RAG_WORKER_IMAGE_TAG=latest
+# CI publishes `:latest` (and pinned SHAs) — those track main.
+#
+# For local development we use a separate `:dev` tag so your local builds
+# can never be clobbered by `docker compose pull` or a CI-published `:latest`.
+# `make container-build` tags images as `:dev` by default; set the same tag
+# here so `docker compose up` reads your local build.
+#
+# Override the registry path with RAG_{API,WORKER}_IMAGE_REF if you publish
+# to a different org. Pin to a SHA or version for reproducibility.
+#
+# DEFAULT (fresh clone, no local build): leave commented → compose pulls
+# `:latest` from GHCR, which is what CI publishes from main.
+#
+# LOCAL DEV (you run `make container-build`): uncomment the two `:dev`
+# lines below so compose reads the same tag the Makefile writes.
+# RAG_API_IMAGE_TAG=dev
+# RAG_WORKER_IMAGE_TAG=dev
+# RAG_API_IMAGE_REF=ghcr.io/juansync7/ragweave-api
+# RAG_WORKER_IMAGE_REF=ghcr.io/juansync7/ragweave-worker
 
 # Pinned versions for high-churn third-party images. Override only when you
 # know the new version is compatible (Temporal in particular has breaking

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,28 @@
 .DEFAULT_GOAL := help
 
 # ---------------------------------------------------------------------------
+# Image-tag config
+#
+# docker-compose.yml pins worker/API services to GHCR-style refs:
+#   image: ${RAG_API_IMAGE_REF:-ghcr.io/juansync7/ragweave-api}:${RAG_API_IMAGE_TAG:-latest}
+# After local builds (which produce `rag-api` / `rag-worker`), we mirror to
+# the same ref so `docker compose up` picks up the freshly built image
+# instead of pulling stale `latest` from GHCR.
+#
+# Override on the command line or in your environment, e.g.:
+#   make container-build-worker RAG_WORKER_IMAGE_REF=myorg/ragweave-worker
+# ---------------------------------------------------------------------------
+#
+# Default tag is `dev` (not `latest`) so local builds can never be clobbered
+# by `docker compose pull` or a CI-published GHCR `:latest`. Set your local
+# `.env` to `RAG_{API,WORKER}_IMAGE_TAG=dev` so compose reads the same tag.
+# CI/prod can override to `latest` (or a pinned SHA) on the command line.
+RAG_API_IMAGE_REF    ?= ghcr.io/juansync7/ragweave-api
+RAG_API_IMAGE_TAG    ?= dev
+RAG_WORKER_IMAGE_REF ?= ghcr.io/juansync7/ragweave-worker
+RAG_WORKER_IMAGE_TAG ?= dev
+
+# ---------------------------------------------------------------------------
 # Help
 #
 # Grouped listing of targets. Keep this in sync with README.md's
@@ -330,9 +352,15 @@ container-build: console-build container-build-api container-build-worker contai
 
 container-build-api:
 	DOCKER_BUILDKIT=1 docker build -t rag-api -f containers/Dockerfile.api .
+	# Mirror to the registry ref that docker-compose.yml pins, so `compose up`
+	# picks up the freshly built image instead of pulling stale `latest`.
+	docker tag rag-api $(RAG_API_IMAGE_REF):$(RAG_API_IMAGE_TAG)
 
 container-build-worker:
 	DOCKER_BUILDKIT=1 docker build -t rag-worker -f containers/Dockerfile.runtime .
+	# Mirror to the registry ref that docker-compose.yml pins, so `compose up`
+	# picks up the freshly built image instead of pulling stale `latest`.
+	docker tag rag-worker $(RAG_WORKER_IMAGE_REF):$(RAG_WORKER_IMAGE_TAG)
 
 # Build with Podman instead of Docker. Passes --format docker so HEALTHCHECK
 # directives are preserved if ever re-added (the compose-level healthcheck
@@ -341,6 +369,9 @@ container-build-worker:
 container-build-podman: console-build
 	podman build --format docker -t rag-api    -f containers/Dockerfile.api .
 	podman build --format docker -t rag-worker -f containers/Dockerfile.runtime .
+	# Mirror to the registry refs that docker-compose.yml pins.
+	podman tag rag-api    $(RAG_API_IMAGE_REF):$(RAG_API_IMAGE_TAG)
+	podman tag rag-worker $(RAG_WORKER_IMAGE_REF):$(RAG_WORKER_IMAGE_TAG)
 	@$(MAKE) container-sizes
 
 # Run the import probe inside the built API image. Catches any transitive
@@ -383,9 +414,9 @@ container-sizes:
 
 # Remove locally-built rag-api / rag-worker images and dangling (<none>) images from both engines
 container-clean:
-	-docker rmi rag-api rag-worker 2>/dev/null || true
+	-docker rmi rag-api rag-worker $(RAG_API_IMAGE_REF):$(RAG_API_IMAGE_TAG) $(RAG_WORKER_IMAGE_REF):$(RAG_WORKER_IMAGE_TAG) 2>/dev/null || true
 	-docker image prune -f 2>/dev/null || true
-	-podman rmi rag-api rag-worker 2>/dev/null || true
+	-podman rmi rag-api rag-worker $(RAG_API_IMAGE_REF):$(RAG_API_IMAGE_TAG) $(RAG_WORKER_IMAGE_REF):$(RAG_WORKER_IMAGE_TAG) 2>/dev/null || true
 	-podman image prune -f 2>/dev/null || true
 
 # Run the full integration smoke test (build + stack + cloudflare tunnel + checks + teardown).

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The fastest path from clone to working query is **7 steps**. Containers-only use
 | **Containers-only** (fastest start) | Just trying it out, or running without modifying Python/TS code | Docker only — `rag-api` / `rag-worker` pull from `ghcr.io/juansync7/ragweave-{api,worker}:latest` |
 | **Local dev** (this guide) | Iterating on Python or TypeScript code | All prerequisites above |
 
-For containers-only, jump to [Step 5](#step-5--start-the-stack) after copying `.env`. To rebuild app images locally instead of pulling: `./scripts/compose.sh build rag-api rag-worker`. Pin to a specific image tag via `RAG_API_IMAGE_TAG` / `RAG_WORKER_IMAGE_TAG` in `.env`.
+For containers-only, jump to [Step 5](#step-5--start-the-stack) after copying `.env`. To rebuild app images locally instead of pulling: `make container-build` (writes `:dev`; see [Image tags: `:latest` vs `:dev`](#image-tags-latest-vs-dev)). Pin to a specific image tag via `RAG_API_IMAGE_TAG` / `RAG_WORKER_IMAGE_TAG` in `.env`.
 
 ### Step 1 — Clone & copy environment
 
@@ -322,6 +322,26 @@ DOCKER_BUILDKIT=1 docker build -t rag-worker -f containers/Dockerfile.runtime .
 ```
 
 Multi-stage builds, BuildKit pip-cache mounts, `.dockerignore`, compose-level healthchecks (podman-friendly), `PYTHONPATH=/app` (no `pip install .`), GPU support in the worker — see [`docs/operations/DOCKER_OPTIMIZATION.md`](docs/operations/DOCKER_OPTIMIZATION.md) for the full design.
+
+### Image tags: `:latest` vs `:dev`
+
+`docker-compose.yml` reads `${RAG_{API,WORKER}_IMAGE_REF:-ghcr.io/juansync7/ragweave-{api,worker}}:${RAG_{API,WORKER}_IMAGE_TAG:-latest}`. The Makefile mirrors local builds to the same ref so `compose up` finds your build instead of pulling from GHCR.
+
+Two audiences, two tags:
+
+| You are… | What you want | What to set in `.env` | What runs |
+|---|---|---|---|
+| Fresh-cloning the repo | Whatever CI last published from `main` | _nothing_ (defaults apply) | `docker compose up` pulls `:latest` from GHCR |
+| Hacking locally on a branch | Your freshly-built image, never clobbered by CI's `:latest` | `RAG_API_IMAGE_TAG=dev`<br>`RAG_WORKER_IMAGE_TAG=dev` | `make container-build` writes `:dev`, compose reads `:dev` |
+| CI / prod deploy | Reproducible build | `RAG_*_IMAGE_TAG=<sha-or-version>` | Compose reads the pinned tag |
+
+**Why `:dev` and not just `:latest` everywhere?** A local rebuild and CI's published image share the name `ghcr.io/juansync7/ragweave-worker:latest` but live in different image stores (your laptop vs the GHCR registry). If anything triggers a registry pull (`docker compose pull`, `pull_policy: always`, a teammate running `docker pull`), the registry version overwrites your local build. The `:dev` tag isolates local work from that race — CI never publishes `:dev`, so it can't be clobbered.
+
+Tags are parameterized via Makefile vars (`RAG_API_IMAGE_REF`, `RAG_API_IMAGE_TAG`, `RAG_WORKER_IMAGE_REF`, `RAG_WORKER_IMAGE_TAG`) — override per invocation:
+
+```bash
+make container-build-worker RAG_WORKER_IMAGE_REF=myorg/ragweave-worker RAG_WORKER_IMAGE_TAG=staging
+```
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
 
   rag-api:
     profiles: ["app"]
-    image: ghcr.io/juansync7/ragweave-api:${RAG_API_IMAGE_TAG:-latest}
+    image: ${RAG_API_IMAGE_REF:-ghcr.io/juansync7/ragweave-api}:${RAG_API_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: containers/Dockerfile.api
@@ -189,7 +189,7 @@ services:
 
   rag-worker:
     profiles: ["workers"]
-    image: ghcr.io/juansync7/ragweave-worker:${RAG_WORKER_IMAGE_TAG:-latest}
+    image: ${RAG_WORKER_IMAGE_REF:-ghcr.io/juansync7/ragweave-worker}:${RAG_WORKER_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: containers/Dockerfile.runtime


### PR DESCRIPTION
## Summary

- Local Makefile builds previously tagged only `rag-{api,worker}:latest`, while compose pinned `ghcr.io/juansync7/ragweave-{api,worker}:latest` — two different image names, so fresh builds didn't take effect on `compose up` (compose kept running the stale GHCR-pulled image).
- Fix the naming mismatch and split local `:dev` from registry `:latest` so a `docker compose pull` (or CI publishing a new `:latest`) can never clobber a local build.
- Parameterize image refs/tags in both Makefile and `docker-compose.yml` so org/registry can be overridden without forking the file.

## Changes

- **Makefile**: `container-build-{api,worker}` and `container-build-podman` now also `docker tag` the freshly built image to `${RAG_*_IMAGE_REF}:${RAG_*_IMAGE_TAG}` (defaults `ghcr.io/juansync7/ragweave-*:dev`). `container-clean` removes the GHCR-tagged copies too.
- **docker-compose.yml**: app/worker `image:` lines now read `${RAG_*_IMAGE_REF:-ghcr.io/juansync7/ragweave-*}:${RAG_*_IMAGE_TAG:-latest}`.
- **.env.example**: documents `:latest` (CI/fresh-clone) vs `:dev` (local dev) split. Lines kept commented so fresh clones still pull `:latest` by default.
- **README.md**: new "Image tags: `:latest` vs `:dev`" subsection under Container Images explaining the three audiences (fresh clone, local dev, CI/prod) and override vars.

## Test plan

- [ ] Fresh clone with default `.env.example` → `docker compose up` pulls `:latest` from GHCR (unchanged behavior)
- [ ] `RAG_*_IMAGE_TAG=dev` in `.env` + `make container-build` → compose runs the freshly built image, no GHCR round-trip
- [ ] `make container-clean` removes both `rag-worker` and `ghcr.io/juansync7/ragweave-worker:dev`
- [ ] `make container-build-worker RAG_WORKER_IMAGE_TAG=staging` writes `:staging` instead of `:dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)