### PR TITLE
feat(ops): auto-detect GPU/CPU in compose wrapper + first-run env wizard

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,0 +1,52 @@
+# docker-compose.cpu.yml — CPU-only overlay for hosts without an NVIDIA GPU
+# (AMD, Intel, Apple Silicon, CI runners, WSL2 without CUDA passthrough).
+#
+# Auto-loaded by scripts/compose.sh when nvidia-smi is unavailable, OR can be
+# applied manually:
+#
+#     docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
+#
+# What it does
+# ────────────
+# Replaces the NVIDIA-pinned services (rag-embed, rag-rerank, rag-ollama) with
+# CPU-compatible variants:
+#   - rag-embed:  GPU image -> ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
+#   - rag-rerank: GPU image -> ghcr.io/huggingface/text-embeddings-inference:cpu-1.8
+#   - rag-ollama: unchanged image (ollama runs on CPU by default), GPU
+#                 reservation cleared.
+# The `deploy.resources.reservations.devices: []` empty-list override replaces
+# the GPU reservation cleanly — required, because Compose merges mappings but
+# replaces lists across overlay files.
+#
+# Performance note
+# ────────────────
+# CPU inference is ~10-50x slower than GPU for BGE-M3 / bge-reranker-v2-m3.
+# Acceptable for dev iteration and small corpora; do NOT use for prod traffic.
+# Tune throughput via:
+#   RAG_TEI_EMBED_MAX_BATCH_TOKENS   (default 2048; lower if RAM-constrained)
+#   RAG_TEI_EMBED_MAX_CONCURRENT     (default 8;   try 2-4 on small hosts)
+#   RAG_TEI_RERANK_MAX_BATCH_TOKENS  (default 2048)
+#   RAG_TEI_RERANK_MAX_CONCURRENT    (default 4)
+#
+# Memory: BGE-M3 needs ~2 GB RAM, reranker ~1.5 GB. Plan for 4-6 GB free.
+
+services:
+  rag-embed:
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
+    deploy:
+      resources:
+        reservations:
+          devices: []
+
+  rag-rerank:
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.8
+    deploy:
+      resources:
+        reservations:
+          devices: []
+
+  rag-ollama:
+    deploy:
+      resources:
+        reservations:
+          devices: []

--- a/scripts/compose.sh
+++ b/scripts/compose.sh
@@ -1,22 +1,190 @@
 #!/usr/bin/env bash
 # @summary
-# Auto-detect Docker or Podman and run compose with the correct binary.
-# Usage: ./scripts/compose.sh --profile temporal --profile app up -d
-# Exports: (none — exec's into compose)
-# Deps: podman-compose | podman compose | docker compose
+# Single entry point for `docker compose` / `podman compose` in RagWeave.
+# Auto-detects the container runtime AND the host GPU, then picks the right
+# compose overlays and TEI image tags so `up`, `down`, `ps`, etc. "just work"
+# on NVIDIA, AMD, Intel, Apple Silicon, and WSL2 hosts without manual flags.
+#
+# Usage:
+#   ./scripts/compose.sh up -d                  # full stack, auto GPU/CPU
+#   ./scripts/compose.sh --profile workers up   # with a compose profile
+#   ./scripts/compose.sh --explain up -d        # print plan, do not execute
+#   ./scripts/compose.sh logs -f rag-embed
+#
+# Knobs (env vars — set before running, or export in your shell):
+#   RAGWEAVE_FORCE_CPU=1        Force CPU overlay even if NVIDIA is present.
+#   RAGWEAVE_FORCE_GPU=1        Skip CPU overlay even if no GPU detected
+#                               (will fail at runtime — for debugging).
+#   RAGWEAVE_COMPOSE_EXTRA="-f docker-compose.extra.yml"
+#                               Extra files appended after auto-detected ones.
+#   RAGWEAVE_RUNTIME=docker|podman
+#                               Override runtime auto-detect.
+#   RAGWEAVE_VERBOSE=1          Print resolved command before exec.
+#
+# Exports: (none — exec's into the chosen compose binary)
+# Deps: docker compose v2 | podman compose | podman-compose; optionally
+#       nvidia-smi for GPU detection.
 # @end-summary
