### PR TITLE
fix(ci): regenerate uv.lock to match pyproject.toml

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2110,6 +2110,7 @@ source = { editable = "../KGWeave" }
 dependencies = [
     { name = "hjson" },
     { name = "leidenalg" },
+    { name = "mistune" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "orjson" },
@@ -2130,6 +2131,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'api'", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "leidenalg", specifier = ">=0.10" },
+    { name = "mistune", specifier = ">=3.2.1" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "neo4j", marker = "extra == 'neo4j'", specifier = ">=5" },
     { name = "networkx" },
@@ -2812,6 +2814,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/df/6dfc6540f96a74125a11653cce717603fd5b7d0001a8e847b3e54e72d238/minio-7.2.20.tar.gz", hash = "sha256:95898b7a023fbbfde375985aa77e2cd6a0762268db79cf886f002a9ea8e68598", size = 136113, upload-time = "2025-11-27T00:37:15.569Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/9a/b697530a882588a84db616580f2ba5d1d515c815e11c30d219145afeec87/minio-7.2.20-py3-none-any.whl", hash = "sha256:eb33dd2fb80e04c3726a76b13241c6be3c4c46f8d81e1d58e757786f6501897e", size = 93751, upload-time = "2025-11-27T00:37:13.993Z" },
+]
+
+[[package]]
+name = "mistune"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Restore green CI on develop. Since #95 (\"chore(deps): refresh uv.lock for KGWeave non-community deps\"), every commit on develop has failed CI at the **Install locked dependencies** step:

\`\`\`
Resolved 307 packages in 2.37s
The lockfile at \`uv.lock\` needs to be updated, but \`--locked\` was provided.
\`\`\`

7 consecutive red builds on develop (oldest → newest):
\`0df7ba4 → 326986a → 17db05d → 313d7e8 → 56b4fa3 → 31af5e8 → 9184d38\`

Regenerated \`uv.lock\` against the current \`pyproject.toml\` under **CPython 3.12.3** (the exact version CI runs) with a **fully cleared uv cache**, so resolution mirrors a fresh CI environment.

## Change

- 1 file: \`uv.lock\` (+14 lines)
- Adds one missing transitive entry: **\`mistune 3.2.1\`** — pulled in by an existing top-level package whose upstream metadata changed. No top-level deps added, removed, or upgraded.

## Verified

\`\`\`bash
UV_PYTHON=3.12.3 uv sync --locked --extra dev
# Resolved 311 packages
# Checked 234 packages, installed 234
\`\`\`

Once merged, \`feat/raptor-treerag-research\` (PR #97) and every other in-flight PR will auto-clear the lockfile check on rebuild.

## Test plan

- [ ] CI \`test\` job \"Install locked dependencies\" passes (was the blocker)
- [ ] CI test suite green (was never reached on prior commits)
- [ ] Spot-check: \`uv tree | grep mistune\` shows it as a transitive (not a direct dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)