### PR TITLE
chore(retrieval): enable xref expansion by default; gate figure refs; fix soak resolver

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -865,11 +865,24 @@ RAG_DOCUMENT_FORMATTING_ENABLED = os.environ.get(
 # table-group expansion architecture (src.retrieval.xref_expansion).
 # Scoped MVP: only ``section`` / ``section_symbol`` ref types are resolved;
 # table/figure/appendix refs require a caption registry and remain TODO.
+#
+# Default flipped to ON 2026-05-23 after the ESP32-S3 datasheet soak:
+# table refs resolved 98.8% (559/566), confirming the expander is safe to
+# enable by default. Operators can still disable it via env var.
 RAG_XREF_EXPANSION_ENABLED: bool = os.environ.get(
-    "RAG_XREF_EXPANSION_ENABLED", "false"
+    "RAG_XREF_EXPANSION_ENABLED", "true"
 ).lower() in ("true", "1", "yes")
 RAG_XREF_MAX_PER_HIT: int = int(os.environ.get("RAG_XREF_MAX_PER_HIT", "2"))
 RAG_XREF_MAX_TOTAL: int = int(os.environ.get("RAG_XREF_MAX_TOTAL", "6"))
+
+# Whether ingest-time xref extraction emits ``figure`` refs. We don't yet
+# have a FigureArtifact registry to resolve against, so figure refs are
+# pure noise downstream — default-off. Flip to "true" once figure
+# artifacts land. (Section/section_symbol/table/appendix refs continue to
+# be emitted regardless.)
+RAG_XREF_EXTRACT_FIGURE_REFS: bool = os.environ.get(
+    "RAG_XREF_EXTRACT_FIGURE_REFS", "false"
+).lower() in ("true", "1", "yes")
 
 # --- Visual Embedding Pipeline ---
 RAG_INGESTION_ENABLE_VISUAL_EMBEDDING: bool = os.environ.get(

--- a/docs/soak/table_chunking_real_datasheet_msp430_2026-05-23.json
+++ b/docs/soak/table_chunking_real_datasheet_msp430_2026-05-23.json
@@ -1,0 +1,105 @@
+{
+  "pdf": {
+    "path": "/home/kok-shew-juan/RagWeave/.worktrees/table-aware-chunking/data/datasheets/ti_msp430f5529.pdf",
+    "size_bytes": 4498682,
+    "page_count": 145
+  },
+  "models_ready": true,
+  "models_error": null,
+  "parse_error": null,
+  "counts": {
+    "total_chunks": 2037,
+    "tables": 144,
+    "summary_chunks": 144,
+    "row_chunks": 1539,
+    "group_ids": 144
+  },
+  "heading_depth_distribution": {
+    "0": 3,
+    "1": 141
+  },
+  "truncation_events": 0,
+  "table_samples": [
+    {
+      "table_group_id": "#/tables/130",
+      "section_path": "10.2 Device Nomenclature",
+      "table_caption": "Figure 10-1. Device Nomenclature",
+      "page_no": 114,
+      "page_bbox": [
+        110.58732604980469,
+        605.9351348876953,
+        501.1798400878906,
+        304.53497314453125
+      ],
+      "table_num_rows": 10,
+      "table_num_cols": 3,
+      "text_head": "Table: Figure 10-1. Device Nomenclature\nColumns: \nRows: 10",
+      "markdown_head": "Figure 10-1. Device Nomenclature\n\n| Processor Family              | CC = Embedded RF Radio MSP = Mixed-Signal Processor XMS = Experimental Silicon PMS = Prototype Device                    |                                                  ",
+      "markdown_len": 3575
+    },
+    {
+      "table_group_id": "#/tables/62",
+      "section_path": "9.4 Memory Organization",
+      "table_caption": "Table 9-2. Memory Organization  (1)",
+      "page_no": 56,
+      "page_bbox": [
+        55.758331298828125,
+        647.0240936279297,
+        556.0317993164062,
+        154.3128662109375
+      ],
+      "table_num_rows": 20,
+      "table_num_cols": 6,
+      "text_head": "Table: Table 9-2. Memory Organization  (1)\nColumns:  |  | MSP430F5522 MSP430F5521 MSP430F5513 | MSP430F5525 MSP430F5524 MSP430F5515 MSP430F5514 | MSP430F5527 MSP430F5526 MSP430F5517 | MSP430F5529 MSP430F5528 MSP430F5519\nRows: 19",
+      "markdown_head": "Table 9-2. Memory Organization  (1)\n\n|                                       |            | MSP430F5522 MSP430F5521 MSP430F5513   | MSP430F5525 MSP430F5524 MSP430F5515 MSP430F5514   | MSP430F5527 MSP430F5526 MSP430F5517   | MSP430F5529 MSP4",
+      "markdown_len": 4803
+    },
+    {
+      "table_group_id": "#/tables/45",
+      "section_path": "8.35 12-Bit ADC, Power Supply and Input Range Conditions",
+      "table_caption": "",
+      "page_no": 44,
+      "page_bbox": [
+        55.56804275512695,
+        688.1776275634766,
+        556.0166625976562,
+        560.2726898193359
+      ],
+      "table_num_rows": 7,
+      "table_num_cols": 8,
+      "text_head": "Columns: PARAMETER | PARAMETER | TEST CONDITIONS | V CC | MIN | TYP | MAX | UNIT\nRows: 6",
+      "markdown_head": "| PARAMETER   | PARAMETER                                       | TEST CONDITIONS                                                                                       | V CC   |   MIN |   TYP | MAX   | UNIT   |\n|-------------|-------------",
+      "markdown_len": 1695
+    }
+  ],
+  "determinism": {
+    "ok": true,
+    "first_count": 144,
+    "second_count": 144,
+    "diff_first_minus_second": [],
+    "diff_second_minus_first": []
+  },
+  "xref_edges": {
+    "total_chunks_with_edges": 598,
+    "total_edges": 710,
+    "edges_per_chunk_p50": 1,
+    "edges_per_chunk_p90": 1,
+    "by_type": {
+      "section": 82,
+      "table": 628
+    }
+  },
+  "xref_resolvability": {
+    "section_resolvable": 79,
+    "table_resolvable": 589,
+    "unresolvable_table_no_label": 39,
+    "unresolvable_figure": 0,
+    "unresolvable_appendix": 0
+  },
+  "caption_label_coverage": {
+    "tables_total": 144,
+    "tables_with_label": 40,
+    "label_rate": 0.2777777777777778
+  },
+  "errors": []
+}

--- a/docs/soak/table_chunking_real_datasheet_msp430_2026-05-23.md
+++ b/docs/soak/table_chunking_real_datasheet_msp430_2026-05-23.md
@@ -1,0 +1,133 @@
+# Table-chunking soak — real datasheet (2026-05-23)
+
+## Dataset
+
+- PDF: `/home/kok-shew-juan/RagWeave/.worktrees/table-aware-chunking/data/datasheets/ti_msp430f5529.pdf`
+- Source: Espressif ESP32-S3 datasheet (public, redistributable)
+- Size: 4,498,682 bytes
+- Pages: 145
+
+## Environment
+
+- Docling models ready: **True**
+
+## Counts
+
+| Metric | Value |
+|---|---|
+| total chunks emitted | 2037 |
+| TableArtifact entries | 144 |
+| distinct `table_group_id`s | 144 |
+| `table_summary` chunks | 144 |
+| `table_row` chunks | 1539 |
+| truncation events (V's guard) | 0 |
+
+## section_path breadcrumb depth distribution (over TableArtifacts)
+
+| heading levels | tables |
+|---|---|
+| 0 | 3 |
+| 1 | 141 |
+
+## Spot-checks (3 random `table_summary` chunks)
+
+### Sample 1 — `table_group_id='#/tables/130'`
+
+- section_path: `10.2 Device Nomenclature`
+- caption: `'Figure 10-1. Device Nomenclature'`
+- page_no: `114`
+- page_bbox: `(110.58732604980469, 605.9351348876953, 501.1798400878906, 304.53497314453125)`
+- rows × cols: `10 × 3`
+- table_markdown length: `3575` chars
+
+text excerpt:
+
+```
+Table: Figure 10-1. Device Nomenclature
+Columns: 
+Rows: 10
+```
+
+markdown excerpt:
+
+```
+Figure 10-1. Device Nomenclature
+
+| Processor Family              | CC = Embedded RF Radio MSP = Mixed-Signal Processor XMS = Experimental Silicon PMS = Prototype Device                    |                                                  
+```
+
+### Sample 2 — `table_group_id='#/tables/62'`
+
+- section_path: `9.4 Memory Organization`
+- caption: `'Table 9-2. Memory Organization  (1)'`
+- page_no: `56`
+- page_bbox: `(55.758331298828125, 647.0240936279297, 556.0317993164062, 154.3128662109375)`
+- rows × cols: `20 × 6`
+- table_markdown length: `4803` chars
+
+text excerpt:
+
+```
+Table: Table 9-2. Memory Organization  (1)
+Columns:  |  | MSP430F5522 MSP430F5521 MSP430F5513 | MSP430F5525 MSP430F5524 MSP430F5515 MSP430F5514 | MSP430F5527 MSP430F5526 MSP430F5517 | MSP430F5529 MSP430F5528 MSP430F5519
+Rows: 19
+```
+
+markdown excerpt:
+
+```
+Table 9-2. Memory Organization  (1)
+
+|                                       |            | MSP430F5522 MSP430F5521 MSP430F5513   | MSP430F5525 MSP430F5524 MSP430F5515 MSP430F5514   | MSP430F5527 MSP430F5526 MSP430F5517   | MSP430F5529 MSP4
+```
+
+### Sample 3 — `table_group_id='#/tables/45'`
+
+- section_path: `8.35 12-Bit ADC, Power Supply and Input Range Conditions`
+- caption: `''`
+- page_no: `44`
+- page_bbox: `(55.56804275512695, 688.1776275634766, 556.0166625976562, 560.2726898193359)`
+- rows × cols: `7 × 8`
+- table_markdown length: `1695` chars
+
+text excerpt:
+
+```
+Columns: PARAMETER | PARAMETER | TEST CONDITIONS | V CC | MIN | TYP | MAX | UNIT
+Rows: 6
+```
+
+markdown excerpt:
+
+```
+| PARAMETER   | PARAMETER                                       | TEST CONDITIONS                                                                                       | V CC   |   MIN |   TYP | MAX   | UNIT   |
+|-------------|-------------
+```
+
+## Determinism (cross-reparse)
+
+- Identical `table_group_id` set across two parses: **True**
+- first parse: 144 group_ids
+- second parse: 144 group_ids
+
+## Xref edges
+
+- chunks with edges: 598
+- total edges: 710
+- edges per chunk p50: 1
+- edges per chunk p90: 1
+- by type: section=82, table=628
+
+## Xref resolvability
+
+- section resolvable: 79
+- table resolvable: 589
+- unresolvable table (no matching caption_label): 39
+- unresolvable figure: 0
+- unresolvable appendix: 0
+
+## Caption label coverage
+
+- tables total: 144
+- tables with caption_label: 40
+- label rate: 27.78%

--- a/docs/soak/table_chunking_real_datasheet_xref_2026-05-23.json
+++ b/docs/soak/table_chunking_real_datasheet_xref_2026-05-23.json
@@ -1,0 +1,107 @@
+{
+  "pdf": {
+    "path": "/home/kok-shew-juan/RagWeave/.worktrees/table-aware-chunking/data/datasheets/esp32-s3_datasheet.pdf",
+    "size_bytes": 1098115,
+    "page_count": 87
+  },
+  "models_ready": true,
+  "models_error": null,
+  "parse_error": null,
+  "counts": {
+    "total_chunks": 831,
+    "tables": 71,
+    "summary_chunks": 71,
+    "row_chunks": 536,
+    "group_ids": 71
+  },
+  "heading_depth_distribution": {
+    "0": 6,
+    "1": 65
+  },
+  "truncation_events": 0,
+  "table_samples": [
+    {
+      "table_group_id": "#/tables/28",
+      "section_path": "3.4 JTAG Signal Source Control",
+      "table_caption": "Table 3-5. JTAG Signal Source Control",
+      "page_no": 35,
+      "page_bbox": [
+        55.898406982421875,
+        760.8178482055664,
+        559.1690063476562,
+        648.7037353515625
+      ],
+      "table_num_rows": 7,
+      "table_num_cols": 5,
+      "text_head": "Table: Table 3-5. JTAG Signal Source Control\nColumns: JTAG Signal Source | EFUSE_DIS_PAD_JTAG | EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL | GPIO3\nRows: 6",
+      "markdown_head": "Table 3-5. JTAG Signal Source Control\n\n| JTAG Signal Source          |   EFUSE_DIS_PAD_JTAG |   EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL   | GPIO3   |\n|-----------------------------|----------------------|----------------------|-----------",
+      "markdown_len": 942
+    },
+    {
+      "table_group_id": "#/tables/11",
+      "section_path": "2.3.1 IO MUX Functions",
+      "table_caption": "Table 2-3. Peripheral Signals Routed via IO MUX",
+      "page_no": 20,
+      "page_bbox": [
+        55.7794075012207,
+        508.8037414550781,
+        546.2653198242188,
+        118.4287109375
+      ],
+      "table_num_rows": 8,
+      "table_num_cols": 3,
+      "text_head": "Table: Table 2-3. Peripheral Signals Routed via IO MUX\nColumns: Pin Function | Signal | Description\nRows: 7",
+      "markdown_head": "Table 2-3. Peripheral Signals Routed via IO MUX\n\n| Pin Function                                          | Signal                                                                         | Description                                         ",
+      "markdown_len": 3216
+    },
+    {
+      "table_group_id": "#/tables/5",
+      "section_path": "",
+      "table_caption": "",
+      "page_no": 12,
+      "page_bbox": [
+        69.79170989990234,
+        746.8679275512695,
+        538.8440551757812,
+        611.82080078125
+      ],
+      "table_num_rows": 9,
+      "table_num_cols": 3,
+      "text_head": "Columns: \nRows: 9",
+      "markdown_head": "| 1-1   | ESP32-S3 Series Nomenclature                              |   13 |\n|-------|-----------------------------------------------------------|------|\n| 2-1   | ESP32-S3 Pin Layout (Top View)                            |   15 |\n| 2-2   |",
+      "markdown_len": 769
+    }
+  ],
+  "determinism": {
+    "ok": true,
+    "first_count": 71,
+    "second_count": 71,
+    "diff_first_minus_second": [],
+    "diff_second_minus_first": []
+  },
+  "xref_edges": {
+    "total_chunks_with_edges": 561,
+    "total_edges": 701,
+    "edges_per_chunk_p50": 1,
+    "edges_per_chunk_p90": 1,
+    "by_type": {
+      "section": 114,
+      "table": 566,
+      "figure": 20,
+      "standard": 1
+    }
+  },
+  "xref_resolvability": {
+    "section_resolvable": 0,
+    "table_resolvable": 559,
+    "unresolvable_table_no_label": 7,
+    "unresolvable_figure": 20,
+    "unresolvable_appendix": 0
+  },
+  "caption_label_coverage": {
+    "tables_total": 71,
+    "tables_with_label": 54,
+    "label_rate": 0.7605633802816901
+  },
+  "errors": []
+}

--- a/docs/soak/table_chunking_real_datasheet_xref_2026-05-23.md
+++ b/docs/soak/table_chunking_real_datasheet_xref_2026-05-23.md
@@ -1,0 +1,136 @@
+# Table-chunking soak — real datasheet (2026-05-23)
+
+## Dataset
+
+- PDF: `/home/kok-shew-juan/RagWeave/.worktrees/table-aware-chunking/data/datasheets/esp32-s3_datasheet.pdf`
+- Source: Espressif ESP32-S3 datasheet (public, redistributable)
+- Size: 1,098,115 bytes
+- Pages: 87
+
+## Environment
+
+- Docling models ready: **True**
+
+## Counts
+
+| Metric | Value |
+|---|---|
+| total chunks emitted | 831 |
+| TableArtifact entries | 71 |
+| distinct `table_group_id`s | 71 |
+| `table_summary` chunks | 71 |
+| `table_row` chunks | 536 |
+| truncation events (V's guard) | 0 |
+
+## section_path breadcrumb depth distribution (over TableArtifacts)
+
+| heading levels | tables |
+|---|---|
+| 0 | 6 |
+| 1 | 65 |
+
+## Spot-checks (3 random `table_summary` chunks)
+
+### Sample 1 — `table_group_id='#/tables/28'`
+
+- section_path: `3.4 JTAG Signal Source Control`
+- caption: `'Table 3-5. JTAG Signal Source Control'`
+- page_no: `35`
+- page_bbox: `(55.898406982421875, 760.8178482055664, 559.1690063476562, 648.7037353515625)`
+- rows × cols: `7 × 5`
+- table_markdown length: `942` chars
+
+text excerpt:
+
+```
+Table: Table 3-5. JTAG Signal Source Control
+Columns: JTAG Signal Source | EFUSE_DIS_PAD_JTAG | EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL | GPIO3
+Rows: 6
+```
+
+markdown excerpt:
+
+```
+Table 3-5. JTAG Signal Source Control
+
+| JTAG Signal Source          |   EFUSE_DIS_PAD_JTAG |   EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL   | GPIO3   |
+|-----------------------------|----------------------|----------------------|-----------
+```
+
+### Sample 2 — `table_group_id='#/tables/11'`
+
+- section_path: `2.3.1 IO MUX Functions`
+- caption: `'Table 2-3. Peripheral Signals Routed via IO MUX'`
+- page_no: `20`
+- page_bbox: `(55.7794075012207, 508.8037414550781, 546.2653198242188, 118.4287109375)`
+- rows × cols: `8 × 3`
+- table_markdown length: `3216` chars
+
+text excerpt:
+
+```
+Table: Table 2-3. Peripheral Signals Routed via IO MUX
+Columns: Pin Function | Signal | Description
+Rows: 7
+```
+
+markdown excerpt:
+
+```
+Table 2-3. Peripheral Signals Routed via IO MUX
+
+| Pin Function                                          | Signal                                                                         | Description                                         
+```
+
+### Sample 3 — `table_group_id='#/tables/5'`
+
+- section_path: ``
+- caption: `''`
+- page_no: `12`
+- page_bbox: `(69.79170989990234, 746.8679275512695, 538.8440551757812, 611.82080078125)`
+- rows × cols: `9 × 3`
+- table_markdown length: `769` chars
+
+text excerpt:
+
+```
+Columns: 
+Rows: 9
+```
+
+markdown excerpt:
+
+```
+| 1-1   | ESP32-S3 Series Nomenclature                              |   13 |
+|-------|-----------------------------------------------------------|------|
+| 2-1   | ESP32-S3 Pin Layout (Top View)                            |   15 |
+| 2-2   |
+```
+
+## Determinism (cross-reparse)
+
+- Identical `table_group_id` set across two parses: **True**
+- first parse: 71 group_ids
+- second parse: 71 group_ids
+
+## Xref edges
+
+- chunks with edges: 561
+- total edges: 701
+- edges per chunk p50: 1
+- edges per chunk p90: 1
+- by type: figure=20, section=114, standard=1, table=566
+
+## Xref resolvability
+
+- section resolvable: 0
+- table resolvable: 559
+- unresolvable table (no matching caption_label): 7
+- unresolvable figure: 20
+- unresolvable appendix: 0
+
+## Caption label coverage
+
+- tables total: 71
+- tables with caption_label: 54
+- label rate: 76.06%

--- a/docs/soak/table_chunking_real_datasheet_xref_2026-05-23_after_fix.json
+++ b/docs/soak/table_chunking_real_datasheet_xref_2026-05-23_after_fix.json
@@ -1,0 +1,106 @@
+{
+  "pdf": {
+    "path": "/home/kok-shew-juan/RagWeave/.worktrees/table-aware-chunking/data/datasheets/esp32-s3_datasheet.pdf",
+    "size_bytes": 1098115,
+    "page_count": 87
+  },
+  "models_ready": true,
+  "models_error": null,
+  "parse_error": null,
+  "counts": {
+    "total_chunks": 831,
+    "tables": 71,
+    "summary_chunks": 71,
+    "row_chunks": 536,
+    "group_ids": 71
+  },
+  "heading_depth_distribution": {
+    "0": 6,
+    "1": 65
+  },
+  "truncation_events": 0,
+  "table_samples": [
+    {
+      "table_group_id": "#/tables/28",
+      "section_path": "3.4 JTAG Signal Source Control",
+      "table_caption": "Table 3-5. JTAG Signal Source Control",
+      "page_no": 35,
+      "page_bbox": [
+        55.898406982421875,
+        760.8178482055664,
+        559.1690063476562,
+        648.7037353515625
+      ],
+      "table_num_rows": 7,
+      "table_num_cols": 5,
+      "text_head": "Table: Table 3-5. JTAG Signal Source Control\nColumns: JTAG Signal Source | EFUSE_DIS_PAD_JTAG | EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL | GPIO3\nRows: 6",
+      "markdown_head": "Table 3-5. JTAG Signal Source Control\n\n| JTAG Signal Source          |   EFUSE_DIS_PAD_JTAG |   EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL   | GPIO3   |\n|-----------------------------|----------------------|----------------------|-----------",
+      "markdown_len": 942
+    },
+    {
+      "table_group_id": "#/tables/11",
+      "section_path": "2.3.1 IO MUX Functions",
+      "table_caption": "Table 2-3. Peripheral Signals Routed via IO MUX",
+      "page_no": 20,
+      "page_bbox": [
+        55.7794075012207,
+        508.8037414550781,
+        546.2653198242188,
+        118.4287109375
+      ],
+      "table_num_rows": 8,
+      "table_num_cols": 3,
+      "text_head": "Table: Table 2-3. Peripheral Signals Routed via IO MUX\nColumns: Pin Function | Signal | Description\nRows: 7",
+      "markdown_head": "Table 2-3. Peripheral Signals Routed via IO MUX\n\n| Pin Function                                          | Signal                                                                         | Description                                         ",
+      "markdown_len": 3216
+    },
+    {
+      "table_group_id": "#/tables/5",
+      "section_path": "",
+      "table_caption": "",
+      "page_no": 12,
+      "page_bbox": [
+        69.79170989990234,
+        746.8679275512695,
+        538.8440551757812,
+        611.82080078125
+      ],
+      "table_num_rows": 9,
+      "table_num_cols": 3,
+      "text_head": "Columns: \nRows: 9",
+      "markdown_head": "| 1-1   | ESP32-S3 Series Nomenclature                              |   13 |\n|-------|-----------------------------------------------------------|------|\n| 2-1   | ESP32-S3 Pin Layout (Top View)                            |   15 |\n| 2-2   |",
+      "markdown_len": 769
+    }
+  ],
+  "determinism": {
+    "ok": true,
+    "first_count": 71,
+    "second_count": 71,
+    "diff_first_minus_second": [],
+    "diff_second_minus_first": []
+  },
+  "xref_edges": {
+    "total_chunks_with_edges": 558,
+    "total_edges": 681,
+    "edges_per_chunk_p50": 1,
+    "edges_per_chunk_p90": 1,
+    "by_type": {
+      "section": 114,
+      "table": 566,
+      "standard": 1
+    }
+  },
+  "xref_resolvability": {
+    "section_resolvable": 91,
+    "table_resolvable": 559,
+    "unresolvable_table_no_label": 7,
+    "unresolvable_figure": 0,
+    "unresolvable_appendix": 0
+  },
+  "caption_label_coverage": {
+    "tables_total": 71,
+    "tables_with_label": 54,
+    "label_rate": 0.7605633802816901
+  },
+  "errors": []
+}

--- a/docs/soak/table_chunking_real_datasheet_xref_2026-05-23_after_fix.md
+++ b/docs/soak/table_chunking_real_datasheet_xref_2026-05-23_after_fix.md
@@ -1,0 +1,136 @@
+# Table-chunking soak — real datasheet (2026-05-23)
+
+## Dataset
+
+- PDF: `/home/kok-shew-juan/RagWeave/.worktrees/table-aware-chunking/data/datasheets/esp32-s3_datasheet.pdf`
+- Source: Espressif ESP32-S3 datasheet (public, redistributable)
+- Size: 1,098,115 bytes
+- Pages: 87
+
+## Environment
+
+- Docling models ready: **True**
+
+## Counts
+
+| Metric | Value |
+|---|---|
+| total chunks emitted | 831 |
+| TableArtifact entries | 71 |
+| distinct `table_group_id`s | 71 |
+| `table_summary` chunks | 71 |
+| `table_row` chunks | 536 |
+| truncation events (V's guard) | 0 |
+
+## section_path breadcrumb depth distribution (over TableArtifacts)
+
+| heading levels | tables |
+|---|---|
+| 0 | 6 |
+| 1 | 65 |
+
+## Spot-checks (3 random `table_summary` chunks)
+
+### Sample 1 — `table_group_id='#/tables/28'`
+
+- section_path: `3.4 JTAG Signal Source Control`
+- caption: `'Table 3-5. JTAG Signal Source Control'`
+- page_no: `35`
+- page_bbox: `(55.898406982421875, 760.8178482055664, 559.1690063476562, 648.7037353515625)`
+- rows × cols: `7 × 5`
+- table_markdown length: `942` chars
+
+text excerpt:
+
+```
+Table: Table 3-5. JTAG Signal Source Control
+Columns: JTAG Signal Source | EFUSE_DIS_PAD_JTAG | EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL | GPIO3
+Rows: 6
+```
+
+markdown excerpt:
+
+```
+Table 3-5. JTAG Signal Source Control
+
+| JTAG Signal Source          |   EFUSE_DIS_PAD_JTAG |   EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL   | GPIO3   |
+|-----------------------------|----------------------|----------------------|-----------
+```
+
+### Sample 2 — `table_group_id='#/tables/11'`
+
+- section_path: `2.3.1 IO MUX Functions`
+- caption: `'Table 2-3. Peripheral Signals Routed via IO MUX'`
+- page_no: `20`
+- page_bbox: `(55.7794075012207, 508.8037414550781, 546.2653198242188, 118.4287109375)`
+- rows × cols: `8 × 3`
+- table_markdown length: `3216` chars
+
+text excerpt:
+
+```
+Table: Table 2-3. Peripheral Signals Routed via IO MUX
+Columns: Pin Function | Signal | Description
+Rows: 7
+```
+
+markdown excerpt:
+
+```
+Table 2-3. Peripheral Signals Routed via IO MUX
+
+| Pin Function                                          | Signal                                                                         | Description                                         
+```
+
+### Sample 3 — `table_group_id='#/tables/5'`
+
+- section_path: ``
+- caption: `''`
+- page_no: `12`
+- page_bbox: `(69.79170989990234, 746.8679275512695, 538.8440551757812, 611.82080078125)`
+- rows × cols: `9 × 3`
+- table_markdown length: `769` chars
+
+text excerpt:
+
+```
+Columns: 
+Rows: 9
+```
+
+markdown excerpt:
+
+```
+| 1-1   | ESP32-S3 Series Nomenclature                              |   13 |
+|-------|-----------------------------------------------------------|------|
+| 2-1   | ESP32-S3 Pin Layout (Top View)                            |   15 |
+| 2-2   |
+```
+
+## Determinism (cross-reparse)
+
+- Identical `table_group_id` set across two parses: **True**
+- first parse: 71 group_ids
+- second parse: 71 group_ids
+
+## Xref edges
+
+- chunks with edges: 558
+- total edges: 681
+- edges per chunk p50: 1
+- edges per chunk p90: 1
+- by type: section=114, standard=1, table=566
+
+## Xref resolvability
+
+- section resolvable: 91
+- table resolvable: 559
+- unresolvable table (no matching caption_label): 7
+- unresolvable figure: 0
+- unresolvable appendix: 0
+
+## Caption label coverage
+
+- tables total: 71
+- tables with caption_label: 54
+- label rate: 76.06%

--- a/scripts/soak_table_chunking.py
+++ b/scripts/soak_table_chunking.py
@@ -193,11 +193,17 @@ def _xref_resolvability(chunks: list, tables: list) -> dict:
     )
 
     # Index chunks by document_id → list of section_paths.
+    #
+    # ``section_path`` lives on the Chunk dataclass as a direct attribute —
+    # only table chunks redundantly copy it into ``extra_metadata``. Prose
+    # chunks do not. Prefer the direct attribute; keep the metadata fallback
+    # so callers/tests that stuff section_path into metadata still work.
+    # ``document_id`` is currently metadata-only on raw parser Chunks.
     section_paths_by_doc: dict[str, list[str]] = {}
     for c in chunks:
         meta = getattr(c, "extra_metadata", {}) or {}
         doc_id = str(meta.get("document_id") or "")
-        sp = str(meta.get("section_path") or "")
+        sp = str(getattr(c, "section_path", "") or "") or str(meta.get("section_path") or "")
         if sp:
             section_paths_by_doc.setdefault(doc_id, []).append(sp)
 

--- a/src/ingest/support/docling.py
+++ b/src/ingest/support/docling.py
@@ -62,6 +62,12 @@ def _stamp_xref_targets(meta: dict, text: str) -> None:
     The payload is a JSON-encoded ``list[{type, value}]`` (Weaviate's TEXT
     column doesn't support list-of-struct natively; the retrieval-side
     expander decodes it back).  Empty text yields ``"[]"``.
+
+    ``figure``-type refs are filtered when
+    ``RAG_XREF_EXTRACT_FIGURE_REFS`` is False — we don't have a
+    FigureArtifact registry to resolve against yet, so emitting them is
+    pure downstream noise.  Read the flag fresh on each call so tests can
+    monkeypatch ``config.settings`` without re-importing this module.
     """
     # Imported here to avoid widening the module's top-of-file dep graph.
     from src.ingest.common.shared import cross_refs
@@ -70,6 +76,16 @@ def _stamp_xref_targets(meta: dict, text: str) -> None:
         refs = cross_refs(text or "")
     except Exception:  # pragma: no cover - defensive
         refs = []
+
+    try:
+        from config import settings as _settings
+
+        emit_figures = bool(getattr(_settings, "RAG_XREF_EXTRACT_FIGURE_REFS", False))
+    except Exception:  # pragma: no cover - defensive
+        emit_figures = False
+    if not emit_figures:
+        refs = [r for r in refs if str((r or {}).get("type") or "") != "figure"]
+
     meta["xref_targets"] = json.dumps(refs)
 
 try:

--- a/tests/ingest/test_xref_targets_metadata.py
+++ b/tests/ingest/test_xref_targets_metadata.py
@@ -43,14 +43,19 @@ def test_encoded_payload_is_json_decodable_list_of_dicts():
         assert set(entry.keys()) == {"type", "value"}
 
 
-def test_prose_chunk_metadata_has_xref_targets_after_chunking():
+def test_prose_chunk_metadata_has_xref_targets_after_chunking(monkeypatch):
     """Smoke: invoke the ingest-side stamping function on a fake chunk dict
     and confirm xref_targets is populated.
 
     We reach into the small helper that ingest uses to populate metadata,
     not the full DoclingParser pipeline (which requires real docs).
     """
+    from config import settings as _settings
     from src.ingest.support.docling import _stamp_xref_targets
+
+    # Opt-in to figure refs for this assertion — the default-off gate is
+    # exercised by ``test_figure_refs_gated_out_by_default`` below.
+    monkeypatch.setattr(_settings, "RAG_XREF_EXTRACT_FIGURE_REFS", True)
 
     meta: dict = {}
     _stamp_xref_targets(meta, "see §3.1 and Figure 7-1")
@@ -66,3 +71,37 @@ def test_xref_stamp_on_empty_text_writes_empty_list():
     meta: dict = {}
     _stamp_xref_targets(meta, "")
     assert meta["xref_targets"] == "[]"
+
+
+def test_figure_refs_gated_out_by_default(monkeypatch):
+    """With ``RAG_XREF_EXTRACT_FIGURE_REFS`` False (the default), the
+    stamping helper must drop ``figure``-type refs while keeping every
+    other ref type.  Section refs and friends survive.
+    """
+    from config import settings as _settings
+    from src.ingest.support.docling import _stamp_xref_targets
+
+    monkeypatch.setattr(_settings, "RAG_XREF_EXTRACT_FIGURE_REFS", False)
+
+    meta: dict = {}
+    _stamp_xref_targets(meta, "see Figure 7-1 and §3.1")
+    decoded = json.loads(meta["xref_targets"])
+    assert all(r["type"] != "figure" for r in decoded), decoded
+    assert any(r["type"] == "section_symbol" for r in decoded), decoded
+
+
+def test_figure_refs_emitted_when_flag_enabled(monkeypatch):
+    """Flipping ``RAG_XREF_EXTRACT_FIGURE_REFS`` to True re-enables figure
+    emission, exercising the future code path once a FigureArtifact
+    registry exists.
+    """
+    from config import settings as _settings
+    from src.ingest.support.docling import _stamp_xref_targets
+
+    monkeypatch.setattr(_settings, "RAG_XREF_EXTRACT_FIGURE_REFS", True)
+
+    meta: dict = {}
+    _stamp_xref_targets(meta, "see Figure 7-1 and §3.1")
+    decoded = json.loads(meta["xref_targets"])
+    assert any(r["type"] == "figure" for r in decoded), decoded
+    assert any(r["type"] == "section_symbol" for r in decoded), decoded

--- a/tests/scripts/test_soak_xref_metrics.py
+++ b/tests/scripts/test_soak_xref_metrics.py
@@ -31,6 +31,10 @@ from scripts.soak_table_chunking import (
 class FakeChunk:
     text: str = ""
     extra_metadata: dict[str, Any] = field(default_factory=dict)
+    # Direct attribute mirrors the real ``Chunk.section_path`` field in
+    # ``src.ingest.support.parser_base`` — prose chunks only carry it here,
+    # not in ``extra_metadata``.
+    section_path: str = ""
 
 
 @dataclass
@@ -44,8 +48,11 @@ def _mk_chunk(targets: list[dict] | None = None, **meta: Any) -> FakeChunk:
     em: dict[str, Any] = {}
     if targets is not None:
         em["xref_targets"] = json.dumps(targets)
+    # ``section_path`` lives on Chunk as a direct attr in production; pull it
+    # out of the kwargs so the FakeChunk mirrors real-Chunk shape.
+    section_path = str(meta.pop("section_path", "") or "")
     em.update(meta)
-    return FakeChunk(extra_metadata=em)
+    return FakeChunk(extra_metadata=em, section_path=section_path)
 
 
 # --------------------------------------------------------------------------- #
@@ -138,6 +145,52 @@ class TestXrefResolvability:
             "unresolvable_figure": 0,
             "unresolvable_appendix": 0,
         }
+
+    def test_section_resolves_via_direct_section_path_attr(self):
+        # Regression for the 2026-05-23 ESP32-S3 soak bug: prose chunks
+        # carry ``section_path`` ONLY as a direct dataclass attribute, never
+        # in ``extra_metadata``. The resolvability check must prefer the
+        # direct attr.
+        chunks = [
+            FakeChunk(
+                extra_metadata={
+                    "document_id": "docA",
+                    "xref_targets": json.dumps(
+                        [{"type": "section", "value": "Section 3.4"}]
+                    ),
+                },
+                section_path="Chapter 3 > 3.4 Foo",
+            ),
+            FakeChunk(
+                extra_metadata={"document_id": "docA"},
+                section_path="Chapter 3 > 3.4 Foo",
+            ),
+        ]
+        r = _xref_resolvability(chunks, tables=[])
+        assert r["section_resolvable"] == 1
+
+    def test_section_resolves_via_extra_metadata_fallback(self):
+        # Backward-compat: callers that stuff section_path into
+        # ``extra_metadata`` (e.g. table-chunk metadata path) still resolve.
+        chunks = [
+            FakeChunk(
+                extra_metadata={
+                    "document_id": "docA",
+                    "section_path": "Chapter 3 > 3.4 Foo",
+                    "xref_targets": json.dumps(
+                        [{"type": "section", "value": "Section 3.4"}]
+                    ),
+                },
+            ),
+            FakeChunk(
+                extra_metadata={
+                    "document_id": "docA",
+                    "section_path": "Chapter 3 > 3.4 Foo",
+                },
+            ),
+        ]
+        r = _xref_resolvability(chunks, tables=[])
+        assert r["section_resolvable"] == 1
 
     def test_section_resolves_via_section_path(self):
         chunks = [


### PR DESCRIPTION
## Summary
- Flip `RAG_XREF_EXPANSION_ENABLED` default `false` → `true`. Justified by the post-fix ESP32-S3 soak: 98.8% table-ref resolution + 79.8% section-ref resolution.
- Gate figure xref emission behind `RAG_XREF_EXTRACT_FIGURE_REFS` (default `false`) — no `FigureArtifact` exists yet, so emitted figure refs were dangling noise.
- Fix `scripts/soak_table_chunking.py:_xref_resolvability` reading `section_path` from `extra_metadata`; `Chunk.section_path` is a direct dataclass attribute on prose chunks.

## Soak: pre-fix vs post-fix (ESP32-S3 datasheet)

| Metric | Pre | Post |
|---|---|---|
| `section_resolvable` | 0 | **91** |
| `xref_edges.by_type.figure` | 20 | **0** |
| `unresolvable_figure` | 20 | **0** |
| `total_edges` | 701 | 681 |
| `table_resolvable` | 559 | 559 |
| `caption_label_rate` | 76.06% | 76.06% |

Both transcripts committed under `docs/soak/`.

## Verdict
**GO** — all default-enable thresholds pass.

## Test plan
- [x] `_xref_resolvability` reads direct `Chunk.section_path` (+ falls back to extra_metadata for table chunks)
- [x] `_stamp_xref_targets` filters figure refs when flag is off; preserves them when on
- [x] `RAG_XREF_EXPANSION_ENABLED` default flip surfaces in settings tests
- [x] Re-soak confirms section_resolvable > 0 and figure noise eliminated
- [x] Scoped suite (`tests/ingest tests/retrieval tests/scripts`, not slow/integration): 2696 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)