+
 set -euo pipefail
 
-if command -v podman-compose &>/dev/null; then
-    COMPOSE_CMD="podman-compose"
-elif command -v podman &>/dev/null && podman compose version &>/dev/null 2>&1; then
-    COMPOSE_CMD="podman compose"
-elif command -v docker &>/dev/null && docker compose version &>/dev/null 2>&1; then
-    COMPOSE_CMD="docker compose"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# ── Colors (tty only) ──────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+    _G=$'\e[32m'; _Y=$'\e[33m'; _R=$'\e[31m'; _D=$'\e[2m'; _B=$'\e[1m'; _N=$'\e[0m'
 else
-    echo "Error: Neither podman-compose nor docker compose found." >&2
+    _G=""; _Y=""; _R=""; _D=""; _B=""; _N=""
+fi
+_log()  { printf '%s[compose]%s %s\n' "$_D" "$_N" "$*" >&2; }
+_warn() { printf '%s[compose]%s %s%s%s\n' "$_D" "$_N" "$_Y" "$*" "$_N" >&2; }
+_err()  { printf '%s[compose]%s %s%s%s\n' "$_D" "$_N" "$_R" "$*" "$_N" >&2; }
+
+# ── Optional flags handled by the wrapper (everything else passes through) ──
+EXPLAIN=0
+PASSTHRU=()
+for arg in "$@"; do
+    case "$arg" in
+        --explain|--dry-run) EXPLAIN=1 ;;
+        --help-wrapper)
+            sed -n '2,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) PASSTHRU+=("$arg") ;;
+    esac
+done
+
+# ── 1. Container runtime ───────────────────────────────────────────────
+choose_runtime() {
+    if [[ -n "${RAGWEAVE_RUNTIME:-}" ]]; then
+        case "$RAGWEAVE_RUNTIME" in
+            docker)
+                command -v docker >/dev/null && docker compose version >/dev/null 2>&1 \
+                    && { echo "docker compose"; return; }
+                ;;
+            podman)
+                if command -v podman-compose >/dev/null 2>&1; then
+                    echo "podman-compose"; return
+                elif podman compose version >/dev/null 2>&1; then
+                    echo "podman compose"; return
+                fi
+                ;;
+        esac
+        _err "RAGWEAVE_RUNTIME=$RAGWEAVE_RUNTIME requested but not usable."
+        exit 1
+    fi
+    if command -v podman-compose >/dev/null 2>&1; then echo "podman-compose"; return; fi
+    if command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then
+        echo "podman compose"; return
+    fi
+    if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+        echo "docker compose"; return
+    fi
+    _err "Neither docker compose v2 nor podman compose found. Install one and retry."
     exit 1
