### PR TITLE
fix(console): scroll on .message-thread instead of .chat-body

### DIFF
--- a/server/console/static/user/styles.css
+++ b/server/console/static/user/styles.css
@@ -299,13 +299,15 @@
     }
 
     /* ── Message Thread ── */
-    /* Note: overflow lives on .chat-body so the scrollbar lands at the
-       page's rightmost edge (past the chat rail). */
     .message-thread {
-      flex: 1; padding: 24px max(16px, calc((100% - 820px) / 2));
+      flex: 1; min-height: 0; overflow-y: auto;
+      padding: 24px max(16px, calc((100% - 820px) / 2));
       display: flex; flex-direction: column; gap: 4px;
       width: 100%;
     }
+    .message-thread::-webkit-scrollbar { width: 8px; }
+    .message-thread::-webkit-scrollbar-track { background: transparent; }
+    .message-thread::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
 
     .scroll-fab {
       position: absolute; right: 20px; bottom: 116px;
@@ -1182,14 +1184,11 @@
        input-bar are position: sticky so they stay pinned while scrolling. */
     .chat-body {
       flex: 1; min-height: 0; display: flex; flex-direction: row;
-      overflow-y: auto;
+      overflow: hidden;
     }
-    .chat-body::-webkit-scrollbar { width: 8px; }
-    .chat-body::-webkit-scrollbar-track { background: transparent; }
-    .chat-body::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
     .chat-main {
       flex: 1; min-width: 0; display: flex; flex-direction: column;
-      min-height: 100%;
+      min-height: 0;
     }
     .chat-main .input-bar {
       position: sticky; bottom: 0; z-index: 50;
@@ -1199,8 +1198,7 @@
       display: flex; flex-direction: column;
       background: var(--bg-surface); flex-shrink: 0;
       transition: width 0.15s ease;
-      position: sticky; top: 0;
-      align-self: stretch; height: 100vh;
+      height: 100%;
     }
     .chat-rail.collapsed { width: 32px; }
     .chat-rail-header {


### PR DESCRIPTION
## Summary

Console chat scrollbar lived on `.chat-body`, which made the input box scroll along with the messages. Moved `overflow-y: auto` to `.message-thread` so only the messages scroll and the input/header stay pinned.

## Test plan

- [x] Long conversation: messages scroll; input box stays at the bottom
- [x] Short conversation: no premature scrollbar
- [x] No layout shift on resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)