### PR TITLE
fix(ingest): align DoclingParser._max_tokens default 512 → 1024

### DIFF
--- a/src/ingest/support/docling.py
+++ b/src/ingest/support/docling.py
@@ -728,7 +728,10 @@ class DoclingParser:
     def __init__(self) -> None:
         self._docling_document: Any = None
         self._vlm_mode: str = "disabled"
-        self._max_tokens: int = 512
+        # Aligns with parse-time fallback (line ~751) and the package-wide default
+        # (config.settings.RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS = 1024). Used
+        # only on the rare path where chunk() runs before parse() (in tests).
+        self._max_tokens: int = 1024
         self._config: Any = None
 
     def parse(self, file_path: Path, config: Any) -> "ParseResult":


### PR DESCRIPTION
## Summary

Follow-up from #91. `DoclingParser.__init__` set `self._max_tokens = 512` while the parse-time fallback (line 751) and the package-wide default (`RAG_INGESTION_HYBRID_CHUNKER_MAX_TOKENS`) are `1024`. Aligned to 1024 with a comment explaining when the pre-`parse()` default is reached.

## Why now (not later)

Flagged on #91 self-review as "fix next time the file is touched" — touching it now since it's a 1-line cosmetic change and avoids future drift.

## Test plan

- [x] No behavior change on the normal path (`parse()` always runs before `chunk()`)
- [x] Edge case (`chunk()` without `parse()`) now uses 1024 instead of 512

🤖 Generated with [Claude Code](https://claude.com/claude-code)