+}
+COMPOSE_CMD="$(choose_runtime)"
+
+# ── 2. GPU detection → TEI image tags + overlay choice ────────────────
+# Mirrors scripts/check_env.sh. SM = "compute capability"; TEI publishes one
+# image per arch family. Mapping is deliberately conservative — bumping to a
+# newer minor (1.6/1.7/1.8) per arch is opt-in via .env overrides.
+detect_gpu_and_tei_tags() {
+    local sm="" gpu_name="" wsl=""
+    if [[ -r /proc/version ]] && grep -qiE "microsoft|wsl" /proc/version; then
+        wsl="yes"
+    fi
+
+    if [[ "${RAGWEAVE_FORCE_CPU:-0}" == "1" ]]; then
+        echo "cpu|cpu-1.5|cpu-1.8||$wsl"; return
+    fi
+
+    if command -v nvidia-smi >/dev/null 2>&1; then
+        # On WSL2, if nvidia-smi returns a compute_cap the CUDA passthrough
+        # is wired and Docker will see the GPU.
+        sm=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null \
+                | head -1 | tr -d ' ')
+        gpu_name=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1)
+    fi
+
+    local embed_tag rerank_tag mode
+    case "$sm" in
+        7.5)      embed_tag="turing-1.5"; rerank_tag="turing-1.8"; mode="gpu" ;;
+        8.0|8.6)  embed_tag="86-1.5";     rerank_tag="86-1.8";     mode="gpu" ;;
+        8.9)      embed_tag="89-1.5";     rerank_tag="89-1.8";     mode="gpu" ;;
+        9.0|10.0|12.0)
+                  embed_tag="latest";     rerank_tag="latest";     mode="gpu" ;;
+        "")       embed_tag="cpu-1.5";    rerank_tag="cpu-1.8";    mode="cpu" ;;
+        *)        # Unknown / future arch — try `latest`, but warn.
+                  embed_tag="latest";     rerank_tag="latest";     mode="gpu"
+                  _warn "Unknown GPU compute capability '$sm' (${gpu_name:-?}); using TEI 'latest'."
+                  ;;
+    esac
+
+    # Force-GPU escape hatch even when no nvidia-smi (testing / mis-detection).
+    if [[ "$mode" == "cpu" && "${RAGWEAVE_FORCE_GPU:-0}" == "1" ]]; then
+        _warn "RAGWEAVE_FORCE_GPU=1 set but no NVIDIA detected — using turing-1.5 anyway."
+        embed_tag="turing-1.5"; rerank_tag="turing-1.8"; mode="gpu"
+    fi
+
+    echo "${mode}|${embed_tag}|${rerank_tag}|${gpu_name}|${wsl}"
+}
+
+IFS='|' read -r GPU_MODE EMBED_TAG RERANK_TAG GPU_NAME IS_WSL \
+    <<<"$(detect_gpu_and_tei_tags)"
+
+# Respect any user-set values in the environment — env wins over auto-detect.
+EMBED_TAG="${RAG_TEI_IMAGE_TAG:-$EMBED_TAG}"
+RERANK_TAG="${RAG_TEI_RERANK_IMAGE_TAG:-$RERANK_TAG}"
+export RAG_TEI_IMAGE_TAG="$EMBED_TAG"
+export RAG_TEI_RERANK_IMAGE_TAG="$RERANK_TAG"
+
+# ── 3. Overlay assembly ───────────────────────────────────────────────
+# Compose auto-loads docker-compose.override.yml, so we do NOT pass it via
+# -f. The CPU overlay is appended only when no GPU was detected; user extras
+# come last so they can override either layer.
+FILES=(-f docker-compose.yml)
+if [[ "$GPU_MODE" == "cpu" ]]; then
+    FILES+=(-f docker-compose.cpu.yml)
+fi
+# shellcheck disable=SC2206  # intentional word-split of caller-supplied flags
+EXTRA=( ${RAGWEAVE_COMPOSE_EXTRA:-} )
+if (( ${#EXTRA[@]} )); then
+    FILES+=("${EXTRA[@]}")
 fi
 
-echo "[compose] Using: $COMPOSE_CMD"
-exec $COMPOSE_CMD "$@"
+# ── 4. Banner ─────────────────────────────────────────────────────────
+print_banner() {
+    printf '%s[compose]%s runtime  %s%s%s\n' "$_D" "$_N" "$_B" "$COMPOSE_CMD" "$_N"
+    if [[ "$GPU_MODE" == "gpu" ]]; then
+        printf '%s[compose]%s mode     %sGPU%s  (%s)\n' \
+            "$_D" "$_N" "$_G" "$_N" "${GPU_NAME:-NVIDIA detected}"
+    else
+        local forced=""
+        [[ "${RAGWEAVE_FORCE_CPU:-0}" == "1" ]] && forced=', forced by RAGWEAVE_FORCE_CPU=1'
+        printf '%s[compose]%s mode     %sCPU%s  (no NVIDIA GPU detected%s)\n' \
+            "$_D" "$_N" "$_Y" "$_N" "$forced"
+    fi
+    printf '%s[compose]%s embed    %s\n' "$_D" "$_N" "$EMBED_TAG"
+    printf '%s[compose]%s rerank   %s\n' "$_D" "$_N" "$RERANK_TAG"
+    if [[ -n "$IS_WSL" ]]; then
+        printf '%s[compose]%s host     WSL2  %s(ensure NVIDIA Container Toolkit + WSL CUDA driver)%s\n' \
+            "$_D" "$_N" "$_D" "$_N"
+    fi
+    printf '%s[compose]%s files    %s\n' "$_D" "$_N" "${FILES[*]}"
+}
+print_banner
+
+if (( EXPLAIN )); then
+    printf '%s[compose]%s --explain: not executing.\n' "$_D" "$_N"
+    printf '%s[compose]%s would run: %s %s %s\n' \
+        "$_D" "$_N" "$COMPOSE_CMD" "${FILES[*]}" "${PASSTHRU[*]:-}"
+    exit 0
+fi
+
+# ── 5. Exec ───────────────────────────────────────────────────────────
+[[ "${RAGWEAVE_VERBOSE:-0}" == "1" ]] && \
+    _log "exec: $COMPOSE_CMD ${FILES[*]} ${PASSTHRU[*]:-}"
+
+exec $COMPOSE_CMD "${FILES[@]}" "${PASSTHRU[@]}"

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# @summary
+# Interactive first-run env walkthrough for RagWeave. Copies .env.example to
+# .env, generates strong secrets in place of `replace_me` placeholders, auto-
+# detects the host GPU to pick TEI image tags, and prompts for the handful of
+# values a user actually needs to think about (inference backend, HF token).
+#
+# Idempotent: safe to re-run. Existing .env values are preserved unless the
+# user explicitly opts to reset them. Generated secrets are written only when
+# the current value still equals the upstream placeholder.
+#
+# Usage:
+#   ./scripts/setup_env.sh                  # interactive walkthrough
+#   ./scripts/setup_env.sh --non-interactive   # accept all defaults
+#   ./scripts/setup_env.sh --reset          # overwrite existing .env
+#
+# Exports: (none — mutates .env in place)
+# Deps: openssl (for secret generation); optional nvidia-smi (GPU detect).
+# @end-summary
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+ENV_FILE=".env"
+EXAMPLE_FILE=".env.example"
+
+NON_INTERACTIVE=0
+RESET=0
+for arg in "$@"; do
+    case "$arg" in
+        --non-interactive|-y) NON_INTERACTIVE=1 ;;
+        --reset)              RESET=1 ;;
+        -h|--help)
+            sed -n '2,21p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 1 ;;
+    esac
+done
+
+# ── Output helpers ─────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+    _G=$'\e[32m'; _Y=$'\e[33m'; _R=$'\e[31m'; _B=$'\e[1m'; _D=$'\e[2m'; _N=$'\e[0m'
+else
+    _G=""; _Y=""; _R=""; _B=""; _D=""; _N=""
+fi
+step() { printf '\n%s── %s%s\n' "$_B" "$1" "$_N"; }
+ok()   { printf '  %s✓%s %s\n' "$_G" "$_N" "$1"; }
+warn() { printf '  %s⚠%s %s\n' "$_Y" "$_N" "$1"; }
+info() { printf '  %s%s%s\n' "$_D" "$1" "$_N"; }
+
+# ── Helpers ────────────────────────────────────────────────────────────
+# Set KEY=VALUE in .env, replacing the existing line if present, appending
+# otherwise. Values are passed raw — caller is responsible for quoting if
+# the value contains spaces or shell metacharacters (none of ours do).
+set_env() {
+    local key="$1" value="$2"
+    if grep -qE "^${key}=" "$ENV_FILE"; then
+        # Use a delimiter unlikely to appear in secrets/URLs.
+        local esc; esc=$(printf '%s' "$value" | sed 's/[\&|]/\\&/g')
+        sed -i "s|^${key}=.*|${key}=${esc}|" "$ENV_FILE"
+    else
+        printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+    fi
+}
+
+get_env() {
+    # `|| true` keeps `set -o pipefail` from tripping when the key is absent.
+    grep -E "^$1=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
+prompt() {
+    # prompt VAR "Question text" "default" [hidden=0|1]
+    local var="$1" question="$2" default="${3:-}" hidden="${4:-0}" reply
+    if (( NON_INTERACTIVE )); then
+        printf -v "$var" '%s' "$default"
+        return
+    fi
+    if [[ "$hidden" == "1" ]]; then
+        read -rsp "  $question [${default:-leave blank to skip}]: " reply
+        echo
+    else
+        read -rp "  $question [${default:-leave blank to skip}]: " reply
+    fi
+    printf -v "$var" '%s' "${reply:-$default}"
+}
+
+gen_secret() { openssl rand -hex 32; }
+
+# ── 1. Bootstrap .env ─────────────────────────────────────────────────
+step "1. Bootstrap .env"
+if [[ ! -f "$EXAMPLE_FILE" ]]; then
+    echo "Missing $EXAMPLE_FILE — are you in the repo root?" >&2
+    exit 1
+fi
+
+if [[ -f "$ENV_FILE" && "$RESET" == "0" ]]; then
+    ok ".env exists — keeping current values; only filling placeholders & missing keys"
+elif [[ -f "$ENV_FILE" && "$RESET" == "1" ]]; then
+    cp "$ENV_FILE" "${ENV_FILE}.bak.$(date +%s)"
+    cp "$EXAMPLE_FILE" "$ENV_FILE"
+    warn "Reset: backed up old .env to .env.bak.<timestamp> and copied from .env.example"
+else
+    cp "$EXAMPLE_FILE" "$ENV_FILE"
+    ok "Created .env from .env.example"
+fi
+
+# Add any new keys from .env.example that are missing from current .env.
+# Lets users re-run after pulling a repo update without losing local edits.
+ADDED=0
+while IFS= read -r line; do
+    [[ "$line" =~ ^[A-Z_]+= ]] || continue
+    key="${line%%=*}"
+    if ! grep -qE "^${key}=" "$ENV_FILE"; then
+        echo "$line" >> "$ENV_FILE"
+        ADDED=$((ADDED+1))
+    fi
+done < "$EXAMPLE_FILE"
+(( ADDED > 0 )) && ok "Appended $ADDED new key(s) from .env.example"
+
+# ── 2. Generate secrets where placeholders remain ─────────────────────
+step "2. Generate secrets"
+if ! command -v openssl >/dev/null 2>&1; then
+    warn "openssl not found — skipping secret generation. Install openssl and re-run."
+else
+    # Each secret is independent; never reuse one across slots.
+    SECRET_KEYS=(
+        LANGFUSE_PUBLIC_KEY
+        LANGFUSE_SECRET_KEY
+        LANGFUSE_NEXTAUTH_SECRET
+        LANGFUSE_SALT
+        LANGFUSE_ENCRYPTION_KEY
+        RAG_AUTH_JWT_HS256_SECRET
+    )
+    GENERATED=0
+    for k in "${SECRET_KEYS[@]}"; do
+        current="$(get_env "$k")"
+        if [[ -z "$current" || "$current" == *replace_me* ]]; then
+            # Langfuse public/secret keys conventionally prefix pk_/sk_.
+            case "$k" in
+                LANGFUSE_PUBLIC_KEY) val="pk_$(gen_secret)" ;;
+                LANGFUSE_SECRET_KEY) val="sk_$(gen_secret)" ;;
+                *)                   val="$(gen_secret)"    ;;
+            esac
+            set_env "$k" "$val"
+            GENERATED=$((GENERATED+1))
+        fi
+    done
+    if (( GENERATED > 0 )); then
+        ok "Generated $GENERATED secret(s) — Langfuse + JWT keys"
+    else
+        info "All secrets already set — nothing to generate"
+    fi
+fi
+
+# ── 3. GPU auto-detect → TEI tags ─────────────────────────────────────
+step "3. GPU detection → TEI image tags"
+SM=""; GPU_NAME=""
+if command -v nvidia-smi >/dev/null 2>&1; then
+    SM=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null \
+            | head -1 | tr -d ' ')
+    GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1)
+fi
+case "$SM" in
+    7.5)      EMBED_TAG="turing-1.5"; RERANK_TAG="turing-1.8" ;;
+    8.0|8.6)  EMBED_TAG="86-1.5";     RERANK_TAG="86-1.8"    ;;
+    8.9)      EMBED_TAG="89-1.5";     RERANK_TAG="89-1.8"    ;;
+    9.0|10.0|12.0)
+              EMBED_TAG="latest";     RERANK_TAG="latest"    ;;
+    "")       EMBED_TAG="cpu-1.5";    RERANK_TAG="cpu-1.8"   ;;
+    *)        EMBED_TAG="latest";     RERANK_TAG="latest"    ;;
+esac
+if [[ -n "$SM" ]]; then
+    ok "Detected: ${GPU_NAME:-unknown} (SM=$SM) → embed=$EMBED_TAG, rerank=$RERANK_TAG"
+else
+    info "No NVIDIA GPU detected → embed=$EMBED_TAG, rerank=$RERANK_TAG (CPU)"
+    info "Run scripts/compose.sh and it will auto-load docker-compose.cpu.yml"
+fi
+set_env RAG_TEI_IMAGE_TAG "$EMBED_TAG"
+set_env RAG_TEI_RERANK_IMAGE_TAG "$RERANK_TAG"
+
+# ── 4. User-facing prompts (only things they actually need to choose) ─
+step "4. Inference backend"
+info "tei    = TEI containers (rag-embed/rag-rerank) — recommended, scales with GPU"
+info "local  = in-process torch + transformers — needs ~/models/baai/bge-m3 on disk"
+current_backend="$(get_env RAG_INFERENCE_BACKEND)"
+prompt BACKEND "Inference backend (tei|local)" "${current_backend:-tei}"
+set_env RAG_INFERENCE_BACKEND "$BACKEND"
+ok "RAG_INFERENCE_BACKEND=$BACKEND"
+
+step "5. Hugging Face Hub token (optional)"
+info "Needed only for gated/private models. BGE-M3 and bge-reranker-v2-m3 are public."
+current_hf="$(get_env HUGGING_FACE_HUB_TOKEN)"
+prompt HF "HF token (hf_...) — leave blank to skip" "$current_hf" 1
+if [[ -n "$HF" ]]; then
+    set_env HUGGING_FACE_HUB_TOKEN "$HF"
+    ok "HUGGING_FACE_HUB_TOKEN set"
+else
+    info "Skipped — public models will still work"
+fi
+
+# ── 6. Sanity checks (non-fatal) ──────────────────────────────────────
+step "6. Sanity checks"
+command -v docker  >/dev/null 2>&1 && ok "docker present"           || warn "docker missing — install Docker Engine or Podman"
+docker compose version >/dev/null 2>&1 && ok "docker compose v2 present" || warn "docker compose v2 missing"
+if [[ -n "$SM" ]]; then
+    if docker info 2>/dev/null | grep -qi nvidia; then
+        ok "Docker has the nvidia runtime registered"
+    else
+        warn "NVIDIA GPU detected but Docker has no 'nvidia' runtime — install nvidia-container-toolkit:"
+        info "  sudo apt install nvidia-container-toolkit && sudo nvidia-ctk runtime configure --runtime=docker && sudo systemctl restart docker"
+    fi
+fi
+
+# ── 7. Summary ────────────────────────────────────────────────────────
+step "Done"
+cat <<EOF
+  Env file: $_B$ENV_FILE$_N
+  Mode:     $([[ -n "$SM" ]] && echo "${_G}GPU${_N} (${GPU_NAME})" || echo "${_Y}CPU${_N}")
+  Backend:  $BACKEND
+  TEI:      embed=$EMBED_TAG  rerank=$RERANK_TAG
+
+  ${_D}config/settings.py reads everything from environment variables, so the
+  values above flow through to the Python side automatically — no separate
+  Python config step is needed.${_N}
+
+  Next:
+    ${_B}./scripts/compose.sh up -d${_N}              # start the stack (auto GPU/CPU)
+    ${_B}./scripts/compose.sh --explain up -d${_N}    # preview without running
+    ${_B}./scripts/check_env.sh${_N}                  # deeper verification
+
+EOF


