### PR TITLE
fix(ingest): tighten table cross_ref pattern to reject 3-segment section headings

### DIFF
--- a/docs/soak/table_chunking_real_datasheet_xref_2026-05-25_after_fig7.json
+++ b/docs/soak/table_chunking_real_datasheet_xref_2026-05-25_after_fig7.json
@@ -1,0 +1,202 @@
+{
+  "pdf": {
+    "path": "/home/kok-shew-juan/RagWeave/.worktrees/table-aware-chunking/data/datasheets/esp32-s3_datasheet.pdf",
+    "size_bytes": 1098115,
+    "page_count": 87
+  },
+  "models_ready": true,
+  "models_error": null,
+  "parse_error": null,
+  "counts": {
+    "total_chunks": 841,
+    "tables": 71,
+    "summary_chunks": 71,
+    "row_chunks": 536,
+    "group_ids": 71
+  },
+  "heading_depth_distribution": {
+    "0": 6,
+    "1": 65
+  },
+  "truncation_events": 0,
+  "table_samples": [
+    {
+      "table_group_id": "#/tables/28",
+      "section_path": "3.4 JTAG Signal Source Control",
+      "table_caption": "Table 3-5. JTAG Signal Source Control",
+      "page_no": 35,
+      "page_bbox": [
+        55.898406982421875,
+        760.8178482055664,
+        559.1690063476562,
+        648.7037353515625
+      ],
+      "table_num_rows": 7,
+      "table_num_cols": 5,
+      "text_head": "Table: Table 3-5. JTAG Signal Source Control\nColumns: JTAG Signal Source | EFUSE_DIS_PAD_JTAG | EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL | GPIO3\nRows: 6",
+      "markdown_head": "Table 3-5. JTAG Signal Source Control\n\n| JTAG Signal Source          |   EFUSE_DIS_PAD_JTAG |   EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL   | GPIO3   |\n|-----------------------------|----------------------|----------------------|-----------",
+      "markdown_len": 942
+    },
+    {
+      "table_group_id": "#/tables/11",
+      "section_path": "2.3.1 IO MUX Functions",
+      "table_caption": "Table 2-3. Peripheral Signals Routed via IO MUX",
+      "page_no": 20,
+      "page_bbox": [
+        55.7794075012207,
+        508.8037414550781,
+        546.2653198242188,
+        118.4287109375
+      ],
+      "table_num_rows": 8,
+      "table_num_cols": 3,
+      "text_head": "Table: Table 2-3. Peripheral Signals Routed via IO MUX\nColumns: Pin Function | Signal | Description\nRows: 7",
+      "markdown_head": "Table 2-3. Peripheral Signals Routed via IO MUX\n\n| Pin Function                                          | Signal                                                                         | Description                                         ",
+      "markdown_len": 3216
+    },
+    {
+      "table_group_id": "#/tables/5",
+      "section_path": "",
+      "table_caption": "",
+      "page_no": 12,
+      "page_bbox": [
+        69.79170989990234,
+        746.8679275512695,
+        538.8440551757812,
+        611.82080078125
+      ],
+      "table_num_rows": 9,
+      "table_num_cols": 3,
+      "text_head": "Columns: \nRows: 9",
+      "markdown_head": "| 1-1   | ESP32-S3 Series Nomenclature                              |   13 |\n|-------|-----------------------------------------------------------|------|\n| 2-1   | ESP32-S3 Pin Layout (Top View)                            |   15 |\n| 2-2   |",
+      "markdown_len": 769
+    }
+  ],
+  "determinism": {
+    "ok": true,
+    "first_count": 71,
+    "second_count": 71,
+    "diff_first_minus_second": [],
+    "diff_second_minus_first": []
+  },
+  "xref_edges": {
+    "total_chunks_with_edges": 571,
+    "total_edges": 709,
+    "edges_per_chunk_p50": 1,
+    "edges_per_chunk_p90": 1,
+    "by_type": {
+      "section": 114,
+      "table": 567,
+      "figure": 27,
+      "standard": 1
+    }
+  },
+  "xref_resolvability": {
+    "section_resolvable": 97,
+    "table_resolvable": 559,
+    "unresolvable_table_no_label": 8,
+    "unresolvable_figure": 27,
+    "unresolvable_appendix": 0
+  },
+  "caption_label_coverage": {
+    "tables_total": 71,
+    "tables_with_label": 54,
+    "label_rate": 0.7605633802816901
+  },
+  "figure_soak": {
+    "counts": {
+      "figure_count": 85,
+      "figure_chunks_emitted": 10
+    },
+    "caption_coverage": {
+      "figures_total": 85,
+      "figures_with_label": 9,
+      "figures_with_caption": 10,
+      "label_rate": 0.10588235294117647,
+      "label_rate_of_captioned": 0.9
+    },
+    "caption_binding": {
+      "captioned_total": 10,
+      "via_fallback": 0,
+      "via_native": 10,
+      "fallback_share": 0.0
+    },
+    "section_distribution_top5": [
+      {
+        "section_path": "Feature List",
+        "count": 9
+      },
+      {
+        "section_path": "Cont'd from previous page",
+        "count": 6
+      },
+      {
+        "section_path": "7 Packaging",
+        "count": 4
+      },
+      {
+        "section_path": "6.2.2 Bluetooth LE RF Receiver (RX) Characteristics",
+        "count": 3
+      },
+      {
+        "section_path": "List of T ables",
+        "count": 2
+      }
+    ],
+    "idempotency": {
+      "ok": true,
+      "first_count": 85,
+      "second_count": 85,
+      "duplicates_within_parse": 0
+    },
+    "figure_image_uri_sanitized": true,
+    "mode_a": {
+      "figure_refs_emitted": 0,
+      "unique_targets": 0,
+      "resolved": 0,
+      "resolvable_rate": 0.0
+    },
+    "mode_b": {
+      "figure_refs_emitted": 18,
+      "unique_targets": 6,
+      "resolved": 6,
+      "resolvable_rate": 1.0
+    },
+    "verdict": {
+      "criteria": {
+        "figure_count_gt_0": {
+          "ok": true,
+          "value": 85,
+          "threshold": "> 0"
+        },
+        "figure_caption_label_rate_ge_0_30": {
+          "ok": false,
+          "value": 0.1059,
+          "threshold": ">= 0.30"
+        },
+        "figure_image_uri_sanitized": {
+          "ok": true,
+          "value": true,
+          "threshold": "true"
+        },
+        "figure_chunk_idempotent": {
+          "ok": true,
+          "value": true,
+          "threshold": "true"
+        },
+        "mode_a_emits_zero_figure_refs": {
+          "ok": true,
+          "value": 0,
+          "threshold": "== 0"
+        },
+        "mode_b_resolvable_rate_ge_0_30": {
+          "ok": true,
+          "value": 1.0,
+          "threshold": ">= 0.30"
+        }
+      },
+      "all_pass": false
+    }
+  },
+  "errors": []
+}

