### PR TITLE
fix(ingest): wire HuggingFaceTokenizer + bump chunker token budget

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -72,8 +72,16 @@ SEARCH_LIMIT = 10
 RERANK_TOP_K = 5
 
 # --- Document Processing ---
-CHUNK_SIZE = 512
-CHUNK_OVERLAP = 50
+# CHUNK_SIZE / CHUNK_OVERLAP apply to the **LangChain fallback** chunker
+# (RecursiveCharacterTextSplitter). They are CHARACTER counts, not token
+# counts. Kept roughly equivalent in tokens to the Docling HybridChunker
+# default RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS=1024 at ~3.5 chars/token
+# for English (BGE-M3 tokenizer). If you change one, check the other.
+# Docling's HybridChunker has no overlap parameter — it splits at structural
+# boundaries and uses heading breadcrumbs to bridge context, so overlap only
+# matters for the char-window fallback path.
+CHUNK_SIZE = 3500
+CHUNK_OVERLAP = 350
 
 # --- Query Processing (LangGraph) ---
 QUERY_CONFIDENCE_THRESHOLD = float(
@@ -439,9 +447,16 @@ Valid values: "disabled", "builtin", "external".
 """
 
 RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS: int = int(
-    os.environ.get("RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS", "512")
+    os.environ.get("RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS", "1024")
 )
-"""Maximum token count per chunk for HybridChunker (bge-m3 limit is 512)."""
+"""Maximum token count per chunk for HybridChunker.
+
+Default 1024 — empirical sweet spot for technical-doc retrieval. BGE-M3
+itself accepts inputs up to 8192 tokens, but past ~1500–2000 the embedding
+loses specificity (a single dense vector covers too many subtopics) and
+single-sentence chunks (under ~50 tokens) lack contextual grounding.
+1024 keeps natural section units whole while staying comfortably below
+the dilution threshold."""
 
 RAG_INGESTION_PERSIST_DOCLING_DOCUMENT: bool = os.environ.get(
     "RAG_INGESTION_PERSIST_DOCLING_DOCUMENT", "true"

--- a/src/ingest/common/types.py
+++ b/src/ingest/common/types.py
@@ -167,6 +167,13 @@ class IngestionConfig:
     """VLM mode: "disabled" | "builtin" | "external". Default: "disabled"."""
     hybrid_chunker_max_tokens: int = RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS
     """Max tokens per HybridChunker chunk. Default: 512 (bge-m3 limit)."""
+    hybrid_chunker_tokenizer_model: str | None = None
+    """HF tokenizer repo id (or local path) used by HybridChunker for token
+    counting. When None (default), the chunker resolves the tokenizer from
+    ``EMBEDDING_MODEL_PATH`` so token counts match what the embedder will
+    actually consume. Final fallback is ``BAAI/bge-m3``. Env-driven override
+    is intentionally not wired — set this on IngestionConfig directly when a
+    different tokenizer is desired."""
     persist_docling_document: bool = RAG_INGESTION_PERSIST_DOCLING_DOCUMENT
     """If True, persist DoclingDocument JSON to CleanDocumentStore. Default: True."""
     use_docling_chunker_for_markdown: bool = RAG_INGESTION_USE_DOCLING_CHUNKER_FOR_MARKDOWN

--- a/src/ingest/impl.py
+++ b/src/ingest/impl.py
@@ -4,7 +4,7 @@
 # Deps: src.vector_db, src.core.embeddings, src.ingest.embedding,
 #       src.ingest.doc_processing, src.ingest.support.parser_registry
 # verify_core_design calls _check_docling_chunking_config (Task 4.2) which validates
-#   vlm_mode values, builtin-requires-docling, and hybrid_chunker_max_tokens > 512 limit.
+#   vlm_mode values, builtin-requires-docling, and hybrid_chunker_max_tokens > 8192 limit.
 # verify_core_design also calls _check_visual_embedding_config (Task 1.1) which validates
 #   enable_visual_embedding requires enable_docling_parser, colqwen_batch_size 1-32,
 #   page_image_quality 1-100, and page_image_max_dimension 256-4096.
@@ -271,7 +271,7 @@ def _check_docling_chunking_config(
     Checks three contradiction patterns:
     1. vlm_mode=builtin without docling installed → fatal error
     2. vlm_mode=external without LiteLLM vision model configured → warning
-    3. hybrid_chunker_max_tokens > 512 (bge-m3 limit) → warning
+    3. hybrid_chunker_max_tokens > 8192 (bge-m3 limit) → warning
 
     Args:
         config: IngestionConfig to validate.
@@ -308,12 +308,14 @@ def _check_docling_chunking_config(
                 " VLM enrichment will be skipped at runtime"
             )
 
-    # Rule C: hybrid_chunker_max_tokens exceeds bge-m3 maximum input.
-    if config.hybrid_chunker_max_tokens > 512:
+    # Rule C: hybrid_chunker_max_tokens exceeds bge-m3 maximum input (8192).
+    # BGE-M3 supports up to 8192 tokens. Past ~1500–2000 the embedding loses
+    # specificity, but truncation only kicks in above 8192.
+    if config.hybrid_chunker_max_tokens > 8192:
         warnings.append(
             f"hybrid_chunker_max_tokens ({config.hybrid_chunker_max_tokens})"
-            " exceeds bge-m3 maximum input (512);"
-            " chunks may be silently truncated during embedding"
+            " exceeds bge-m3 maximum input (8192);"
+            " chunks will be silently truncated during embedding"
         )
 
     return errors, warnings

--- a/src/ingest/support/docling.py
+++ b/src/ingest/support/docling.py
@@ -21,7 +21,75 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+try:
+    from config.settings import EMBEDDING_MODEL_PATH
+except Exception:  # pragma: no cover — defensive; settings should always import
+    EMBEDDING_MODEL_PATH = ""
+
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# HybridChunker tokenizer resolution + module-level cache
+# ---------------------------------------------------------------------------
+
+_TOKENIZER_CACHE: dict[tuple[str, int], Any] = {}
+
+
+def _resolve_tokenizer_model_id(config: Any) -> str:
+    """Resolve which HF tokenizer model id to use for HybridChunker.
+
+    Resolution order:
+      1. ``config.hybrid_chunker_tokenizer_model`` if non-empty.
+      2. ``EMBEDDING_MODEL_PATH`` (the embedder repo / local path) if non-empty,
+         so token counts match the embedding model.
+      3. Hardcoded final fallback ``"BAAI/bge-m3"``.
+    """
+    cfg_model = getattr(config, "hybrid_chunker_tokenizer_model", None) if config is not None else None
+    if cfg_model:
+        return cfg_model
+    if EMBEDDING_MODEL_PATH:
+        return EMBEDDING_MODEL_PATH
+    return "BAAI/bge-m3"
+
+
+def _build_hf_tokenizer(model_id: str, max_tokens: int) -> Any:
+    """Build a docling-core HuggingFaceTokenizer for ``model_id``.
+
+    Isolated for monkeypatching in tests. Raises any underlying exception so the
+    caller (``_get_or_build_tokenizer``) can decide on fallback behavior.
+    """
+    from docling_core.transforms.chunker.tokenizer.huggingface import (
+        HuggingFaceTokenizer,
+    )
+    from transformers import AutoTokenizer
+
+    return HuggingFaceTokenizer(
+        tokenizer=AutoTokenizer.from_pretrained(model_id),
+        max_tokens=max_tokens,
+    )
+
+
+def _get_or_build_tokenizer(model_id: str, *, max_tokens: int) -> Any:
+    """Return a cached HuggingFaceTokenizer or build (and cache) a new one.
+
+    Cache key is ``(model_id, max_tokens)`` since max_tokens is baked into the
+    tokenizer instance.
+    """
+    key = (model_id, int(max_tokens))
+    cached = _TOKENIZER_CACHE.get(key)
+    if cached is not None:
+        return cached
+    tokenizer = _build_hf_tokenizer(model_id, max_tokens)
+    _TOKENIZER_CACHE[key] = tokenizer
+    # Surface the resolved tokenizer choice once per (model, max_tokens) pair —
+    # silent auto-tracking is hard to debug otherwise.
+    logger.info(
+        "HybridChunker tokenizer resolved: model_id=%s max_tokens=%d",
+        model_id,
+        max_tokens,
+    )
+    return tokenizer
 
 
 @dataclass
@@ -403,8 +471,13 @@ def chunk_markdown_via_docling(
          warning (alt text preserved). On VLM failure, alt text stands in.
       2. Build a DoclingDocument from the rewritten markdown via the MD backend
          (~0.2s, no models).
-      3. Run HybridChunker — preserves lists, tables, and requirement blocks
-         as atomic units.
+      3. Run HybridChunker with an explicit HuggingFaceTokenizer so
+         ``merge_peers=True`` consolidates sentence-per-line markdown into
+         token-budgeted chunks. The tokenizer model is resolved in this order:
+           1. ``config.hybrid_chunker_tokenizer_model`` if set.
+           2. ``EMBEDDING_MODEL_PATH`` (so the chunker's token accounting
+              matches the embedder).
+           3. Final fallback ``"BAAI/bge-m3"``.
 
     Captioning runs only when both ``source_path`` and ``config`` are provided
     AND ``config.enable_vision_processing`` is True. Without those, the function
@@ -447,7 +520,20 @@ def chunk_markdown_via_docling(
     )
     docling_document = conv_result.document
 
-    chunker = HybridChunker(max_tokens=max_tokens, merge_peers=True)
+    model_id = _resolve_tokenizer_model_id(config)
+    try:
+        tokenizer = _get_or_build_tokenizer(model_id, max_tokens=max_tokens)
+        chunker = HybridChunker(tokenizer=tokenizer, merge_peers=True)
+    except Exception as exc:  # pragma: no cover — env-dependent
+        # Tokenizer load failed (no network, model not in HF cache, etc.).
+        # Re-raise so the caller's existing fallback path
+        # (parser_text.chunk → chunk_with_markdown) can handle it.
+        logger.warning(
+            "HybridChunker tokenizer load failed for model_id=%s: %s; "
+            "caller should fall back to char-splitter chunking.",
+            model_id, exc,
+        )
+        raise
     raw_chunks = list(chunker.chunk(dl_doc=docling_document))
 
     figures_payload = figures if figures else []
@@ -643,6 +729,7 @@ class DoclingParser:
         self._docling_document: Any = None
         self._vlm_mode: str = "disabled"
         self._max_tokens: int = 512
+        self._config: Any = None
 
     def parse(self, file_path: Path, config: Any) -> "ParseResult":
         """Parse a document using Docling. FR-3221.
@@ -661,7 +748,8 @@ class DoclingParser:
         from src.ingest.support.parser_base import ParseResult
 
         self._vlm_mode = getattr(config, "vlm_mode", "disabled")
-        self._max_tokens = getattr(config, "hybrid_chunker_max_tokens", 512)
+        self._max_tokens = getattr(config, "hybrid_chunker_max_tokens", 1024)
+        self._config = config
 
         result = parse_with_docling(
             file_path,
@@ -710,10 +798,19 @@ class DoclingParser:
 
         from docling_core.transforms.chunker import HybridChunker
 
-        chunker = HybridChunker(
-            max_tokens=self._max_tokens,
-            merge_peers=True,
-        )
+        model_id = _resolve_tokenizer_model_id(getattr(self, "_config", None))
+        try:
+            tokenizer = _get_or_build_tokenizer(
+                model_id, max_tokens=self._max_tokens
+            )
+            chunker = HybridChunker(tokenizer=tokenizer, merge_peers=True)
+        except Exception as exc:  # pragma: no cover — env-dependent
+            logger.warning(
+                "HybridChunker tokenizer load failed (model_id=%s): %s; "
+                "raising for caller fallback.",
+                model_id, exc,
+            )
+            raise
         chunk_iter = chunker.chunk(dl_doc=self._docling_document)
         raw_chunks = list(chunk_iter)
 

--- a/src/ingest/support/parser_text.py
+++ b/src/ingest/support/parser_text.py
@@ -124,7 +124,7 @@ class PlainTextParser:
                 from src.ingest.support.docling import chunk_markdown_via_docling
 
                 max_tokens = getattr(
-                    self._config, "hybrid_chunker_max_tokens", 512
+                    self._config, "hybrid_chunker_max_tokens", 1024
                 )
                 return chunk_markdown_via_docling(
                     parse_result.markdown,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,18 @@ import types
 
 
 def _install_stub_modules() -> None:
+    # Prefer real heavyweight ML deps when present (Docling's HybridChunker
+    # tokenizer wrapper transitively needs real torch + transformers; without
+    # them, integration tests can't run). Import order matters: torch must be
+    # real before transformers tries to detect it. If any fail, fall through
+    # to per-module stubs below.
+    for _real_mod in ("torch", "transformers", "sentence_transformers"):
+        if _real_mod not in sys.modules:
+            try:
+                __import__(_real_mod)
+            except Exception:
+                pass
+
     if "sentence_transformers" not in sys.modules:
         st = types.ModuleType("sentence_transformers")
 
@@ -237,29 +249,40 @@ def _install_stub_modules() -> None:
         sys.modules["minio.commonconfig"] = minio_commonconfig
 
     if "PIL" not in sys.modules:
-        pil = types.ModuleType("PIL")
-        pil_image = types.ModuleType("PIL.Image")
+        # Prefer the real Pillow when available — Docling's chunker/converter
+        # needs PIL.ImageColor / ImageDraw / ImageFont, which a hand-rolled
+        # stub does not provide. Real PIL is a transitive dep of Pillow,
+        # which the project already requires, so this should normally succeed.
+        try:
+            import PIL  # noqa: F401
+            import PIL.Image  # noqa: F401
+            import PIL.ImageColor  # noqa: F401
+            import PIL.ImageDraw  # noqa: F401
+            import PIL.ImageFont  # noqa: F401
+        except ImportError:
+            pil = types.ModuleType("PIL")
+            pil_image = types.ModuleType("PIL.Image")
 
-        class Image:
-            size = (0, 0)
+            class Image:
+                size = (0, 0)
 
-            @staticmethod
-            def open(*args, **kwargs):
-                return Image()
+                @staticmethod
+                def open(*args, **kwargs):
+                    return Image()
 
-            def convert(self, mode):
-                return self
+                def convert(self, mode):
+                    return self
 
-            def tobytes(self):
-                return b""
+                def tobytes(self):
+                    return b""
 
-        # `from PIL import Image` resolves to the PIL.Image module; callers
-        # then call Image.open(...) at module level, not on the class.
-        pil_image.Image = Image
-        pil_image.open = Image.open
-        pil.Image = pil_image
-        sys.modules["PIL"] = pil
-        sys.modules["PIL.Image"] = pil_image
+            # `from PIL import Image` resolves to the PIL.Image module; callers
+            # then call Image.open(...) at module level, not on the class.
+            pil_image.Image = Image
+            pil_image.open = Image.open
+            pil.Image = pil_image
+            sys.modules["PIL"] = pil
+            sys.modules["PIL.Image"] = pil_image
 
     # Only stub temporalio when the real package can't be imported. Tests that
     # exercise sandbox/workflow code (e.g. test_temporal_worker.py) need the
@@ -551,43 +574,50 @@ def _install_stub_modules() -> None:
         sys.modules["bitsandbytes"] = bnb
 
     if "PIL" not in sys.modules:
-        pil = types.ModuleType("PIL")
-        pil_image = types.ModuleType("PIL.Image")
+        try:
+            import PIL  # noqa: F401
+            import PIL.Image  # noqa: F401
+            import PIL.ImageColor  # noqa: F401
+            import PIL.ImageDraw  # noqa: F401
+            import PIL.ImageFont  # noqa: F401
+        except ImportError:
+            pil = types.ModuleType("PIL")
+            pil_image = types.ModuleType("PIL.Image")
 
-        class Image:
-            """Minimal PIL.Image stub."""
+            class Image:
+                """Minimal PIL.Image stub."""
 
-            LANCZOS = 1
+                LANCZOS = 1
 
-            @staticmethod
-            def open(*args, **kwargs):
-                return Image()
+                @staticmethod
+                def open(*args, **kwargs):
+                    return Image()
 
-            @staticmethod
-            def new(*args, **kwargs):
-                return Image()
+                @staticmethod
+                def new(*args, **kwargs):
+                    return Image()
 
-            def convert(self, *args, **kwargs):
-                return self
+                def convert(self, *args, **kwargs):
+                    return self
 
-            def resize(self, *args, **kwargs):
-                return self
+                def resize(self, *args, **kwargs):
+                    return self
 
-            def save(self, *args, **kwargs):
-                pass
+                def save(self, *args, **kwargs):
+                    pass
 
-            def tobytes(self, *args, **kwargs):
-                return b""
+                def tobytes(self, *args, **kwargs):
+                    return b""
 
-            @property
-            def size(self):
-                return (100, 100)
+                @property
+                def size(self):
+                    return (100, 100)
 
-        pil_image.Image = Image
-        pil_image.LANCZOS = Image.LANCZOS
-        pil.Image = pil_image
-        sys.modules["PIL"] = pil
-        sys.modules["PIL.Image"] = pil_image
+            pil_image.Image = Image
+            pil_image.LANCZOS = Image.LANCZOS
+            pil.Image = pil_image
+            sys.modules["PIL"] = pil
+            sys.modules["PIL.Image"] = pil_image
 
     if "prometheus_client" not in sys.modules:
         # Prefer the real prometheus_client when installed (see comment above).

--- a/tests/ingest/conftest.py
+++ b/tests/ingest/conftest.py
@@ -24,6 +24,29 @@ try:
 except ImportError:
     pass  # datasketch not installed — minhash tests will be skipped by the engine
 
+# Pre-import the real docling / docling_core / transformers / tree_sitter
+# submodules our integration tests touch. Other ingest tests context-manage
+# MagicMock entries into ``sys.modules`` for these and restore via ``pop``,
+# which can leave a partial module in Python's import state. Pre-importing
+# now locks real, complete modules into ``sys.modules`` before stubs can
+# overwrite them, and survives the pop/restore dance because the saved
+# "original" they restore is the real module we cached here.
+for _real_mod in (
+    "docling",
+    "docling.datamodel.base_models",
+    "docling.document_converter",
+    "docling_core",
+    "docling_core.types.doc",
+    "docling_core.transforms.chunker",
+    "docling_core.transforms.chunker.tokenizer.huggingface",
+    "transformers",
+    "tree_sitter",
+):
+    try:
+        __import__(_real_mod)
+    except Exception:
+        pass
+
 
 def _install_ingest_stubs() -> None:
     """Install lightweight stubs for optional dependencies that are not installed."""

--- a/tests/ingest/test_docling_chunking_config.py
+++ b/tests/ingest/test_docling_chunking_config.py
@@ -48,10 +48,10 @@ class TestSettingsDefaults:
         s = _reload_settings()
         assert s.RAG_INGESTION_VLM_MODE == "disabled"
 
-    def test_hybrid_chunker_max_tokens_default_is_512(self, monkeypatch):
+    def test_hybrid_chunker_max_tokens_default_is_1024(self, monkeypatch):
         monkeypatch.delenv("RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS", raising=False)
         s = _reload_settings()
-        assert s.RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS == 512
+        assert s.RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS == 1024
 
     def test_hybrid_chunker_max_tokens_default_is_int(self, monkeypatch):
         monkeypatch.delenv("RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS", raising=False)
@@ -75,7 +75,7 @@ class TestSettingsDefaults:
         monkeypatch.delenv("RAG_INGESTION_PERSIST_DOCLING_DOCUMENT", raising=False)
         s = _reload_settings()
         assert s.RAG_INGESTION_VLM_MODE == "disabled"
-        assert s.RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS == 512
+        assert s.RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS == 1024
         assert s.RAG_INGESTION_PERSIST_DOCLING_DOCUMENT is True
 
 
@@ -201,9 +201,9 @@ class TestIngestionConfigNewFieldDefaults:
         cfg = IngestionConfig()
         assert cfg.vlm_mode == "disabled"
 
-    def test_default_hybrid_chunker_max_tokens_is_512(self):
+    def test_default_hybrid_chunker_max_tokens_is_1024(self):
         cfg = IngestionConfig()
-        assert cfg.hybrid_chunker_max_tokens == 512
+        assert cfg.hybrid_chunker_max_tokens == 1024
 
     def test_default_persist_docling_document_is_true(self):
         cfg = IngestionConfig()

--- a/tests/ingest/test_docling_chunking_tokenizer.py
+++ b/tests/ingest/test_docling_chunking_tokenizer.py
@@ -1,0 +1,182 @@
+"""Tests for tokenizer wiring in chunk_markdown_via_docling.
+
+Verifies:
+  1. Sentence-per-line markdown (OpenTitan-style) is consolidated by HybridChunker
+     when a tokenizer is supplied (regression: bare HybridChunker invocation
+     without a tokenizer produces one chunk per source line).
+  2. The hybrid_chunker_tokenizer_model config knob is respected when set.
+  3. When the knob is None, the embedding-model config (EMBEDDING_MODEL_PATH)
+     is used as the tokenizer source.
+"""
+from __future__ import annotations
+
+# Eagerly import PIL submodules so root conftest doesn't replace them with a
+# stub before docling-core's page module imports them.
+try:
+    import PIL  # noqa: F401
+    import PIL.Image  # noqa: F401
+    import PIL.ImageColor  # noqa: F401
+    import PIL.ImageDraw  # noqa: F401
+    import PIL.ImageFont  # noqa: F401
+except ImportError:
+    pass
+
+from dataclasses import dataclass
+
+import pytest
+
+
+AES_MARKDOWN = """##### AES
+
+AES is the primary symmetric encryption and decryption mechanism used in OpenTitan protocols.
+AES runs with key sizes of 128b, 192b, or 256b.
+The module can select encryption or decryption of data that arrives in 16 byte quantities to be encrypted or decrypted using different block cipher modes of operation.
+It supports ECB mode, CBC mode, CFB mode, OFB mode and CTR mode.
+
+The GCM mode is not implemented in hardware, but can be constructed using AES in counter mode.
+The integrity tag calculation can be implemented in Ibex and accelerated via bitmanip instructions.
+"""
+
+
+@dataclass
+class _FakeIngestionConfig:
+    """Minimal stand-in for IngestionConfig (avoids import-time settings cost)."""
+    enable_vision_processing: bool = False
+    hybrid_chunker_max_tokens: int = 512
+    hybrid_chunker_tokenizer_model: str | None = None
+
+
+@pytest.fixture(autouse=True)
+def _clear_tokenizer_cache():
+    """Ensure each test starts with a clean tokenizer cache."""
+    from src.ingest.support import docling as docling_mod
+    cache = getattr(docling_mod, "_TOKENIZER_CACHE", None)
+    if cache is not None:
+        cache.clear()
+    yield
+    if cache is not None:
+        cache.clear()
+
+
+def test_aes_section_consolidates_to_few_chunks():
+    """Sentence-per-line AES section should produce <=2 chunks, not 6+.
+
+    This is the primary regression test for the bug where HybridChunker was
+    invoked without a tokenizer, defeating merge_peers.
+    """
+    pytest.importorskip("transformers")
+    pytest.importorskip("docling")
+    pytest.importorskip("docling_core")
+    # The root conftest stubs PIL when it isn't already in sys.modules. Real
+    # docling's page module imports PIL.ImageColor, which the stub doesn't
+    # provide. Skip this integration test in that environment — the unit
+    # tests below cover the resolution logic without invoking real docling.
+    try:
+        from PIL import ImageColor as _IC  # noqa: F401
+    except ImportError:
+        pytest.skip("real PIL.ImageColor not available (PIL is stubbed)")
+
+    # Other ingest tests context-manage MagicMock submodules into
+    # ``sys.modules`` (e.g. ``docling.datamodel.base_models``) and restore by
+    # popping them in ``finally``. Once popped, Python's import system
+    # remembers their absence in some cases — re-importing the real submodule
+    # then yields a partial module without DocumentStream / InputFormat.
+    # Force a clean re-import by purging any docling-related sys.modules
+    # entries before this integration test runs.
+    import sys as _sys
+    for _mod in list(_sys.modules):
+        if (
+            _mod == "docling"
+            or _mod.startswith("docling.")
+            or _mod == "docling_core"
+            or _mod.startswith("docling_core.")
+        ):
+            _sys.modules.pop(_mod, None)
+
+    from src.ingest.support.docling import chunk_markdown_via_docling
+
+    chunks = chunk_markdown_via_docling(
+        AES_MARKDOWN,
+        max_tokens=512,
+        config=_FakeIngestionConfig(
+            hybrid_chunker_tokenizer_model="BAAI/bge-m3",
+        ),
+    )
+
+    assert len(chunks) >= 1, "expected at least one chunk"
+    assert len(chunks) <= 2, (
+        f"AES section should consolidate to <=2 chunks, got {len(chunks)}: "
+        f"{[c.text[:60] for c in chunks]}"
+    )
+
+    combined = " ".join(c.text for c in chunks)
+    for phrase in [
+        "primary symmetric encryption",
+        "128b, 192b, or 256b",
+        "ECB mode",
+        "GCM mode",
+        "Ibex",
+    ]:
+        assert phrase in combined, f"missing phrase: {phrase!r}"
+
+    # Heading metadata: each chunk should carry "AES" in its heading path.
+    for c in chunks:
+        path = (c.section_path or "") + " " + (c.heading or "")
+        assert "AES" in path, f"AES not in heading metadata for chunk: {c!r}"
+
+
+def test_config_tokenizer_model_is_used(monkeypatch):
+    """hybrid_chunker_tokenizer_model wins over embedding model fallback."""
+    from src.ingest.support import docling as docling_mod
+
+    seen: dict = {}
+
+    class _DummyTokenizer:
+        def __init__(self, model_id, max_tokens):
+            seen["model_id"] = model_id
+            seen["max_tokens"] = max_tokens
+
+    def _fake_build(model_id, max_tokens):
+        return _DummyTokenizer(model_id, max_tokens)
+
+    monkeypatch.setattr(docling_mod, "_build_hf_tokenizer", _fake_build)
+
+    config = _FakeIngestionConfig(
+        hybrid_chunker_tokenizer_model="BAAI/bge-small-en-v1.5",
+    )
+    resolved = docling_mod._resolve_tokenizer_model_id(config)
+    assert resolved == "BAAI/bge-small-en-v1.5"
+
+    tok = docling_mod._get_or_build_tokenizer(resolved, max_tokens=256)
+    assert seen["model_id"] == "BAAI/bge-small-en-v1.5"
+    assert seen["max_tokens"] == 256
+    # Cache hit on second call.
+    tok2 = docling_mod._get_or_build_tokenizer(resolved, max_tokens=256)
+    assert tok is tok2
+
+
+def test_falls_back_to_embedding_model(monkeypatch):
+    """When hybrid_chunker_tokenizer_model is None, EMBEDDING_MODEL_PATH is used."""
+    from src.ingest.support import docling as docling_mod
+
+    monkeypatch.setattr(
+        docling_mod,
+        "EMBEDDING_MODEL_PATH",
+        "BAAI/bge-small-en-v1.5",
+        raising=False,
+    )
+
+    config = _FakeIngestionConfig(hybrid_chunker_tokenizer_model=None)
+    resolved = docling_mod._resolve_tokenizer_model_id(config)
+    assert resolved == "BAAI/bge-small-en-v1.5"
+
+
+def test_final_fallback_to_bge_m3(monkeypatch):
+    """No config + no embedding model -> 'BAAI/bge-m3' fallback."""
+    from src.ingest.support import docling as docling_mod
+
+    monkeypatch.setattr(docling_mod, "EMBEDDING_MODEL_PATH", "", raising=False)
+
+    config = _FakeIngestionConfig(hybrid_chunker_tokenizer_model=None)
+    resolved = docling_mod._resolve_tokenizer_model_id(config)
+    assert resolved == "BAAI/bge-m3"

--- a/tests/ingest/test_docling_chunking_vlm_and_validation.py
+++ b/tests/ingest/test_docling_chunking_vlm_and_validation.py
@@ -716,38 +716,38 @@ class TestCheckDoclingChunkingConfigWarnings:
         combined = " ".join(warnings)
         assert "skip" in combined.lower() or "skipped" in combined.lower()
 
-    def test_max_tokens_above_512_produces_warning(self):
-        """hybrid_chunker_max_tokens=1024: warning contains 'hybrid_chunker_max_tokens'."""
+    def test_max_tokens_above_8192_produces_warning(self):
+        """hybrid_chunker_max_tokens=9000: warning contains 'hybrid_chunker_max_tokens'."""
         from src.ingest.impl import _check_docling_chunking_config
 
-        config = IngestionConfig(vlm_mode="disabled", hybrid_chunker_max_tokens=1024)
+        config = IngestionConfig(vlm_mode="disabled", hybrid_chunker_max_tokens=9000)
         _, warnings = _check_docling_chunking_config(config)
         assert len(warnings) > 0
         combined = " ".join(warnings)
         assert "hybrid_chunker_max_tokens" in combined
 
-    def test_max_tokens_warning_mentions_512(self):
-        """Warning for max_tokens > 512 references the 512 limit."""
+    def test_max_tokens_warning_mentions_8192(self):
+        """Warning for max_tokens > 8192 references the 8192 limit."""
         from src.ingest.impl import _check_docling_chunking_config
 
-        config = IngestionConfig(vlm_mode="disabled", hybrid_chunker_max_tokens=1024)
+        config = IngestionConfig(vlm_mode="disabled", hybrid_chunker_max_tokens=9000)
         _, warnings = _check_docling_chunking_config(config)
         combined = " ".join(warnings)
-        assert "512" in combined
+        assert "8192" in combined
 
-    def test_max_tokens_at_513_produces_warning(self):
-        """hybrid_chunker_max_tokens=513: exactly one step above limit triggers warning."""
+    def test_max_tokens_at_8193_produces_warning(self):
+        """hybrid_chunker_max_tokens=8193: exactly one step above limit triggers warning."""
         from src.ingest.impl import _check_docling_chunking_config
 
-        config = IngestionConfig(vlm_mode="disabled", hybrid_chunker_max_tokens=513)
+        config = IngestionConfig(vlm_mode="disabled", hybrid_chunker_max_tokens=8193)
         _, warnings = _check_docling_chunking_config(config)
         assert any("hybrid_chunker_max_tokens" in w for w in warnings)
 
     def test_max_tokens_warning_is_not_an_error(self):
-        """hybrid_chunker_max_tokens > 512 is a warning only, not an error."""
+        """hybrid_chunker_max_tokens > 8192 is a warning only, not an error."""
         from src.ingest.impl import _check_docling_chunking_config
 
-        config = IngestionConfig(vlm_mode="disabled", hybrid_chunker_max_tokens=1024)
+        config = IngestionConfig(vlm_mode="disabled", hybrid_chunker_max_tokens=9000)
         errors, _ = _check_docling_chunking_config(config)
         assert not any("hybrid_chunker_max_tokens" in e for e in errors)
 
@@ -780,7 +780,7 @@ class TestCheckDoclingChunkingConfigBoundary:
         # Rule A (builtin-requires-docling) should NOT also fire since the vlm_mode
         # string "BUILTIN" != "builtin". But if we use "builtin" with no docling,
         # Rule 0 passes and Rule A fires. Combine: invalid mode + max_tokens:
-        config = IngestionConfig(vlm_mode="wrong_mode", hybrid_chunker_max_tokens=1024)
+        config = IngestionConfig(vlm_mode="wrong_mode", hybrid_chunker_max_tokens=9000)
         errors, warnings = _check_docling_chunking_config(config)
         # At minimum: one error (invalid mode).
         assert len(errors) >= 1
@@ -859,7 +859,7 @@ class TestVerifyCoreDesignDoclingChecks:
 
         config = IngestionConfig(
             vlm_mode="disabled",
-            hybrid_chunker_max_tokens=1024,
+            hybrid_chunker_max_tokens=9000,
             chunk_size=512,
             chunk_overlap=50,
         )

--- a/tests/ingest/test_docling_support.py
+++ b/tests/ingest/test_docling_support.py
@@ -589,13 +589,17 @@ class TestDoclingParser:
         mock_docling_core = MagicMock()
         mock_docling_core.transforms.chunker.HybridChunker = mock_hybrid_chunker_cls
 
+        from src.ingest.support import docling as _docling_mod
+
         with patch.dict("sys.modules", {
             "docling_core": mock_docling_core,
             "docling_core.transforms": mock_docling_core.transforms,
             "docling_core.transforms.chunker": MagicMock(
                 HybridChunker=mock_hybrid_chunker_cls
             ),
-        }):
+        }), patch.object(
+            _docling_mod, "_get_or_build_tokenizer", return_value=MagicMock()
+        ):
             parser = DoclingParser()
             parser._docling_document = mock_doc
             parser._max_tokens = 512
@@ -633,11 +637,15 @@ class TestDoclingParser:
 
         mock_hybrid_chunker_cls = MagicMock(return_value=mock_chunker)
 
+        from src.ingest.support import docling as _docling_mod
+
         with patch.dict("sys.modules", {
             "docling_core.transforms.chunker": MagicMock(
                 HybridChunker=mock_hybrid_chunker_cls
             ),
-        }):
+        }), patch.object(
+            _docling_mod, "_get_or_build_tokenizer", return_value=MagicMock()
+        ):
             parser = DoclingParser()
             parser._docling_document = mock_doc
             parser._max_tokens = 512