### PR DESCRIPTION
## Summary
- `./scripts/compose.sh up -d` now auto-detects the host GPU (via `nvidia-smi --query-gpu=compute_cap`), picks the right TEI image tags for both `rag-embed` and `rag-rerank`, and auto-appends a new CPU overlay when no NVIDIA is present — so AMD / Intel / Apple / WSL2-without-CUDA users get a working stack with no manual `-f` flags.
- New `docker-compose.cpu.yml` overlay swaps the three GPU-pinned services (`rag-embed`, `rag-rerank`, `rag-ollama`) to CPU-compatible images and clears `deploy.resources.reservations.devices` with an empty list — the only portable way to "delete" the nvidia reservation across overlay files.
- New `scripts/setup_env.sh` interactive walkthrough: copies `.env.example`, backfills missing keys on re-run, generates Langfuse + JWT secrets via `openssl rand -hex 32` only where `replace_me` placeholders remain, auto-writes the detected TEI tags, prompts only for what the user actually needs to think about (`RAG_INFERENCE_BACKEND`, optional HF token), and sanity-checks `nvidia-container-toolkit`. `config/settings.py` is env-driven (plain `os.environ.get(...)`), so the wizard's `.env` flows through to the Python side with no separate step.

## Why
- Single-file compose conditionals don't exist in Compose v2 — overlay-picking is the idiomatic solution, but forcing every user to remember `-f docker-compose.cpu.yml` defeats the purpose. The wrapper hides it.
- `scripts/cold_start_setup.sh` previously did `cp .env.example .env` and stopped — leaving five `replace_me` secrets and a TEI tag that only matches Turing GPUs. New users on a 30xx/40xx card would hit a confusing image-pull error on first `up`.
- Decoupling the SM→tag mapping from compose YAML means `check_env.sh`, `setup_env.sh`, and `compose.sh` all share the same logic (and stay overridable via `RAG_TEI_IMAGE_TAG` / `RAG_TEI_RERANK_IMAGE_TAG`).