--- a/docs/soak/table_chunking_real_datasheet_xref_2026-05-25_after_fig7.md
+++ b/docs/soak/table_chunking_real_datasheet_xref_2026-05-25_after_fig7.md
@@ -1,0 +1,198 @@
+# Table-chunking soak — real datasheet (2026-05-25, after FIG-7)
+
+## FIG-7 verdict
+
+Preventative tightening of `_CROSS_REF_PATTERNS["table"]` with a trailing
+`(?![.-]\d)` negative lookahead, mirroring the PR #104 figure-pattern fix.
+
+| metric | baseline (origin/develop) | after FIG-7 | delta |
+|---|---|---|---|
+| total xref edges | 709 | 709 | 0 |
+| table edges emitted | 567 | 567 | 0 |
+| table_resolvable | 559 | 559 | 0 |
+| unresolvable_table_no_label | 8 | 8 | 0 |
+| table_resolvable_rate | 98.59% (559/567) | 98.59% (559/567) | 0.00% |
+
+Baseline soak: `docs/soak/table_chunking_real_datasheet_xref_2026-05-25_baseline.md`.
+Conclusion: **no real-PDF FP observed** on ESP32-S3 — fix is parity hardening
+only. No 3-segment "Table X.Y.Z" section headings appear in this datasheet.
+Rate is unchanged, confirming the lookahead does not reduce true positives.
+The structural risk identified in FIG-5 (identical regex shape to the figure
+pattern that DID misfire) is now closed at source.
+
+## Dataset
+
+- PDF: `/home/kok-shew-juan/RagWeave/.worktrees/table-aware-chunking/data/datasheets/esp32-s3_datasheet.pdf`
+- Source: Espressif ESP32-S3 datasheet (public, redistributable)
+- Size: 1,098,115 bytes
+- Pages: 87
+
+## Environment
+
+- Docling models ready: **True**
+
+## Counts
+
+| Metric | Value |
+|---|---|
+| total chunks emitted | 841 |
+| TableArtifact entries | 71 |
+| distinct `table_group_id`s | 71 |
+| `table_summary` chunks | 71 |
+| `table_row` chunks | 536 |
+| truncation events (V's guard) | 0 |
+
+## section_path breadcrumb depth distribution (over TableArtifacts)
+
+| heading levels | tables |
+|---|---|
+| 0 | 6 |
+| 1 | 65 |
+
+## Spot-checks (3 random `table_summary` chunks)
+
+### Sample 1 — `table_group_id='#/tables/28'`
+
+- section_path: `3.4 JTAG Signal Source Control`
+- caption: `'Table 3-5. JTAG Signal Source Control'`
+- page_no: `35`
+- page_bbox: `(55.898406982421875, 760.8178482055664, 559.1690063476562, 648.7037353515625)`
+- rows × cols: `7 × 5`
+- table_markdown length: `942` chars
+
+text excerpt:
+
+```
+Table: Table 3-5. JTAG Signal Source Control
+Columns: JTAG Signal Source | EFUSE_DIS_PAD_JTAG | EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL | GPIO3
+Rows: 6
+```
+
+markdown excerpt:
+
+```
+Table 3-5. JTAG Signal Source Control
+
+| JTAG Signal Source          |   EFUSE_DIS_PAD_JTAG |   EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL   | GPIO3   |
+|-----------------------------|----------------------|----------------------|-----------
+```
+
+### Sample 2 — `table_group_id='#/tables/11'`
+
+- section_path: `2.3.1 IO MUX Functions`
+- caption: `'Table 2-3. Peripheral Signals Routed via IO MUX'`
+- page_no: `20`
+- page_bbox: `(55.7794075012207, 508.8037414550781, 546.2653198242188, 118.4287109375)`
+- rows × cols: `8 × 3`
+- table_markdown length: `3216` chars
+
+text excerpt:
+
+```
+Table: Table 2-3. Peripheral Signals Routed via IO MUX
+Columns: Pin Function | Signal | Description
+Rows: 7
+```
+
+markdown excerpt:
+
+```
+Table 2-3. Peripheral Signals Routed via IO MUX
+
+| Pin Function                                          | Signal                                                                         | Description                                         
+```
+
+### Sample 3 — `table_group_id='#/tables/5'`
+
+- section_path: ``
+- caption: `''`
+- page_no: `12`
+- page_bbox: `(69.79170989990234, 746.8679275512695, 538.8440551757812, 611.82080078125)`
+- rows × cols: `9 × 3`
+- table_markdown length: `769` chars
+
+text excerpt:
+
+```
+Columns: 
+Rows: 9
+```
+
+markdown excerpt:
+
+```
+| 1-1   | ESP32-S3 Series Nomenclature                              |   13 |
+|-------|-----------------------------------------------------------|------|
+| 2-1   | ESP32-S3 Pin Layout (Top View)                            |   15 |
+| 2-2   |
+```
+
+## Determinism (cross-reparse)
+
+- Identical `table_group_id` set across two parses: **True**
+- first parse: 71 group_ids
+- second parse: 71 group_ids
+
+## Xref edges
+
+- chunks with edges: 571
+- total edges: 709
+- edges per chunk p50: 1
+- edges per chunk p90: 1
+- by type: figure=27, section=114, standard=1, table=567
+
+## Xref resolvability
+
+- section resolvable: 97
+- table resolvable: 559
+- unresolvable table (no matching caption_label): 8
+- unresolvable figure: 27
+- unresolvable appendix: 0
+
+## Caption label coverage
+
+- tables total: 71
+- tables with caption_label: 54
+- label rate: 76.06%
+
+## Figure-artifact soak (FIG-3)
+
+| Metric | Value |
+|---|---|
+| figure_count | 85 |
+| figure_chunks_emitted | 10 |
+| figures_with_caption_label | 9 |
+| figure_caption_label_rate | 10.59% |
+| figure_caption_label_rate_of_captioned | 90.00% (9/10) |
+| figure_caption_via_fallback_count | 0 (of 10 captioned; 0.00%) |
+| figure_caption_via_native_count | 10 |
+| figure_image_uri_sanitized | True |
+| figure_chunk_idempotent | True (85 ids, 0 dupes) |
+| mode_a figure_refs_emitted (flag off) | 0 |
+| mode_b figure_refs_emitted (flag on) | 18 |
+| mode_b unique_targets | 6 |
+| mode_b resolved | 6 |
+| mode_b resolvable_rate | 100.00% |
+
+### Top section_paths by figure count
+
+| section_path | figures |
+|---|---|
+| `Feature List` | 9 |
+| `Cont'd from previous page` | 6 |
+| `7 Packaging` | 4 |
+| `6.2.2 Bluetooth LE RF Receiver (RX) Characteristics` | 3 |
+| `List of T ables` | 2 |
+
+### Verdict criteria
+
+| criterion | threshold | actual | result |
+|---|---|---|---|
+| figure_count_gt_0 | > 0 | 85 | **PASS** |
+| figure_caption_label_rate_ge_0_30 | >= 0.30 | 0.1059 | **FAIL** |
+| figure_image_uri_sanitized | true | True | **PASS** |
+| figure_chunk_idempotent | true | True | **PASS** |
+| mode_a_emits_zero_figure_refs | == 0 | 0 | **PASS** |
+| mode_b_resolvable_rate_ge_0_30 | >= 0.30 | 1.0 | **PASS** |
+
+**FIG-3 verdict: FAIL** — see criteria table above.

--- a/docs/soak/table_chunking_real_datasheet_xref_2026-05-25_baseline.json
+++ b/docs/soak/table_chunking_real_datasheet_xref_2026-05-25_baseline.json
@@ -1,0 +1,202 @@
+{
+  "pdf": {
+    "path": "/home/kok-shew-juan/RagWeave/.worktrees/table-aware-chunking/data/datasheets/esp32-s3_datasheet.pdf",
+    "size_bytes": 1098115,
+    "page_count": 87
+  },
+  "models_ready": true,
+  "models_error": null,
+  "parse_error": null,
+  "counts": {
+    "total_chunks": 841,
+    "tables": 71,
+    "summary_chunks": 71,
+    "row_chunks": 536,
+    "group_ids": 71
+  },
+  "heading_depth_distribution": {
+    "0": 6,
+    "1": 65
+  },
+  "truncation_events": 0,
+  "table_samples": [
+    {
+      "table_group_id": "#/tables/28",
+      "section_path": "3.4 JTAG Signal Source Control",
+      "table_caption": "Table 3-5. JTAG Signal Source Control",
+      "page_no": 35,
+      "page_bbox": [
+        55.898406982421875,
+        760.8178482055664,
+        559.1690063476562,
+        648.7037353515625
+      ],
+      "table_num_rows": 7,
+      "table_num_cols": 5,
+      "text_head": "Table: Table 3-5. JTAG Signal Source Control\nColumns: JTAG Signal Source | EFUSE_DIS_PAD_JTAG | EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL | GPIO3\nRows: 6",
+      "markdown_head": "Table 3-5. JTAG Signal Source Control\n\n| JTAG Signal Source          |   EFUSE_DIS_PAD_JTAG |   EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL   | GPIO3   |\n|-----------------------------|----------------------|----------------------|-----------",
+      "markdown_len": 942
+    },
+    {
+      "table_group_id": "#/tables/11",
+      "section_path": "2.3.1 IO MUX Functions",
+      "table_caption": "Table 2-3. Peripheral Signals Routed via IO MUX",
+      "page_no": 20,
+      "page_bbox": [
+        55.7794075012207,
+        508.8037414550781,
+        546.2653198242188,
+        118.4287109375
+      ],
+      "table_num_rows": 8,
+      "table_num_cols": 3,
+      "text_head": "Table: Table 2-3. Peripheral Signals Routed via IO MUX\nColumns: Pin Function | Signal | Description\nRows: 7",
+      "markdown_head": "Table 2-3. Peripheral Signals Routed via IO MUX\n\n| Pin Function                                          | Signal                                                                         | Description                                         ",
+      "markdown_len": 3216
+    },
+    {
+      "table_group_id": "#/tables/5",
+      "section_path": "",
+      "table_caption": "",
+      "page_no": 12,
+      "page_bbox": [
+        69.79170989990234,
+        746.8679275512695,
+        538.8440551757812,
+        611.82080078125
+      ],
+      "table_num_rows": 9,
+      "table_num_cols": 3,
+      "text_head": "Columns: \nRows: 9",
+      "markdown_head": "| 1-1   | ESP32-S3 Series Nomenclature                              |   13 |\n|-------|-----------------------------------------------------------|------|\n| 2-1   | ESP32-S3 Pin Layout (Top View)                            |   15 |\n| 2-2   |",
+      "markdown_len": 769
+    }
+  ],
+  "determinism": {
+    "ok": true,
+    "first_count": 71,
+    "second_count": 71,
+    "diff_first_minus_second": [],
+    "diff_second_minus_first": []
+  },
+  "xref_edges": {
+    "total_chunks_with_edges": 571,
+    "total_edges": 709,
+    "edges_per_chunk_p50": 1,
+    "edges_per_chunk_p90": 1,
+    "by_type": {
+      "section": 114,
+      "table": 567,
+      "figure": 27,
+      "standard": 1
+    }
+  },
+  "xref_resolvability": {
+    "section_resolvable": 97,
+    "table_resolvable": 559,
+    "unresolvable_table_no_label": 8,
+    "unresolvable_figure": 27,
+    "unresolvable_appendix": 0
+  },
+  "caption_label_coverage": {
+    "tables_total": 71,
+    "tables_with_label": 54,
+    "label_rate": 0.7605633802816901
+  },
+  "figure_soak": {
+    "counts": {
+      "figure_count": 85,
+      "figure_chunks_emitted": 10
+    },
+    "caption_coverage": {
+      "figures_total": 85,
+      "figures_with_label": 9,
+      "figures_with_caption": 10,
+      "label_rate": 0.10588235294117647,
+      "label_rate_of_captioned": 0.9
+    },
+    "caption_binding": {
+      "captioned_total": 10,
+      "via_fallback": 0,
+      "via_native": 10,
+      "fallback_share": 0.0
+    },
+    "section_distribution_top5": [
+      {
+        "section_path": "Feature List",
+        "count": 9
+      },
+      {
+        "section_path": "Cont'd from previous page",
+        "count": 6
+      },
+      {
+        "section_path": "7 Packaging",
+        "count": 4
+      },
+      {
+        "section_path": "6.2.2 Bluetooth LE RF Receiver (RX) Characteristics",
+        "count": 3
+      },
+      {
+        "section_path": "List of T ables",
+        "count": 2
+      }
+    ],
+    "idempotency": {
+      "ok": true,
+      "first_count": 85,
+      "second_count": 85,
+      "duplicates_within_parse": 0
+    },
+    "figure_image_uri_sanitized": true,
+    "mode_a": {
+      "figure_refs_emitted": 0,
+      "unique_targets": 0,
+      "resolved": 0,
+      "resolvable_rate": 0.0
+    },
+    "mode_b": {
+      "figure_refs_emitted": 18,
+      "unique_targets": 6,
+      "resolved": 6,
+      "resolvable_rate": 1.0
+    },
+    "verdict": {
+      "criteria": {
+        "figure_count_gt_0": {
+          "ok": true,
+          "value": 85,
+          "threshold": "> 0"
+        },
+        "figure_caption_label_rate_ge_0_30": {
+          "ok": false,
+          "value": 0.1059,
+          "threshold": ">= 0.30"
+        },
+        "figure_image_uri_sanitized": {
+          "ok": true,
+          "value": true,
+          "threshold": "true"
+        },
+        "figure_chunk_idempotent": {
+          "ok": true,
+          "value": true,
+          "threshold": "true"
+        },
+        "mode_a_emits_zero_figure_refs": {
+          "ok": true,
+          "value": 0,
+          "threshold": "== 0"
+        },
+        "mode_b_resolvable_rate_ge_0_30": {
+          "ok": true,
+          "value": 1.0,
+          "threshold": ">= 0.30"
+        }
+      },
+      "all_pass": false
+    }
+  },
+  "errors": []
+}

--- a/docs/soak/table_chunking_real_datasheet_xref_2026-05-25_baseline.md
+++ b/docs/soak/table_chunking_real_datasheet_xref_2026-05-25_baseline.md
@@ -1,0 +1,178 @@
+# Table-chunking soak — real datasheet (2026-05-25)
+
+## Dataset
+
+- PDF: `/home/kok-shew-juan/RagWeave/.worktrees/table-aware-chunking/data/datasheets/esp32-s3_datasheet.pdf`
+- Source: Espressif ESP32-S3 datasheet (public, redistributable)
+- Size: 1,098,115 bytes
+- Pages: 87
+
+## Environment
+
+- Docling models ready: **True**
+
+## Counts
+
+| Metric | Value |
+|---|---|
+| total chunks emitted | 841 |
+| TableArtifact entries | 71 |
+| distinct `table_group_id`s | 71 |
+| `table_summary` chunks | 71 |
+| `table_row` chunks | 536 |
+| truncation events (V's guard) | 0 |
+
+## section_path breadcrumb depth distribution (over TableArtifacts)
+
+| heading levels | tables |
+|---|---|
+| 0 | 6 |
+| 1 | 65 |
+
+## Spot-checks (3 random `table_summary` chunks)
+
+### Sample 1 — `table_group_id='#/tables/28'`
+
+- section_path: `3.4 JTAG Signal Source Control`
+- caption: `'Table 3-5. JTAG Signal Source Control'`
+- page_no: `35`
+- page_bbox: `(55.898406982421875, 760.8178482055664, 559.1690063476562, 648.7037353515625)`
+- rows × cols: `7 × 5`
+- table_markdown length: `942` chars
+
+text excerpt:
+
+```
+Table: Table 3-5. JTAG Signal Source Control
+Columns: JTAG Signal Source | EFUSE_DIS_PAD_JTAG | EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL | GPIO3
+Rows: 6
+```
+
+markdown excerpt:
+
+```
+Table 3-5. JTAG Signal Source Control
+
+| JTAG Signal Source          |   EFUSE_DIS_PAD_JTAG |   EFUSE_DIS_USB_JTAG | EFUSE_STRAP_JTAG_SEL   | GPIO3   |
+|-----------------------------|----------------------|----------------------|-----------
+```
+
+### Sample 2 — `table_group_id='#/tables/11'`
+
+- section_path: `2.3.1 IO MUX Functions`
+- caption: `'Table 2-3. Peripheral Signals Routed via IO MUX'`
+- page_no: `20`
+- page_bbox: `(55.7794075012207, 508.8037414550781, 546.2653198242188, 118.4287109375)`
+- rows × cols: `8 × 3`
+- table_markdown length: `3216` chars
+
+text excerpt:
+
+```
+Table: Table 2-3. Peripheral Signals Routed via IO MUX
+Columns: Pin Function | Signal | Description
+Rows: 7
+```
+
+markdown excerpt:
+
+```
+Table 2-3. Peripheral Signals Routed via IO MUX
+
+| Pin Function                                          | Signal                                                                         | Description                                         
+```
+
+### Sample 3 — `table_group_id='#/tables/5'`
+
+- section_path: ``
+- caption: `''`
+- page_no: `12`
+- page_bbox: `(69.79170989990234, 746.8679275512695, 538.8440551757812, 611.82080078125)`
+- rows × cols: `9 × 3`
+- table_markdown length: `769` chars
+
+text excerpt:
+
+```
+Columns: 
+Rows: 9
+```
+
+markdown excerpt:
+
+```
+| 1-1   | ESP32-S3 Series Nomenclature                              |   13 |
+|-------|-----------------------------------------------------------|------|
+| 2-1   | ESP32-S3 Pin Layout (Top View)                            |   15 |
+| 2-2   |
+```
+
+## Determinism (cross-reparse)
+
+- Identical `table_group_id` set across two parses: **True**
+- first parse: 71 group_ids
+- second parse: 71 group_ids
+
+## Xref edges
+
+- chunks with edges: 571
+- total edges: 709
+- edges per chunk p50: 1
+- edges per chunk p90: 1
+- by type: figure=27, section=114, standard=1, table=567
+
+## Xref resolvability
+
+- section resolvable: 97
+- table resolvable: 559
+- unresolvable table (no matching caption_label): 8
+- unresolvable figure: 27
+- unresolvable appendix: 0
+
+## Caption label coverage
+
+- tables total: 71
+- tables with caption_label: 54
+- label rate: 76.06%
+
+## Figure-artifact soak (FIG-3)
+
+| Metric | Value |
+|---|---|
+| figure_count | 85 |
+| figure_chunks_emitted | 10 |
+| figures_with_caption_label | 9 |
+| figure_caption_label_rate | 10.59% |
+| figure_caption_label_rate_of_captioned | 90.00% (9/10) |
+| figure_caption_via_fallback_count | 0 (of 10 captioned; 0.00%) |
+| figure_caption_via_native_count | 10 |
+| figure_image_uri_sanitized | True |
+| figure_chunk_idempotent | True (85 ids, 0 dupes) |
+| mode_a figure_refs_emitted (flag off) | 0 |
+| mode_b figure_refs_emitted (flag on) | 18 |
+| mode_b unique_targets | 6 |
+| mode_b resolved | 6 |
+| mode_b resolvable_rate | 100.00% |
+
+### Top section_paths by figure count
+
+| section_path | figures |
+|---|---|
+| `Feature List` | 9 |
+| `Cont'd from previous page` | 6 |
+| `7 Packaging` | 4 |
+| `6.2.2 Bluetooth LE RF Receiver (RX) Characteristics` | 3 |
+| `List of T ables` | 2 |
+
+### Verdict criteria
+
+| criterion | threshold | actual | result |
+|---|---|---|---|
+| figure_count_gt_0 | > 0 | 85 | **PASS** |
+| figure_caption_label_rate_ge_0_30 | >= 0.30 | 0.1059 | **FAIL** |
+| figure_image_uri_sanitized | true | True | **PASS** |
+| figure_chunk_idempotent | true | True | **PASS** |
+| mode_a_emits_zero_figure_refs | == 0 | 0 | **PASS** |
+| mode_b_resolvable_rate_ge_0_30 | >= 0.30 | 1.0 | **PASS** |
+
+**FIG-3 verdict: FAIL** — see criteria table above.

--- a/src/ingest/common/shared.py
+++ b/src/ingest/common/shared.py
@@ -44,9 +44,14 @@ _CROSS_REF_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     # Require a digit immediately after the symbol (with optional single space)
     # so prose like "§abc" does not match.
     (re.compile(r"§\s?\d+(?:\.\d+){0,3}\b"), "section_symbol"),
-    # Table refs: "Table 5", "Table 5-2", "Table 5.2". Word-boundary on
-    # "Table" prevents matches inside "tablespoon".
-    (re.compile(r"\bTable\s+\d+(?:[.-]\d+)?\b", re.IGNORECASE), "table"),
+    # Table refs: "Table 5", "Table 5-2", "Table 5.2", "Table 10.3". Word
+    # boundary on "Table" prevents matches inside "tablespoon". The trailing
+    # negative lookahead `(?![.-]\d)` rejects 3-segment forms like
+    # "Table 4.1.2" or "Table 4-1.2" which in datasheets are section
+    # headings (e.g. "Table 4.1.2 Memory Organization"), not table
+    # citations — table numbers are at most two segments. Mirrors the
+    # figure-pattern fix in PR #104 as a preventative parity tightening.
+    (re.compile(r"\bTable\s+\d+(?:[.-]\d+)?\b(?![.-]\d)", re.IGNORECASE), "table"),
     # Figure refs: "Figure 7-1", "Fig 7-1", "Fig. 7-1", "Figure 10.3". Word
     # boundary on the head + required digit blocks "figurine". The trailing
     # negative lookahead `(?![.-]\d)` rejects 3-segment forms like

--- a/tests/ingest/test_cross_refs_patterns.py
+++ b/tests/ingest/test_cross_refs_patterns.py
@@ -73,6 +73,35 @@ class TestTablePattern:
         refs = cross_refs("add a tablespoon 5 of sugar")
         assert not any(r["type"] == "table" for r in refs)
 
+    def test_table_three_segment_dot_section_heading_does_not_match(self):
+        # Mirror of the figure-pattern FP: "Table 4.1.2 Memory Organization"
+        # is a section heading, not a table citation. Table numbers in
+        # datasheets are at most two segments (chapter.table or chapter-table).
+        refs = cross_refs("see Table 4.1.2 Memory Organization for details")
+        assert not any(r["type"] == "table" for r in refs)
+
+    def test_table_three_segment_dot_form_does_not_match(self):
+        refs = cross_refs("see Table 10.3.5 for details")
+        assert not any(r["type"] == "table" for r in refs)
+
+    def test_table_dash_then_dot_does_not_match(self):
+        # "Table 4-1.2" — dash form then a trailing dot-segment is rejected;
+        # genuine tables use either dash or dot, not both.
+        refs = cross_refs("see Table 4-1.2 here")
+        assert not any(r["type"] == "table" for r in refs)
+
+    def test_table_two_segment_dash_form_still_matches(self):
+        refs = cross_refs("see Table 4-1 for details")
+        assert any(r["type"] == "table" and r["value"].endswith("4-1") for r in refs)
+
+    def test_table_two_segment_dot_form_still_matches(self):
+        refs = cross_refs("see Table 4.1 for details")
+        assert any(r["type"] == "table" and r["value"].endswith("4.1") for r in refs)
+
+    def test_table_two_segment_dot_form_ten_three_still_matches(self):
+        refs = cross_refs("see Table 10.3 for details")
+        assert any(r["type"] == "table" and r["value"].endswith("10.3") for r in refs)
+
 
 # --- figure -------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Preventative parity fix mirroring PR #104 (figure pattern). The
`_CROSS_REF_PATTERNS["table"]` regex had the identical shape to the figure
pattern that misfired on real PDFs (matched `Table 4.1` out of the prose
`Table 4.1.2 Memory Organization`, a section heading). Add the same trailing
`(?![.-]\d)` negative lookahead so 3-segment forms no longer match while
genuine 1- and 2-segment citations still resolve.

This is a one-line emission-side fix in `src/ingest/common/shared.py` with
no resolver-side changes.

## Soak verdict (ESP32-S3, table soak path)

| metric | baseline (origin/develop) | after FIG-7 |
|---|---|---|
| table edges emitted | 567 | 567 |
| table_resolvable | 559 | 559 |
| table_resolvable_rate | 98.59% (559/567) | 98.59% (559/567) |

No real-PDF FP observed on ESP32-S3 today — the rate is unchanged. This is
preventative: the structural risk identified in the FIG-5 follow-up note (same
regex shape as the figure pattern that DID misfire on the same datasheet) is
closed at source before a real datasheet exhibits the pattern.

Soak transcripts: `docs/soak/table_chunking_real_datasheet_xref_2026-05-25_baseline.{md,json}`
and `docs/soak/table_chunking_real_datasheet_xref_2026-05-25_after_fig7.{md,json}`.

## TDD trace

Three failing negative tests added under `TestTablePattern` BEFORE the regex
change, plus three positive guards. Confirmed-fail on baseline pattern, all
green after fix:

- `test_table_three_segment_dot_section_heading_does_not_match` — `"Table 4.1.2 Memory Organization"` → no match
- `test_table_three_segment_dot_form_does_not_match` — `"Table 10.3.5"` → no match
- `test_table_dash_then_dot_does_not_match` — `"Table 4-1.2"` → no match
- `test_table_two_segment_dash_form_still_matches` — `"Table 4-1"` → match
- `test_table_two_segment_dot_form_still_matches` — `"Table 4.1"` → match
- `test_table_two_segment_dot_form_ten_three_still_matches` — `"Table 10.3"` → match

Existing negatives (`tablespoon`) still pass.

## Triggered by

Follow-up note in PR #104's FIG-5 final summary calling out that the table
pattern was structurally identical to the now-fixed figure pattern and
deserved the same parity tightening.

## Test plan
- [x] `uv run pytest -q tests/ingest/test_cross_refs_patterns.py` — 36 passed
- [x] `uv run pytest -q -m "not slow and not integration" tests/ingest/ tests/retrieval/ tests/vector_db/ tests/scripts/` — 2834 passed, 4 skipped
- [x] Re-soak on ESP32-S3 — table_resolvable_rate unchanged (98.59% → 98.59%)

Generated with Claude Code (Opus 4.7, 1M context).