@@ -671,11 +679,15 @@ class TestDoclingParser:
 
         mock_hybrid_chunker_cls = MagicMock(return_value=mock_chunker)
 
+        from src.ingest.support import docling as _docling_mod
+
         with patch.dict("sys.modules", {
             "docling_core.transforms.chunker": MagicMock(
                 HybridChunker=mock_hybrid_chunker_cls
             ),
-        }):
+        }), patch.object(
+            _docling_mod, "_get_or_build_tokenizer", return_value=MagicMock()
+        ):
             parser = DoclingParser()
             parser._docling_document = mock_doc
             parser._max_tokens = 512


### PR DESCRIPTION
## Summary

- **Tokenizer wiring**: `HybridChunker` was being constructed without an explicit tokenizer, so it silently fell back to a default that didn't match the embedding model (BGE-M3). Result: AES-style chunks were collapsing to single sentences.
- **Token-budget bump**: Default `hybrid_chunker_max_tokens` 512 → 1024; `CHUNK_SIZE` 512 → 3500 chars; `CHUNK_OVERLAP` 50 → 350 chars. BGE-M3 actually accepts 8192 tokens, so the 512 default was leaving ~16x headroom on the table. Rule C warning threshold raised from 512 → 8192 to match.

## Changes

- `src/ingest/support/docling.py` — `_resolve_tokenizer_model_id()` / `_build_hf_tokenizer()` / `_get_or_build_tokenizer()`; module-level cache; resolution order: `config.hybrid_chunker_tokenizer_model` → `EMBEDDING_MODEL_PATH` → `BAAI/bge-m3`. `HybridChunker(tokenizer=hf_tok, merge_peers=True)`.
- `src/ingest/common/types.py` — adds `hybrid_chunker_tokenizer_model: str | None = None` config field.
- `config/settings.py` — token-budget bumps with comments on the char-vs-token ratio for BGE-M3.
- `src/ingest/impl.py` — Rule C warning threshold 512 → 8192.
- `src/ingest/support/parser_text.py` — inline fallback default 512 → 1024.
- `tests/conftest.py` — try-real-import-first for `torch`/`transformers`/`sentence_transformers`/`PIL` so integration tests aren't silently masked by stubs.
- `tests/ingest/conftest.py` — pre-imports real docling/docling_core submodules at session start to avoid MagicMock-pop-on-finally leaving partial modules.
- `tests/ingest/test_docling_chunking_tokenizer.py` (NEW) — 4 tests covering AES regression, config wiring, embedding-model fallback, BGE-M3 final fallback.
- `tests/ingest/test_docling_chunking_config.py`, `tests/ingest/test_docling_chunking_vlm_and_validation.py` — assertions updated for new defaults (1024 max_tokens, 8192 warning threshold).

## Test plan

- [x] `pytest tests/ingest/` passes locally with real docling/torch/transformers
- [x] AES regression test produces 1 chunk containing all expected phrases with correct heading metadata
- [x] Worker rebuilt and end-to-end ingest verified — chunks no longer collapse to single sentences

🤖 Generated with [Claude Code](https://claude.com/claude-code)