## Knobs
| Env var | Effect |
|---|---|
| `RAGWEAVE_FORCE_CPU=1` | Use CPU overlay even if NVIDIA detected (useful for tests / debugging GPU contention) |
| `RAGWEAVE_FORCE_GPU=1` | Skip CPU overlay even if no GPU (force-pull GPU images for image-pull testing) |
| `RAGWEAVE_COMPOSE_EXTRA="-f extra.yml"` | Append ad-hoc overlays after auto-detected ones |
| `RAGWEAVE_RUNTIME=docker\|podman` | Override runtime auto-detect |
| `RAGWEAVE_VERBOSE=1` | Echo resolved command before exec |
| `--explain` / `--dry-run` | Print the plan and exit without running |

## Test plan
- [x] `./scripts/compose.sh --explain up -d` on RTX 2060 host → reports `mode GPU`, `embed turing-1.5`, `rerank turing-1.8`, no CPU overlay
- [x] `RAGWEAVE_FORCE_CPU=1 ./scripts/compose.sh --explain up -d` → reports `mode CPU`, appends `-f docker-compose.cpu.yml`, swaps tags to `cpu-1.5` / `cpu-1.8`
- [x] `./scripts/setup_env.sh --non-interactive` on a `.env` missing 115 keys → backfills them, generates 1 missing secret, writes TEI tags from detected GPU, flags missing `nvidia-container-toolkit`
- [x] Re-run setup wizard → idempotent, "All secrets already set — nothing to generate"
- [x] `bash -n` syntax check on both scripts
- [ ] Verify on a host without `nvidia-smi` (AMD / WSL-no-CUDA / CI runner) that the CPU overlay is appended and `cpu-1.x` images pull
- [ ] Verify on an SM 8.6 host (RTX 30xx / A10) that the `86-1.5` / `86-1.8` tags resolve

## Files
- `docker-compose.cpu.yml` (new, 52 lines)
- `scripts/compose.sh` (rewrite, +194/-13)
- `scripts/setup_env.sh` (new, 234 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)