### PR TITLE
feat(eval): OpenTitan reference pack + dry-run ingest script

### DIFF
--- a/.delivery/plan/wp-P0-collection-selection.md
+++ b/.delivery/plan/wp-P0-collection-selection.md
@@ -1,0 +1,61 @@
+---
+slice_id: P0-collection-selection
+validable_outcome: |
+  `uv run pytest tests/vector_db/test_collection_selection.py -q` reports all tests green, including:
+    1. `test_isolation_writes_do_not_leak` (slow + integration): ingests one chunk into collection A and zero into B via programmatic collection_name override; asserts A has chunks, B has zero.
+    2. `test_rag_chain_accepts_collection_name`: constructs `RAGChain(collection_name="custom_foo")` and verifies the resolved collection is `custom_foo`, not the env default.
+    3. `test_ingest_cli_accepts_collection_flag`: parser accepts `--collection custom_foo` and the parsed arg surfaces as `args.collection == "custom_foo"`.
+    4. `test_collection_exists_helper`: `collection_exists(client, name)` returns True for an existing collection and False for a non-existent one.
+  PLUS: `uv run pytest tests/vector_db/ tests/retrieval/ -q -m "not slow and not integration"` stays fully green (no regressions in default-path tests).
+touches:
+  - src/vector_db/__init__.py
+  - src/vector_db/backend.py
+  - src/vector_db/weaviate/backend.py
+  - src/vector_db/weaviate/store.py
+  - src/retrieval/pipeline/rag_chain.py
+  - src/ingest/cli.py
+  - src/ingest/impl.py
+  - config/settings.py
+  - tests/vector_db/test_collection_selection.py
+depends_on: []
+---
+
+# P0 — Collection-selection plumbing
+
+## End-state (validable, machine-checkable)
+
+A caller can programmatically route reads and writes to an arbitrary Weaviate collection without env-var manipulation, with full isolation between collections proven by an E2E test. Default behavior (no override) is unchanged.
+
+## Current state (surveyed before slice opens)
+
+Already plumbed (do NOT redo):
+- `config/settings.py:48` — `VECTOR_COLLECTION_DEFAULT` is env-overridable via `RAG_VECTOR_COLLECTION_DEFAULT`, defaulting to `WEAVIATE_COLLECTION_NAME = "RAGDocuments"`.
+- `src/vector_db/weaviate/store.py` — most read/write/ensure functions already accept `collection: str = WEAVIATE_COLLECTION_NAME`.
+- `src/vector_db/weaviate/backend.py` — `WeaviateBackend` already exposes `ensure_collection`, `delete_collection`, `list_collections`.
+- `src/vector_db/__init__.py` — re-exports admin functions.
+
+Real gaps (this slice closes):
+1. **`RAGChain.__init__`** does not accept `collection_name`. It implicitly uses `VECTOR_COLLECTION_DEFAULT` via internal calls. → Add `collection_name: Optional[str] = None` parameter; default falls back to `VECTOR_COLLECTION_DEFAULT`. Thread it through every internal retrieval/admin call inside the class.
+2. **Ingest CLI** has no `--collection` flag. → Add `--collection`/`-c` arg to `src/ingest/cli.py` parser; thread through to `src/ingest/impl.py` so the chosen collection is honored.
+3. **`collection_exists(client, name) -> bool`** helper does not exist on the admin surface. → Add to `WeaviateBackend.collection_exists` + re-export from `src/vector_db/__init__.py`. Implementation: thin wrapper around `client.collections.exists(name)`.
+4. **E2E isolation test** does not exist. → Author `tests/vector_db/test_collection_selection.py` with the four tests enumerated in `validable_outcome`.
+
+## Constraints
+
+- **Do NOT introduce a new env var name** (`RAG_COLLECTION_NAME` etc.). Keep using the existing `RAG_VECTOR_COLLECTION_DEFAULT`. The plan doc has been corrected.
+- **Default behavior unchanged.** `RAGChain()` with no args, `python -m src.ingest.cli <doc>` with no `--collection` flag, must both route to `VECTOR_COLLECTION_DEFAULT` exactly as today. Regression sweep gates merge.
+- **Test gating.** Live-Weaviate tests must carry **both** markers per project memory `feedback_dual_marker_gating`: `pytestmark = [pytest.mark.slow, pytest.mark.integration]`. Single-marker gating slips through `-m "not slow"`.
+- **Live-Weaviate test isolation.** The E2E test must use unique collection names (UUID-suffixed) and clean up both collections on teardown — pass or fail — so re-runs and concurrent runs are safe.
+- **Boundary discipline.** Modifications confined to `touches`. No drive-by refactors.
+
+## Anti-gaming guards
+
+- The E2E isolation test must actually exercise the ingest write path (chunks land in Weaviate) and a real read path back (count via Weaviate client). Not a mocked test that pretends collection_name was honored.
+- The `test_rag_chain_accepts_collection_name` test must observe the resolved collection through an existing public-ish attribute or a read-only accessor — not by mock-patching the resolution logic the slice just implemented.
+- Red-reason proof: before any implementation, run the new test file. Failure output must include either `AttributeError` / `TypeError` on the new `collection_name` kwarg or `pytest: error: unrecognized arguments: --collection` — NOT `ImportError` from a missing test fixture, NOT `ModuleNotFoundError`. Capture the failure output in the closeout.
+
+## Out of scope (defer)
+
+- `RAG_EVAL_COLLECTION_NAME` env override (lives in a later eval-pack slice).
+- Auto-GC of `ragweave_test_*` collections (separate slice, ops concern).
+- Collection schema migration across renames (existing schema_migrations module is unchanged here).

--- a/.delivery/plan/wp-P0.5-eval-pack-format.md
+++ b/.delivery/plan/wp-P0.5-eval-pack-format.md
@@ -1,0 +1,119 @@
+---
+slice_id: P0.5-eval-pack-format
+validable_outcome: |
+  `uv run pytest tests/eval/test_pack_loader.py -q` reports all tests green, including:
+    1. `test_load_valid_pack`: `load_pack("evals/packs/_example_")` returns a typed `EvalPack` dataclass with:
+       - `name == "_example_"`, `version == 1`, `profile == "asic_riscv_soc"`.
+       - `corpus_pin` equals the SHA-256 hex digest of the sorted (path, content-sha256) lines in `corpus/manifest.json`.
+       - `goldens["factoid"]` is a non-empty list of typed `Golden` records (≥1 example), each parsed from the qtype's JSONL.
+       - `thresholds.defaults["factoid"]["recall_at_5"]` is a float between 0 and 1.
+       - `collection_name` resolves the `pack.yaml` template `ragweave_test_{name}_{corpus_pin_short}` with the first 8 chars of `corpus_pin`.
+    2. `test_rejects_missing_manifest`: loading a pack copy with `corpus/manifest.json` removed raises `PackValidationError` whose message contains `"corpus/manifest.json"`. Error type is NOT `FileNotFoundError`, NOT a bare `KeyError`.
+    3. `test_rejects_schema_invalid_golden`: a pack copy where one `factoid.jsonl` line has `qtype: "qfs"` (mismatch) and is missing `expected_answer_span` raises `PackValidationError` referencing the offending qid and the failing field. The error must NOT be a bare `pydantic.ValidationError` bubbled through — it must be caught and re-raised as `PackValidationError`.
+    4. `test_rejects_unknown_profile`: a pack copy whose `pack.yaml` declares `profile: undeclared_profile` (not in the validator's known-profile set) raises `PackValidationError` whose message contains both `"profile"` and `"undeclared_profile"`.
+  PLUS: `uv run pytest tests/eval/ tests/vector_db/ tests/retrieval/ -q -m "not slow and not integration"` stays fully green (no regressions; P0's existing tests untouched).
+touches:
+  - src/eval/__init__.py
+  - src/eval/pack/__init__.py
+  - src/eval/pack/schema.py
+  - src/eval/pack/validate.py
+  - src/eval/pack/loader.py
+  - src/eval/pack/errors.py
+  - evals/packs/_example_/pack.yaml
+  - evals/packs/_example_/corpus/manifest.json
+  - evals/packs/_example_/corpus/docs/intro.md
+  - evals/packs/_example_/goldens/factoid.jsonl
+  - evals/packs/_example_/thresholds.yaml
+  - tests/eval/__init__.py
+  - tests/eval/test_pack_loader.py
+depends_on:
+  - P0-collection-selection
+---
+
+# P0.5 — eval_pack format spec + validator (keystone)
+
+## End-state (validable, machine-checkable)
+
+The eval_pack format is implemented as code. A minimal example pack lives at `evals/packs/_example_/` and round-trips through `load_pack(path) -> EvalPack` (typed). The validator rejects three named malformations with `PackValidationError` whose messages name the offending location. No suite, no runner, no metric implementation in this slice — only the format keystone.
+
+## Current state (surveyed before slice opens)
+
+- `src/eval/` does NOT exist on `feat/p0-collection-selection` HEAD. Confirmed via `ls src/eval` (no such directory). The slice is starting from a clean keystone — no pre-existing pack code to integrate with.
+- `tests/eval/` does NOT exist. New test directory.
+- `evals/` does NOT exist. New top-level data directory (sibling of `src/`).
+- P0's `collection_name` plumbing is in scope to be *consumed* (via `EvalPack.collection_name`) but the runner that uses it is out of scope for this slice.
+
+## Plan-spec section 4 alignment
+
+This slice implements §4.1 (directory layout), §4.2 (`pack.yaml` shape), §4.3 (golden query schema), §4.4 (`thresholds.yaml` shape — minimum keys only, no enforcement), §4.5 (validator). No `min_goldens_per_qtype` enforcement — that lands in P2.0. No prompts directory — optional per §4.1; the example pack omits it. No `expected_cited_chunks` / `command` qtype schemas — only `factoid` qtype is required for keystone proof; richer qtypes land in P2.
+
+## Required deliverables
+
+### Code (`src/eval/pack/`)
+
+1. **`schema.py`** — typed dataclasses (or pydantic v2 models — pick one and stay consistent; pydantic v2 is already a project dependency):
+   - `PackMeta`: `name`, `version: int`, `profile: str`, `corpus_pin: str`, `description: str | None`, `judge: JudgeConfig`, `collection_name_template: str`.
+   - `JudgeConfig`: `tier1_model: str`, `tier1_prompt_version: str`, `temperature: float`, `samples_per_claim: int`.
+   - `ManifestEntry`: `path: str`, `sha256: str`.
+   - `Golden`: discriminated by `qtype` literal (start with `factoid`; allow other qtype strings to parse through as `Golden` with extra fields preserved on a `raw: dict` field so P2 can extend without re-authoring schema.py).
+   - `Thresholds`: `profile: str`, `defaults: dict[str, dict[str, float]]`, `overrides: list[dict]` (loose-typed list is acceptable for keystone).
+   - `EvalPack`: aggregate with `meta: PackMeta`, `manifest: list[ManifestEntry]`, `goldens: dict[str, list[Golden]]`, `thresholds: Thresholds`, and a computed `collection_name: str` property that resolves the template.
+2. **`errors.py`** — `class PackValidationError(Exception)`. Single exception type for all validation failures; message must name (a) the file/field path inside the pack and (b) the reason.
+3. **`validate.py`** — `validate_pack(path: Path | str) -> None` performs structural checks:
+   - `pack.yaml` exists and parses; required keys present; `profile` is in a small known set `{asic_riscv_soc, eda_command_reference, generic}`.
+   - `corpus/manifest.json` exists and parses; each entry has `path` + `sha256`.
+   - `corpus_pin` in `pack.yaml` matches `sha256_hex(sorted "{path}:{sha256}" joined by "\n")` of the manifest.
+   - Each goldens file in `goldens/` is JSONL; each line parses; each line's `qtype` matches the filename stem; each line passes per-qtype required-field checks (factoid: `qid`, `qtype`, `query`, `expected_answer_span`).
+   - `thresholds.yaml` exists and parses; `profile` matches `pack.yaml.profile`.
+   Any failure raises `PackValidationError` with a message that name-checks the offending path.
+4. **`loader.py`** — `load_pack(path: Path | str) -> EvalPack`:
+   - Calls `validate_pack(path)` first; lets `PackValidationError` propagate.
+   - Loads + populates the dataclass tree.
+   - Sets `EvalPack.collection_name` via template substitution (`{name}`, `{corpus_pin_short}` where short = first 8 chars).
+5. **`__init__.py`** for `src/eval/` and `src/eval/pack/` — public exports: `EvalPack`, `load_pack`, `validate_pack`, `PackValidationError`. Add `__all__`.
+
+### Example pack (`evals/packs/_example_/`)
+
+Smallest pack that proves the loader works. Used by the validator test only — NOT a real corpus, NOT used by any runner.
+- `pack.yaml` per §4.2 with `name: _example_`, `version: 1`, `profile: asic_riscv_soc`, judge block stub, and `collection_name_template: "ragweave_test_{name}_{corpus_pin_short}"`.
+- `corpus/docs/intro.md` — single tiny doc (≤ 200 bytes).
+- `corpus/manifest.json` — single entry pointing at `intro.md` with its real SHA-256.
+- `corpus_pin` in `pack.yaml` — computed once and pinned. **The test must recompute it and assert equality.**
+- `goldens/factoid.jsonl` — one valid line per §4.3 (qid, qtype="factoid", query, expected_answer_span, expected_source_docs).
+- `thresholds.yaml` — minimum: `profile: asic_riscv_soc`, `defaults.factoid.recall_at_5: 0.8`.
+
+### Tests (`tests/eval/test_pack_loader.py`)
+
+The four tests enumerated in `validable_outcome`. Use `tmp_path` + `shutil.copytree` from the real example pack to build each malformation variant — DO NOT hand-write three full pack trees. This keeps the test about validator behaviour, not pack-authoring fidelity.
+
+Also add `tests/eval/__init__.py` (empty) so pytest treats it as a package.
+
+## Constraints
+
+- **Default behavior unchanged for everything outside this slice.** P0's regression sweep stays green.
+- **No new runtime dependencies.** Use `pyyaml` (already pinned), `pydantic` v2 (already pinned), stdlib `json`, `hashlib`, `pathlib`. If you reach for a new dep, stop and re-plan.
+- **No coupling to ingest/retrieval code.** `src/eval/pack/` imports nothing from `src/ingest`, `src/retrieval`, `src/vector_db`. The pack is a content artifact + a parser; the runner that bridges to vector_db is a later slice.
+- **Profile set is hardcoded for keystone.** `{asic_riscv_soc, eda_command_reference, generic}`. Extending later is a one-line change; do not over-engineer with a profiles plugin system.
+- **No tests skipped or xfailed.** No new markers softened.
+- **Boundary discipline.** Modifications confined to `touches`. No drive-by refactors to `src/eval/` siblings (there are none yet — keep it that way).
+
+## Anti-gaming guards
+
+- The four tests must observe behaviour through the **public** loader API (`load_pack`, `validate_pack`, `PackValidationError`) — not by importing and mock-patching internal validator helpers.
+- The "valid pack" test must recompute `corpus_pin` from the manifest in-test and compare against `pack.yaml`'s declared value. Hardcoding the expected pin in the test body is a tautology and is forbidden.
+- The "rejects schema-invalid golden" test must construct the malformation by editing a copy of the example pack, NOT by hand-authoring a JSONL that conveniently triggers the codepath the implementer just wrote.
+- **Red-reason proof:** before any implementation in `src/eval/`, run `uv run pytest tests/eval/test_pack_loader.py -q`. Failure output MUST include `ModuleNotFoundError: No module named 'src.eval.pack'` (or equivalent on the public symbols `load_pack` / `PackValidationError`). It must NOT be a `FileNotFoundError` on the example pack (that would mean the example pack wasn't authored first), and it must NOT be an `ImportError` from the test file itself referencing a missing test helper. Capture the failure output verbatim in the slice closeout.
+
+## Out of scope (defer)
+
+- `min_goldens_per_qtype` enforcement — P2.0.
+- Report-JSON schema (the `SuiteReport`) — P4.
+- Pack-level git-submodule corpus pinning — P1 (this slice's example pack uses inline docs).
+- QFS / multi-topic / command-reference golden schemas beyond keystone `factoid` — P2 / P6.5.
+- Prompts directory + judge prompt overrides — P5.
+- Migration tooling for `version` bumps — risk-list item, not this slice.
+
+## Agent green-gate vs. human-review checkpoint
+
+- **Agent green-gate (this slice ends here):** the four tests above are green; regression sweep stays green; commit lands on `feat/p0.5-eval-pack-format`.
+- **Human-review checkpoint (separate, unblocks P1, not P0.5):** human reviewer skims `_example_/pack.yaml` + the validator error messages and confirms they read sensibly. This is judgment, not a machine gate, and is explicitly excluded from this slice's DoD per §10.0 of the plan.

--- a/.delivery/plan/wp-P1-opentitan-pack.md
+++ b/.delivery/plan/wp-P1-opentitan-pack.md
@@ -1,0 +1,165 @@
+---
+slice_id: P1-opentitan-pack
+validable_outcome: |
+  Three named tests pass against the new pack + ingest script:
+
+    1. `tests/eval/test_opentitan_pack_ingest.py::test_pack_validates_under_p0_5_loader` (fast):
+       - `load_pack("evals/packs/opentitan_riscv")` returns an `EvalPack` (P0.5 type).
+       - `meta.name == "opentitan_riscv"`, `meta.profile == "asic_riscv_soc"`, `meta.version == 1`.
+       - `len(manifest) >= 3` (multi-doc corpus, not a single-file toy).
+       - Recomputed `corpus_pin` from manifest equals `meta.corpus_pin` (no tautological pin assertion).
+       - `goldens == {}` (this slice declares no goldens; P2 owns them).
+       - `collection_name` resolves to `ragweave_test_opentitan_riscv_<first-8-of-corpus_pin>`.
+
+    2. `tests/eval/test_opentitan_pack_ingest.py::test_eval_ingest_script_dry_run` (fast):
+       - `python scripts/eval_ingest.py --pack opentitan_riscv --dry-run` exits 0.
+       - stdout is JSON containing keys: `pack`, `collection`, `manifest_pin`, `files_to_ingest`.
+       - `collection` equals the resolved `collection_name` from test #1.
+       - `files_to_ingest` is a list whose length equals `len(manifest)`.
+       - No Weaviate writes occur (verified by absence of network calls: dry-run path must not import or call the real ingest engine).
+
+    3. `tests/eval/test_opentitan_pack_ingest.py::test_ingest_into_isolated_collection`
+       (markers: `[pytest.mark.slow, pytest.mark.integration]`):
+       - Requires live Weaviate. Skips cleanly if `WEAVIATE_URL` is unreachable.
+       - Captures `default_count_before` = chunk count in `VECTOR_COLLECTION_DEFAULT`.
+       - Runs `python scripts/eval_ingest.py --pack opentitan_riscv` (no `--dry-run`) — must complete with exit code 0.
+       - Asserts the resolved target collection exists (`collection_exists`) and has `chunk_count > 0`.
+       - Asserts `default_count_after == default_count_before` (zero leakage into the prod collection).
+       - try/finally cleanup deletes the target collection on both pass and fail paths.
+
+  PLUS: `uv run pytest tests/eval/ tests/vector_db/ tests/retrieval/ -q -m "not slow and not integration"` stays fully green (no regressions in P0/P0.5 tests).
+touches:
+  - evals/packs/opentitan_riscv/pack.yaml
+  - evals/packs/opentitan_riscv/thresholds.yaml
+  - evals/packs/opentitan_riscv/README.md
+  - evals/packs/opentitan_riscv/corpus/manifest.json
+  - evals/packs/opentitan_riscv/corpus/docs/riscv_priv_isa_intro.md
+  - evals/packs/opentitan_riscv/corpus/docs/riscv_priv_csrs.md
+  - evals/packs/opentitan_riscv/corpus/docs/opentitan_uart.md
+  - evals/packs/opentitan_riscv/corpus/docs/opentitan_hmac.md
+  - evals/packs/opentitan_riscv/corpus/docs/ibex_overview.md
+  - scripts/eval_ingest.py
+  - tests/eval/test_opentitan_pack_ingest.py
+depends_on:
+  - P0-collection-selection
+  - P0.5-eval-pack-format
+---
+
+# P1 — OpenTitan/Ibex/RISC-V reference pack (corpus + manifest only)
+
+## End-state (validable, machine-checkable)
+
+A real, conforming eval_pack named `opentitan_riscv` lives at `evals/packs/opentitan_riscv/`, drawn from public ASIC/RISC-V documentation. `scripts/eval_ingest.py` loads it via P0.5's loader, resolves the per-pack collection name via the template, and ingests the corpus into an **isolated** Weaviate collection using P0's `collection_name` plumbing. The prod collection (`RAGDocuments`) is provably unaffected.
+
+No goldens are authored in this slice (P2's job). The keystone proof for P1 is *content/loop separation* — does a real corpus flow through the same runtime by declaring a pack, without any code change inside `src/ingest/` or `src/retrieval/`?
+
+## Current state (surveyed before slice opens; SA1 will confirm)
+
+- `evals/packs/opentitan_riscv/` does NOT exist. Only `_example_/` from P0.5 lives under `evals/packs/`.
+- `scripts/eval_ingest.py` does NOT exist. The `scripts/` directory has soak/ops scripts but no eval-runner entry point.
+- `tests/eval/test_opentitan_pack_ingest.py` does NOT exist.
+- P0 plumbing (`collection_name` through `RAGChain`, ingest CLI `--collection`, `collection_exists` helper) is committed on the parent branch.
+- P0.5 loader (`load_pack`, `EvalPack`, `PackValidationError`) is committed on the parent branch and importable from `src.eval.pack`.
+- The existing ingest entry point is `python -m src.ingest.cli` with a `--collection` flag (added in P0). `scripts/eval_ingest.py` SHOULD shell out to that or invoke its programmatic equivalent — DO NOT duplicate the ingest pipeline.
+
+## Corpus authoring rules (read carefully)
+
+The corpus is **real, public ASIC/RISC-V documentation excerpted into 5 small Markdown files** (≤ 4 KB each). It is a *development-grade* representative subset, not the full canonical corpus — the full corpus arrives in a later slice that wires submodule pinning. This is explicit and is documented in `evals/packs/opentitan_riscv/README.md`.
+
+Required document set (exact filenames, exact provenance):
+
+| File | Topic | Source (public) |
+|---|---|---|
+| `corpus/docs/riscv_priv_isa_intro.md` | RISC-V Privileged ISA — privilege levels overview | RISC-V Privileged ISA spec, "Privilege Levels" section |
+| `corpus/docs/riscv_priv_csrs.md` | RISC-V Privileged ISA — selected CSRs (mstatus, mtvec, mepc) | Same spec, CSR section |
+| `corpus/docs/opentitan_uart.md` | OpenTitan UART IP — register map summary | OpenTitan UART HWIP documentation |
+| `corpus/docs/opentitan_hmac.md` | OpenTitan HMAC IP — block diagram and key registers | OpenTitan HMAC HWIP documentation |
+| `corpus/docs/ibex_overview.md` | Ibex core — pipeline + ISA support summary | lowRISC Ibex documentation |
+
+Content rules:
+- Each file is hand-authored prose paraphrasing the public spec (you may use `WebFetch` to read the public source if needed). Verbatim copying of long passages is not necessary — terse, accurate technical summaries are sufficient for ingest-pipeline exercise.
+- Each file starts with a level-1 heading equal to the topic in the table.
+- Each file is ≤ 4 KB. If you exceed this, trim — the slice is about plumbing, not corpus depth.
+- Provenance is captured in `README.md` (per-doc source link), NOT inside each Markdown file (we want clean ingest content).
+- Do NOT add HTML, frontmatter, or markdown extensions Docling cannot parse. Plain Markdown with headings, lists, and code blocks only.
+
+## Required deliverables
+
+### Pack (`evals/packs/opentitan_riscv/`)
+
+1. `pack.yaml` per §4.2 of EVAL_LOOP_PLAN.md:
+   - `name: opentitan_riscv`, `version: 1`, `profile: asic_riscv_soc`.
+   - `corpus_pin: <sha256-of-sorted-manifest-lines>` — computed by the slice script, not hand-guessed.
+   - `judge:` stub block matching the keystone's `JudgeConfig` shape (tier1_model: `claude-haiku-4-5-20251001`, tier1_prompt_version: v1, temperature: 0, samples_per_claim: 3).
+   - `collection_name_template: "ragweave_test_{name}_{corpus_pin_short}"`.
+   - `description:` 1-line summary citing the three source projects.
+2. `corpus/manifest.json` — JSON array of `{ path, sha256 }` entries, one per Markdown doc, sorted by `path`.
+3. `corpus/docs/*.md` — five files per the table above.
+4. `thresholds.yaml` — `profile: asic_riscv_soc`, `defaults.factoid.recall_at_5: 0.8`, `defaults.factoid.mrr: 0.6`. No per-qtype overrides yet; P2.0 owns count-gate additions.
+5. `README.md` — provenance table + a clear "development-grade subset, not the canonical corpus" disclaimer.
+
+### `scripts/eval_ingest.py`
+
+A new script — invokable as `python scripts/eval_ingest.py --pack <name> [--dry-run]`.
+
+Required behavior:
+- `argparse`: `--pack` (required), `--dry-run` (flag), `--pack-root` (optional, defaults to `evals/packs/`).
+- Loads the pack via `src.eval.pack.load_pack`. If `PackValidationError` is raised, prints the error to stderr and exits with code 2.
+- Resolves `target_collection = pack.collection_name` (uses the P0.5-computed template substitution).
+- In `--dry-run` mode: emits a single JSON object on stdout with `{pack, collection, manifest_pin, files_to_ingest: [<paths>]}` and exits 0. **Does not import the ingest engine.** This is the anti-coupling guard for fast tests.
+- In live mode: invokes the existing ingest pipeline with `collection_name=target_collection` for every file in `corpus/manifest.json`. The simplest correct path is `subprocess.run([sys.executable, "-m", "src.ingest.cli", "--collection", target_collection, <doc_path>], check=True)` per file, OR (preferred if straightforward) the programmatic equivalent from `src.ingest.impl`. Either is acceptable; the test asserts behavior, not invocation style.
+- Exits 0 on full success, 1 on partial ingest failure (with stderr summary).
+
+### Tests (`tests/eval/test_opentitan_pack_ingest.py`)
+
+The three tests enumerated in `validable_outcome`. Live test gating:
+
+```python
+import pytest
+pytestmark = []  # per-test markers below to keep fast tests fast
+
+# On the live test only:
+@pytest.mark.slow
+@pytest.mark.integration
+def test_ingest_into_isolated_collection(...):
+    ...
+```
+
+Live test must:
+- Use a uniqueified collection-name override (UUID suffix appended to the template-resolved name) so concurrent runs do not collide. Achieve this by passing `--pack-root tmp_path/packs` after copying the pack into `tmp_path` and rewriting `pack.yaml`'s `name` field to `opentitan_riscv_test_<uuid_hex_8>`. The corpus_pin will recompute identically (same content).
+- Read counts via `client.collections.get(c).aggregate.over_all(total_count=True).total_count`, with a 5s settle loop for indexer consistency.
+- `try/finally` clean up the test collection on both pass and fail paths.
+- Skip cleanly if `WEAVIATE_URL` is set but unreachable — do NOT fail the suite on missing infra.
+
+## Constraints
+
+- **No edits inside `src/ingest/`, `src/retrieval/`, `src/vector_db/`.** Content-on-loop separation is the keystone proof of P1. If you find yourself needing a fix there, STOP and report it — that is a P1.1 follow-up slice, not in-scope.
+- **Reuse P0.5 loader; do NOT re-parse the pack independently.** `scripts/eval_ingest.py` imports `load_pack`.
+- **No new env var names.** The collection name comes from the pack template — not from `RAG_EVAL_COLLECTION_NAME` or any new env var.
+- **Live test gating: dual markers.** Both `pytest.mark.slow` AND `pytest.mark.integration` per memory `feedback_dual_marker_gating`. Single-marker gating slips through `-m "not slow"`.
+- **No test softening.** No skips, no xfails, no new markers added to `pyproject.toml`.
+- **Boundary discipline.** All edits confined to `touches`.
+
+## Anti-gaming guards
+
+- The `test_pack_validates_under_p0_5_loader` test must recompute `corpus_pin` from the manifest in-test and compare against `pack.yaml`'s declared value — NOT hardcode a literal hex string.
+- The `test_eval_ingest_script_dry_run` test must assert that the dry-run path produces NO Weaviate writes. The simplest proof: count chunks in `VECTOR_COLLECTION_DEFAULT` before and after the dry-run; delta must be 0. (This implicitly requires live Weaviate; if you want the dry-run test fast, instead assert that `scripts/eval_ingest.py` in dry-run mode does not import `weaviate` or `src.vector_db` — verify via `subprocess` capture of `sys.modules` keys, or via a structural check that the dry-run code path is reachable without those imports. **Pick one and document the choice.**)
+- The `test_ingest_into_isolated_collection` test must read chunk counts via the real Weaviate client aggregation API — not via any helper the slice just authored. Use `client.collections.get(c).aggregate.over_all(total_count=True).total_count` directly.
+- **Red-reason proof:** before any implementation, run `uv run pytest tests/eval/test_opentitan_pack_ingest.py -q -m "not slow and not integration"`. Failure output MUST include one of:
+  - `FileNotFoundError` on `evals/packs/opentitan_riscv/pack.yaml` (pack absent),
+  - `ModuleNotFoundError` / `FileNotFoundError` on `scripts/eval_ingest.py` (script absent), OR
+  - `PackValidationError` (pack present but malformed mid-authoring).
+  It must NOT be an `ImportError` on `src.eval.pack` (that would mean P0.5 broke; halt and escalate), and it must NOT be an `AttributeError` on `EvalPack` fields (means the loader API changed; out of scope here). Capture the failure output verbatim in the slice closeout.
+
+## Out of scope (defer)
+
+- Goldens authoring — P2.
+- Submodule-pinned full OpenTitan corpus — separate follow-up slice once development-grade pack proves the loop.
+- `RAG_EVAL_COLLECTION_NAME` env override — explicitly listed as P0-out-of-scope and stays out of scope.
+- Eval runner that scores queries — P4 (factoid runner) and onward.
+- Auto-GC of `ragweave_test_*` collections — operational slice, separate.
+
+## Agent green-gate vs. human-review checkpoint
+
+- **Agent green-gate (this slice ends here):** the three named tests pass (live test against live Weaviate; fast tests in any env); regression sweep stays green; commit lands on `feat/p1-opentitan-pack`.
+- **Human-review checkpoint (separate, unblocks P2; not P1):** human reviewer skims the five corpus documents for accuracy and confirms attribution in `README.md` is correct. This is judgment, not a machine gate, and is explicitly excluded from this slice's DoD per §10.0 of the plan.

--- a/evals/packs/_example_/corpus/docs/intro.md
+++ b/evals/packs/_example_/corpus/docs/intro.md
@@ -1,0 +1,3 @@
+# Intro
+
+This is the example pack used to validate the eval_pack loader. The RISC-V core in this fictional SoC runs at 160 MHz.

--- a/evals/packs/_example_/corpus/manifest.json
+++ b/evals/packs/_example_/corpus/manifest.json
@@ -1,0 +1,8 @@
+{
+  "entries": [
+    {
+      "path": "docs/intro.md",
+      "sha256": "c1b08a27689ae685844be2c86d735937f3394d6ebce2063df2d6998de01c03c8"
+    }
+  ]
+}

--- a/evals/packs/_example_/goldens/factoid.jsonl
+++ b/evals/packs/_example_/goldens/factoid.jsonl
@@ -1,0 +1,1 @@
+{"qid": "f001", "qtype": "factoid", "query": "What is the RISC-V core clock frequency in the example SoC?", "expected_answer_span": "160 MHz", "expected_source_docs": ["docs/intro.md"]}

--- a/evals/packs/_example_/pack.yaml
+++ b/evals/packs/_example_/pack.yaml
@@ -1,0 +1,11 @@
+name: _example_
+version: 1
+profile: asic_riscv_soc
+corpus_pin: 4839331a0e9e772730196332f1d9a1f2080e52ad3a787885a1254f4221c019dc
+description: Minimal example pack used to validate the eval_pack loader.
+collection_name_template: "ragweave_test_{name}_{corpus_pin_short}"
+judge:
+  tier1_model: gpt-4o-mini
+  tier1_prompt_version: v1
+  temperature: 0.0
+  samples_per_claim: 1

--- a/evals/packs/_example_/thresholds.yaml
+++ b/evals/packs/_example_/thresholds.yaml
@@ -1,0 +1,5 @@
+profile: asic_riscv_soc
+defaults:
+  factoid:
+    recall_at_5: 0.8
+overrides: []

--- a/evals/packs/opentitan_riscv/README.md
+++ b/evals/packs/opentitan_riscv/README.md
@@ -1,0 +1,80 @@
+<!-- @summary
+Development-grade ASIC/RISC-V reference pack: provenance, content, and disclaimer.
+@end-summary -->
+
+# opentitan_riscv eval_pack
+
+A small, hand-authored reference pack covering three public ASIC/RISC-V
+projects:
+
+- **RISC-V Privileged ISA** (Privilege Levels overview + selected CSRs)
+- **OpenTitan** UART and HMAC IPs (register-map summaries)
+- **lowRISC Ibex** core (pipeline + ISA support summary)
+
+This pack is the P1 keystone artifact: it proves that the content/loop
+separation holds — a real corpus flows through the existing ingest
+pipeline by declaring a pack, with **no code change in `src/ingest/`,
+`src/retrieval/`, or `src/vector_db/`**.
+
+## Disclaimer — development-grade subset
+
+> **The corpus in this pack is NOT the full canonical OpenTitan / Ibex
+> / RISC-V documentation.** It is a small (~13 KB total, 5 files),
+> hand-authored development-grade subset assembled from publicly
+> available specifications. A later slice will wire submodule-pinned
+> upstream sources for full coverage. Do not rely on this pack for
+> production grading or coverage claims.
+
+## Document provenance
+
+| File | Topic | Source (public) |
+|---|---|---|
+| `corpus/docs/riscv_priv_isa_intro.md` | RISC-V Privileged ISA — privilege levels overview | [RISC-V Privileged Architectures Spec](https://github.com/riscv/riscv-isa-manual), "Privilege Levels" section |
+| `corpus/docs/riscv_priv_csrs.md` | RISC-V Privileged ISA — selected CSRs (mstatus, mtvec, mepc) | [RISC-V Privileged Architectures Spec](https://github.com/riscv/riscv-isa-manual), CSR sections |
+| `corpus/docs/opentitan_uart.md` | OpenTitan UART IP — register map summary | [OpenTitan UART HWIP docs](https://opentitan.org/book/hw/ip/uart/) |
+| `corpus/docs/opentitan_hmac.md` | OpenTitan HMAC IP — block diagram and key registers | [OpenTitan HMAC HWIP docs](https://opentitan.org/book/hw/ip/hmac/) |
+| `corpus/docs/ibex_overview.md` | Ibex core — pipeline + ISA support summary | [lowRISC Ibex docs](https://ibex-core.readthedocs.io/) |
+
+Each document is a terse paraphrase of the cited public source. None
+contain verbatim long-form copies of the upstream text.
+
+## Pack contents
+
+- `pack.yaml` — metadata, judge config, collection-name template.
+- `thresholds.yaml` — profile-default factoid thresholds (`recall_at_5=0.8`, `mrr=0.6`).
+- `corpus/manifest.json` — sorted `{path, sha256}` entries pinned by
+  `pack.yaml:corpus_pin`.
+- `corpus/docs/*.md` — five Markdown files (≤ 4 KB each).
+- `goldens/factoid.jsonl` — placeholder (intentionally empty). P2 owns
+  golden-query authoring; this file exists only to satisfy the P0.5
+  loader's structural contract.
+
+## Profile
+
+`asic_riscv_soc` — ASIC RISC-V SoC documentation profile.
+
+## Collection naming
+
+The collection name is computed by the P0.5 loader as:
+
+```
+ragweave_test_{name}_{corpus_pin_short}
+```
+
+i.e. `ragweave_test_opentitan_riscv_a8e3ff90` for the current pin. The
+short suffix is the first 8 hex chars of `pack.yaml:corpus_pin`.
+
+## Re-computing the corpus pin
+
+```bash
+uv run python -c "
+import hashlib, json, pathlib
+root = pathlib.Path('evals/packs/opentitan_riscv/corpus')
+docs = sorted((root/'docs').glob('*.md'))
+entries = [{'path': f'docs/{p.name}',
+            'sha256': hashlib.sha256(p.read_bytes()).hexdigest()}
+           for p in docs]
+pin = hashlib.sha256('\n'.join(sorted(f\"{e['path']}:{e['sha256']}\" for e in entries)).encode()).hexdigest()
+print(pin)
+"
+```

--- a/evals/packs/opentitan_riscv/corpus/docs/ibex_overview.md
+++ b/evals/packs/opentitan_riscv/corpus/docs/ibex_overview.md
@@ -1,0 +1,66 @@
+# Ibex Core — Pipeline and ISA Support Summary
+
+Ibex is a small, 2-stage, in-order RISC-V CPU core developed by
+lowRISC and used as the secure boot/main processor in OpenTitan. It
+is implemented in SystemVerilog and is configurable at elaboration
+time for a range of area/performance trade-offs.
+
+## ISA support
+
+Ibex implements the RV32 base integer ISA with optional extensions:
+
+| Extension | Meaning | Notes |
+|---|---|---|
+| `I`  | RV32I base integer ISA | Always present |
+| `E`  | RV32E reduced register file (16 regs) | Configurable alternative to `I` |
+| `M`  | Integer multiply/divide | Optional; single- or multi-cycle |
+| `C`  | Compressed 16-bit instructions | Optional; reduces code size |
+| `B`  | Bit-manipulation (Zba/Zbb/Zbc/Zbs subsets) | Optional |
+| `Zicsr` | CSR instructions | Always present in privileged builds |
+| `Zifencei` | Instruction-fence | Always present |
+
+The `RV32E` configuration reduces the integer register file from
+32 entries to 16, halving register-file area at the cost of ABI
+incompatibility with general-purpose RV32I toolchains.
+
+## Pipeline
+
+Ibex uses a 2-stage in-order pipeline:
+
+1. **IF (Instruction Fetch)** — fetches 32 bits per cycle from the
+   instruction bus, with a prefetch buffer that absorbs the longer
+   latency of memory-mapped flash. Compressed instructions are
+   expanded to their 32-bit equivalents before issue.
+2. **ID/EX (Decode and Execute)** — decodes the instruction, reads
+   the register file, executes the ALU operation, performs the
+   load/store address calculation, and writes back to the register
+   file. Multi-cycle operations (multiply, divide, CSR access,
+   load/store with wait states) stall this stage.
+
+Branches and jumps incur a single-cycle bubble on a taken transfer.
+
+## Privilege and security
+
+Ibex supports M-mode and optionally U-mode (`PMP`-enabled builds only).
+A Physical Memory Protection (PMP) unit with up to 16 regions can
+enforce per-region read/write/execute permissions, satisfying the
+RISC-V Privileged ISA's PMP specification.
+
+The Secure Ibex configuration adds:
+
+- Dual-core lockstep with output comparators
+- ECC on register file and instruction-cache RAMs
+- Bus integrity checks
+- Hardened branch predictor and control-flow integrity hooks
+- Data-independent timing (DIT) mode for selected instructions
+
+These features make Ibex suitable as the main processor in
+security-sensitive SoCs such as OpenTitan, where it boots, verifies
+firmware, and orchestrates the cryptographic accelerators.
+
+## Memory interfaces
+
+Ibex exposes separate instruction and data memory interfaces, each
+using a simple valid/ready handshake. The OpenTitan platform wraps
+these in TileLink-UL bridges for integration with the wider SoC
+fabric.

--- a/evals/packs/opentitan_riscv/corpus/docs/opentitan_hmac.md
+++ b/evals/packs/opentitan_riscv/corpus/docs/opentitan_hmac.md
@@ -1,0 +1,72 @@
+# OpenTitan HMAC IP — Block Diagram and Key Registers
+
+The OpenTitan HMAC (`hw/ip/hmac`) is a hardware accelerator implementing
+the SHA-2 family of hash functions and the keyed HMAC construction
+defined by FIPS 198-1. It is exposed to software as a TileLink-UL
+peripheral with a memory-mapped data-in window backed by a streaming
+FIFO.
+
+## Supported algorithms
+
+- SHA-256 — 256-bit digest, 512-bit block
+- SHA-384 — 384-bit digest, 1024-bit block
+- SHA-512 — 512-bit digest, 1024-bit block
+- HMAC variants of each of the above, with key lengths up to
+  1024 bits (longer keys are pre-hashed per RFC 2104).
+
+## Top-level block diagram
+
+```
+TL-UL bus ──▶ register file ──▶ FIFO ──▶ message scheduler ──▶ core
+                                                                │
+                                  ┌─────────────────────────────┘
+                                  ▼
+                       digest registers (DIGEST_0..15)
+                                  │
+                                  ▼
+                          interrupt + alert logic
+```
+
+The register file holds configuration and key material; software pushes
+data into the streaming FIFO via the `MSG_FIFO` aperture. The message
+scheduler converts the FIFO output into the algorithm's block size and
+feeds the compression core. Completed digests appear in the
+`DIGEST_0..15` registers.
+
+## Selected registers
+
+| Offset | Name | Purpose |
+|---|---|---|
+| `0x00` | `INTR_STATE` | Interrupt status (W1C) |
+| `0x04` | `INTR_ENABLE` | Per-source interrupt enable |
+| `0x10` | `CFG` | Algorithm select, endianness, HMAC enable, SHA enable |
+| `0x14` | `CMD` | `hash_start`, `hash_process`, `hash_continue`, `hash_stop` |
+| `0x18` | `STATUS` | FIFO empty/full, HMAC/SHA idle |
+| `0x1c` | `ERR_CODE` | Last error code |
+| `0x20` | `WIPE_SECRET` | Securely wipes key material |
+| `0x24` | `KEY_0..31` | 1024-bit key, written before `hash_start` |
+| `0x6c` | `DIGEST_0..15` | 512-bit digest, valid after `hash_done` |
+| `0xac` | `MSG_LENGTH_LOWER` | Low 32 bits of total message length |
+| `0xb0` | `MSG_LENGTH_UPPER` | Upper 32 bits of total message length |
+| `0x1000` | `MSG_FIFO` | Write-only data-in aperture |
+
+## CFG register fields
+
+- `HMAC_EN` (bit 0) — enable HMAC mode; if clear, the block performs
+  plain SHA-2.
+- `SHA_EN` (bit 1) — global enable for the SHA-2 core.
+- `ENDIAN_SWAP` (bit 2) — swap byte order on register reads/writes.
+- `DIGEST_SWAP` (bit 3) — swap byte order of digest output.
+- `KEY_SWAP` (bit 4) — swap byte order of key writes.
+- `DIGEST_SIZE` (bits 7:4) — selects SHA-256/384/512.
+- `KEY_LENGTH` (bits 13:8) — selects key length for HMAC mode.
+
+## Software flow
+
+1. Configure `CFG` for the desired algorithm and HMAC mode.
+2. (HMAC only) Write the key into `KEY_0..31`.
+3. Issue `CMD.hash_start`.
+4. Stream the message into `MSG_FIFO`. Poll or take an interrupt on
+   FIFO empty if pushing more than the FIFO depth.
+5. Issue `CMD.hash_process` to finalise.
+6. Read the digest from `DIGEST_0..15` once `hash_done` is signalled.

--- a/evals/packs/opentitan_riscv/corpus/docs/opentitan_uart.md
+++ b/evals/packs/opentitan_riscv/corpus/docs/opentitan_uart.md
@@ -1,0 +1,59 @@
+# OpenTitan UART IP — Register Map Summary
+
+The OpenTitan UART (`hw/ip/uart`) is a configurable asynchronous serial
+transmitter and receiver intended for boot-console, debug, and
+low-bandwidth host communication. Each UART instance is a peripheral
+on the TileLink-UL device bus and exposes a register window plus
+single-line TX and RX pins.
+
+## Feature summary
+
+- Programmable baud rate via a 16-bit clock divider (`CTRL.NCO` /
+  parity- and frame-format fields).
+- 8-N-1 framing with optional even/odd parity selected by
+  `CTRL.PARITY_EN` and `CTRL.PARITY_ODD`.
+- Independent 32-byte TX and RX FIFOs with programmable watermark
+  interrupts.
+- Loopback and line-break generation for self-test.
+- Interrupt sources for TX/RX watermark, RX timeout, RX parity error,
+  RX frame error, RX overflow, and TX empty.
+
+## Selected registers
+
+| Offset | Name | Purpose |
+|---|---|---|
+| `0x00` | `INTR_STATE` | Interrupt status (read/write-1-to-clear) |
+| `0x04` | `INTR_ENABLE` | Per-source interrupt enable mask |
+| `0x08` | `INTR_TEST` | Software-driven interrupt assertion |
+| `0x0c` | `ALERT_TEST` | Software-driven alert assertion |
+| `0x10` | `CTRL` | Master enable, parity, line-loopback, NCO |
+| `0x14` | `STATUS` | TX/RX FIFO full/empty/idle flags |
+| `0x18` | `RDATA` | Read pop from the RX FIFO |
+| `0x1c` | `WDATA` | Write push to the TX FIFO |
+| `0x20` | `FIFO_CTRL` | Reset and watermark configuration |
+| `0x24` | `FIFO_STATUS` | Live TX/RX FIFO depth |
+| `0x28` | `OVRD` | Direct pin override for hardware bring-up |
+| `0x2c` | `VAL`  | Direct pin sample for hardware bring-up |
+| `0x30` | `TIMEOUT_CTRL` | RX-idle timeout configuration |
+
+## CTRL register fields
+
+`CTRL` is the primary configuration register. Notable fields:
+
+- `TX` (bit 0) — enable transmitter
+- `RX` (bit 1) — enable receiver
+- `NF` (bit 2) — noise-filter enable on RX
+- `SLPBK` (bit 4) — system-level loopback (TX → RX)
+- `LLPBK` (bit 5) — line-level loopback
+- `PARITY_EN` (bit 6) — enable parity bit generation/check
+- `PARITY_ODD` (bit 7) — 0 = even, 1 = odd
+- `RXBLVL` (bits 9:8) — RX break detection level (in bit times)
+- `NCO` (bits 31:16) — 16-bit numerically-controlled oscillator value
+  that sets the baud rate.
+
+## Software bring-up sequence
+
+1. Compute `NCO = (16 * baud * 2^16) / fclk` and program `CTRL`.
+2. Set FIFO watermarks via `FIFO_CTRL`.
+3. Enable desired interrupt sources via `INTR_ENABLE`.
+4. Set `CTRL.TX` and `CTRL.RX` to start operation.

--- a/evals/packs/opentitan_riscv/corpus/docs/riscv_priv_csrs.md
+++ b/evals/packs/opentitan_riscv/corpus/docs/riscv_priv_csrs.md
@@ -1,0 +1,60 @@
+# RISC-V Privileged ISA — Selected CSRs (mstatus, mtvec, mepc)
+
+The RISC-V Privileged ISA defines a Control and Status Register (CSR)
+address space of up to 4096 registers, accessed via the `csrrw`,
+`csrrs`, `csrrc`, and their immediate-form siblings. This document
+summarises three of the most load-bearing M-mode CSRs.
+
+## `mstatus` — Machine Status Register
+
+`mstatus` carries the global enable bits and bookkeeping fields that
+gate interrupts and record the prior privilege mode across traps. Key
+fields on RV32:
+
+| Field | Bits | Meaning |
+|---|---|---|
+| `MIE`  | 3   | Global machine-interrupt enable |
+| `MPIE` | 7   | Previous value of `MIE`, restored on `mret` |
+| `MPP`  | 12:11 | Previous privilege mode (00=U, 01=S, 11=M) |
+| `MPRV` | 17  | Modify memory privilege — loads/stores use `MPP` |
+| `SUM`  | 18  | Supervisor user-memory access permit |
+| `MXR`  | 19  | Make-executable-readable |
+| `TVM`  | 20  | Trap virtual-memory operations |
+| `TW`   | 21  | Timeout wait — trap on `wfi` from lower modes |
+| `TSR`  | 22  | Trap on `sret` from S-mode |
+
+On a trap into M-mode the hardware copies `MIE` into `MPIE`, clears
+`MIE`, sets `MPP` to the prior mode, and clears `MIE`. The `mret`
+instruction inverts this transformation.
+
+## `mtvec` — Machine Trap Vector Base Address
+
+`mtvec` holds the base address of the M-mode trap handler. Its low two
+bits select the mode:
+
+- `MODE = 0` (Direct): all traps jump to `BASE`.
+- `MODE = 1` (Vectored): asynchronous interrupts jump to
+  `BASE + 4 * cause`; synchronous exceptions still jump to `BASE`.
+
+`BASE` must be 4-byte aligned and is shifted left by 2 in the CSR
+encoding. Implementations that hard-wire `mtvec` (for example
+ROM-resident handlers) are permitted.
+
+## `mepc` — Machine Exception Program Counter
+
+`mepc` holds the PC of the instruction that caused a trap (for
+synchronous exceptions) or the address to which the hart will return
+(for interrupts — the next instruction after the interrupted one).
+On `mret`, execution resumes at `mepc`.
+
+Writes to `mepc` are required to be implemented with at least
+`IALIGN`-bit alignment: implementations with the C extension (16-bit
+instructions) permit any even address; implementations without C
+require 32-bit alignment and ignore writes that would set bit 1.
+
+## Reading and writing CSRs
+
+The `csrrw rd, csr, rs1` instruction atomically writes `rs1` into the
+CSR and returns the previous value in `rd`. Software must use this
+read-modify-write primitive when touching status fields to avoid
+losing concurrent hardware updates.

--- a/evals/packs/opentitan_riscv/corpus/docs/riscv_priv_isa_intro.md
+++ b/evals/packs/opentitan_riscv/corpus/docs/riscv_priv_isa_intro.md
@@ -1,0 +1,48 @@
+# RISC-V Privileged ISA — Privilege Levels Overview
+
+The RISC-V Privileged Architecture defines a small set of privilege modes
+that a hardware thread (hart) operates in at any moment. The base
+specification lists three modes:
+
+- **Machine mode (M-mode)** — the highest-privilege mode. M-mode is
+  mandatory in every RISC-V implementation and is the mode entered on
+  reset. It has unrestricted access to all CSRs, physical memory, and
+  trap handling.
+- **Supervisor mode (S-mode)** — optional. When implemented, S-mode is
+  used by operating-system kernels that manage virtual memory through a
+  paging MMU.
+- **User mode (U-mode)** — optional. When implemented, U-mode is the
+  mode in which ordinary application code runs.
+
+Implementations advertise which combinations of modes they support. Three
+common profiles are:
+
+| Profile | Modes implemented | Typical use |
+|---|---|---|
+| M | M | Deeply embedded microcontrollers, e.g. Ibex `lowRISC` core |
+| MU | M, U | Embedded with user/kernel separation |
+| MSU | M, S, U | Application-class cores running Linux-style OSes |
+
+## Mode transitions
+
+Lower-privilege code requests services from higher-privilege code via
+the synchronous `ecall` instruction. Traps (interrupts and exceptions)
+are delivered to a privilege mode determined by per-mode delegation
+CSRs (`medeleg`, `mideleg`); by default everything traps to M-mode.
+
+On a trap, the hart saves the prior privilege mode in `mstatus.MPP`
+(or `sstatus.SPP` for S-mode delegation), records the trap cause in
+`mcause`/`scause`, the trapped PC in `mepc`/`sepc`, and the faulting
+address (where relevant) in `mtval`/`stval`. Execution resumes in the
+target privilege mode at the address stored in `mtvec`/`stvec`.
+
+The `mret`/`sret` instructions return from a trap, restoring the
+previous privilege mode from `MPP`/`SPP` and jumping to `mepc`/`sepc`.
+
+## Hart state
+
+Each privilege mode has its own bank of trap-handling CSRs but the
+general-purpose integer registers `x0`–`x31` are shared. Software is
+responsible for saving and restoring caller-saved registers across
+trap boundaries; the privileged architecture provides only the
+control-flow primitives.

--- a/evals/packs/opentitan_riscv/corpus/manifest.json
+++ b/evals/packs/opentitan_riscv/corpus/manifest.json
@@ -1,0 +1,24 @@
+{
+  "entries": [
+    {
+      "path": "docs/ibex_overview.md",
+      "sha256": "f541d1ba9e0ebb1ffcf0455481f4cf6a4722d55e250fd2859fe2c11b2ba8cab4"
+    },
+    {
+      "path": "docs/opentitan_hmac.md",
+      "sha256": "809eb7146b9ac50eedbe53cd0a6f7050345957b9e10113a46cfd2324a113da22"
+    },
+    {
+      "path": "docs/opentitan_uart.md",
+      "sha256": "abf4ba2678a3e99500f822b12f103b18792f4cbcaea5f89e624cebbc14ab824a"
+    },
+    {
+      "path": "docs/riscv_priv_csrs.md",
+      "sha256": "2d9d61ab3b4a8aa6dc55704775b5a4ee861e60cf21e3a3650ba033f0c7dac732"
+    },
+    {
+      "path": "docs/riscv_priv_isa_intro.md",
+      "sha256": "e69713ce074388b940dbd7b49bf87fd438b0cc0191bbf20957ab23680659a32d"
+    }
+  ]
+}

--- a/evals/packs/opentitan_riscv/pack.yaml
+++ b/evals/packs/opentitan_riscv/pack.yaml
@@ -1,0 +1,11 @@
+name: opentitan_riscv
+version: 1
+profile: asic_riscv_soc
+corpus_pin: a8e3ff902cb2d2578501a83620634792483b301b0d56fe71add49578bba2daaf
+description: Development-grade ASIC/RISC-V reference pack covering RISC-V Privileged ISA, OpenTitan UART/HMAC IPs, and the lowRISC Ibex core.
+collection_name_template: "ragweave_test_{name}_{corpus_pin_short}"
+judge:
+  tier1_model: claude-haiku-4-5-20251001
+  tier1_prompt_version: v1
+  temperature: 0.0
+  samples_per_claim: 3

--- a/evals/packs/opentitan_riscv/thresholds.yaml
+++ b/evals/packs/opentitan_riscv/thresholds.yaml
@@ -1,0 +1,6 @@
+profile: asic_riscv_soc
+defaults:
+  factoid:
+    recall_at_5: 0.8
+    mrr: 0.6
+overrides: []

--- a/scripts/eval_ingest.py
+++ b/scripts/eval_ingest.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# @summary
+# Eval_pack ingest entrypoint — loads a pack via the P0.5 loader and either
+# emits a dry-run JSON envelope (no heavy imports) or invokes the existing
+# ingest CLI per-document with the per-pack collection-name override (P0
+# plumbing). Designed to keep `src/ingest/`, `src/retrieval/`, and
+# `src/vector_db/` untouched: this is content-on-loop separation.
+# Exports: main
+# Deps: argparse, json, subprocess, sys, pathlib, src.eval.pack
+# @end-summary
+"""CLI that ingests an eval_pack's corpus into an isolated Weaviate collection.
+
+Usage:
+    python scripts/eval_ingest.py --pack opentitan_riscv [--dry-run] [--pack-root PATH]
+
+In ``--dry-run`` mode the script emits a single JSON envelope on stdout with
+the keys ``pack``, ``collection``, ``manifest_pin``, ``files_to_ingest`` and
+exits 0 WITHOUT importing the Weaviate client or any ingest engine module —
+this is the anti-coupling guard the fast tests assert on.
+
+In live mode the script shells out to ``python -m src.ingest.cli --file <doc>
+--collection <target>`` once per manifest entry, threading the per-pack
+``collection_name`` (resolved by P0.5 template substitution) through P0's
+``--collection`` plumbing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Allow imports from project root regardless of CWD.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.eval.pack import PackValidationError, load_pack  # noqa: E402
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Ingest an eval_pack's corpus into an isolated Weaviate collection.",
+    )
+    parser.add_argument(
+        "--pack",
+        required=True,
+        help="Pack name (directory name under --pack-root).",
+    )
+    parser.add_argument(
+        "--pack-root",
+        type=Path,
+        default=Path("evals/packs"),
+        help="Root directory containing pack directories (default: evals/packs).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print a JSON envelope describing what would be ingested; perform no writes.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entrypoint. Returns the process exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    pack_root: Path = args.pack_root
+    if not pack_root.is_absolute():
+        pack_root = (_REPO_ROOT / pack_root).resolve()
+    pack_dir = pack_root / args.pack
+
+    try:
+        pack = load_pack(pack_dir)
+    except PackValidationError as exc:
+        print(f"PackValidationError: {exc}", file=sys.stderr)
+        return 2
+
+    target_collection = pack.collection_name
+    files_to_ingest = [str(pack_dir / "corpus" / entry.path) for entry in pack.manifest]
+
+    envelope = {
+        "pack": pack.meta.name,
+        "collection": target_collection,
+        "manifest_pin": pack.meta.corpus_pin,
+        "files_to_ingest": files_to_ingest,
+    }
+
+    if args.dry_run:
+        # Dry-run path: emit envelope and exit. NO heavy imports above this gate.
+        print(json.dumps(envelope))
+        return 0
+
+    # Live mode below: deferred imports keep the dry-run path lightweight.
+    if not args.dry_run:
+        import subprocess  # noqa: PLC0415 - deferred behind the dry-run gate
+
+        failures: list[tuple[str, int, str]] = []
+        for doc_path in files_to_ingest:
+            cmd = [
+                sys.executable,
+                "-m",
+                "src.ingest.cli",
+                "--file",
+                doc_path,
+                "--collection",
+                target_collection,
+            ]
+            proc = subprocess.run(
+                cmd,
+                cwd=str(_REPO_ROOT),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if proc.returncode != 0:
+                failures.append((doc_path, proc.returncode, proc.stderr or proc.stdout))
+
+        if failures:
+            print(
+                f"eval_ingest: {len(failures)}/{len(files_to_ingest)} ingest invocations failed:",
+                file=sys.stderr,
+            )
+            for doc_path, rc, err in failures:
+                print(f"  - {doc_path}: rc={rc}", file=sys.stderr)
+                print(f"    stderr: {err.strip()[:500]}", file=sys.stderr)
+            return 1
+
+        # Success envelope on stdout for live mode as well.
+        print(json.dumps({**envelope, "ingested": len(files_to_ingest)}))
+        return 0
+
+    return 0  # pragma: no cover - unreachable
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/eval/__init__.py
+++ b/src/eval/__init__.py
@@ -1,6 +1,15 @@
 # @summary
 # Eval package — retrieval quality measurement, fixtures, and harnesses.
 # Exports: metrics (recall_at_k, ndcg_at_k, mean_metric), fixtures (load_fixture),
-# tree_retrieval_eval (run_eval, build_simulated_retriever, EvalReport).
-# Deps: stdlib only.
+# tree_retrieval_eval (run_eval, build_simulated_retriever, EvalReport),
+# pack format (EvalPack, load_pack, validate_pack, PackValidationError).
+# Deps: stdlib only (pack subpackage adds pydantic v2 + pyyaml).
 # @end-summary
+from .pack import EvalPack, PackValidationError, load_pack, validate_pack
+
+__all__ = [
+    "EvalPack",
+    "PackValidationError",
+    "load_pack",
+    "validate_pack",
+]

--- a/src/eval/pack/__init__.py
+++ b/src/eval/pack/__init__.py
@@ -1,0 +1,28 @@
+# @summary
+# Public surface of the eval_pack format (P0.5 keystone).
+# Exports: EvalPack, load_pack, validate_pack, PackValidationError.
+# Deps: pydantic v2, pyyaml.
+# @end-summary
+"""Eval_pack format — typed pack loader and validator.
+
+This is the stable import surface; downstream code should never import
+from the submodules directly.
+"""
+from __future__ import annotations
+
+from .errors import PackValidationError
+from .loader import load_pack
+from .schema import EvalPack, Golden, JudgeConfig, ManifestEntry, PackMeta, Thresholds
+from .validate import validate_pack
+
+__all__ = [
+    "EvalPack",
+    "Golden",
+    "JudgeConfig",
+    "ManifestEntry",
+    "PackMeta",
+    "PackValidationError",
+    "Thresholds",
+    "load_pack",
+    "validate_pack",
+]

--- a/src/eval/pack/errors.py
+++ b/src/eval/pack/errors.py
@@ -1,0 +1,16 @@
+# @summary
+# Single exception type for eval_pack validation failures.
+# Exports: PackValidationError
+# Deps: stdlib only.
+# @end-summary
+"""Eval_pack validation errors.
+
+All validator and loader failures surface as :class:`PackValidationError`.
+The message must name (a) the file/field path inside the pack and
+(b) the reason — see ``validate.py`` for the canonical formatter.
+"""
+from __future__ import annotations
+
+
+class PackValidationError(Exception):
+    """Raised when an eval_pack fails structural or schema validation."""

--- a/src/eval/pack/loader.py
+++ b/src/eval/pack/loader.py
@@ -1,0 +1,55 @@
+# @summary
+# Eval_pack loader — validates then materialises the typed EvalPack tree.
+# Exports: load_pack.
+# Deps: pyyaml, json, pathlib, .validate, .schema.
+# @end-summary
+"""Load an eval_pack into a typed :class:`EvalPack` aggregate.
+
+``load_pack`` calls :func:`validate_pack` first so any structural failure
+propagates as :class:`PackValidationError`. Only after validation passes
+does it populate the dataclass tree.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from .schema import EvalPack, Golden, ManifestEntry, PackMeta, Thresholds
+from .validate import validate_pack
+
+
+def load_pack(path: Path | str) -> EvalPack:
+    """Validate and load the eval_pack at ``path``.
+
+    :raises PackValidationError: if validation fails for any reason.
+    """
+    root = Path(path)
+    validate_pack(root)
+
+    pack_data = yaml.safe_load((root / "pack.yaml").read_text())
+    meta = PackMeta(**pack_data)
+
+    manifest_raw = json.loads((root / "corpus" / "manifest.json").read_text())
+    manifest = [ManifestEntry(**e) for e in manifest_raw["entries"]]
+
+    goldens: dict[str, list[Golden]] = {}
+    for gf in sorted((root / "goldens").glob("*.jsonl")):
+        qtype = gf.stem
+        rows: list[Golden] = []
+        for line in gf.read_text().splitlines():
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            rows.append(Golden(**{**row, "raw": row}))
+        goldens[qtype] = rows
+
+    thresholds = Thresholds(**yaml.safe_load((root / "thresholds.yaml").read_text()))
+
+    return EvalPack(
+        meta=meta,
+        manifest=manifest,
+        goldens=goldens,
+        thresholds=thresholds,
+    )

--- a/src/eval/pack/schema.py
+++ b/src/eval/pack/schema.py
@@ -1,0 +1,104 @@
+# @summary
+# Pydantic v2 models for the eval_pack format (P0.5 keystone).
+# Exports: PackMeta, JudgeConfig, ManifestEntry, Golden, Thresholds, EvalPack.
+# Deps: pydantic v2.
+# @end-summary
+"""Typed contracts for the eval_pack format.
+
+Only the ``factoid`` qtype has strict per-field requirements at the
+keystone; other qtypes parse loosely with extra fields preserved on
+``Golden.raw`` so P2 can extend the schema without re-authoring this
+module.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+KNOWN_PROFILES: frozenset[str] = frozenset({"asic_riscv_soc", "eda_command_reference", "generic"})
+
+
+class JudgeConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    tier1_model: str
+    tier1_prompt_version: str
+    temperature: float
+    samples_per_claim: int
+
+
+class PackMeta(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    version: int
+    profile: str
+    corpus_pin: str
+    description: str | None = None
+    judge: JudgeConfig
+    collection_name_template: str
+
+
+class ManifestEntry(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    path: str
+    sha256: str
+
+
+class Golden(BaseModel):
+    """A single golden query.
+
+    ``factoid`` enforces ``qid``, ``qtype``, ``query``, ``expected_answer_span``.
+    Other qtypes accept the same base fields but make span optional, and
+    keep the raw line under ``raw`` for downstream consumers.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    qid: str
+    qtype: str
+    query: str
+    expected_answer_span: str | None = None
+    expected_source_docs: list[str] = Field(default_factory=list)
+    raw: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _check_factoid_required(self) -> Golden:
+        if self.qtype == "factoid" and not self.expected_answer_span:
+            raise ValueError(
+                f"golden qid={self.qid!r} qtype=factoid is missing required field 'expected_answer_span'"
+            )
+        return self
+
+
+class Thresholds(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    profile: str
+    defaults: dict[str, dict[str, float]] = Field(default_factory=dict)
+    overrides: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class EvalPack(BaseModel):
+    """Aggregate pack: meta + manifest + goldens + thresholds.
+
+    ``collection_name`` is computed from ``meta.collection_name_template``
+    with ``{name}`` and ``{corpus_pin_short}`` (first 8 hex chars) substituted.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    meta: PackMeta
+    manifest: list[ManifestEntry]
+    goldens: dict[str, list[Golden]]
+    thresholds: Thresholds
+
+    @property
+    def collection_name(self) -> str:
+        short = self.meta.corpus_pin[:8]
+        return self.meta.collection_name_template.format(
+            name=self.meta.name,
+            corpus_pin_short=short,
+        )

--- a/src/eval/pack/validate.py
+++ b/src/eval/pack/validate.py
@@ -1,0 +1,180 @@
+# @summary
+# Structural validator for eval_pack directories.
+# Exports: validate_pack, compute_corpus_pin, KNOWN_PROFILES.
+# Deps: pyyaml, pydantic, hashlib, json, pathlib.
+# @end-summary
+"""Validate the structural contract of an eval_pack directory.
+
+Every failure path raises :class:`PackValidationError` with a message that
+name-checks the offending file/field. Pydantic ``ValidationError`` is
+caught and re-raised so the public API surfaces a single exception type.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from .errors import PackValidationError
+from .schema import KNOWN_PROFILES, Golden, ManifestEntry, PackMeta, Thresholds
+
+REQUIRED_PACK_YAML_KEYS: tuple[str, ...] = (
+    "name",
+    "version",
+    "profile",
+    "corpus_pin",
+    "judge",
+    "collection_name_template",
+)
+
+
+def compute_corpus_pin(entries: list[dict[str, str]] | list[ManifestEntry]) -> str:
+    """SHA-256 of sorted ``{path}:{sha256}`` lines joined by ``\\n``."""
+
+    def _line(e: Any) -> str:
+        if isinstance(e, ManifestEntry):
+            return f"{e.path}:{e.sha256}"
+        return f"{e['path']}:{e['sha256']}"
+
+    lines = sorted(_line(e) for e in entries)
+    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+
+
+def _read_yaml(path: Path, rel: str) -> dict[str, Any]:
+    if not path.exists():
+        raise PackValidationError(f"{rel}: file is missing")
+    try:
+        data = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        raise PackValidationError(f"{rel}: failed to parse YAML — {exc}") from exc
+    if not isinstance(data, dict):
+        raise PackValidationError(f"{rel}: top-level YAML must be a mapping, got {type(data).__name__}")
+    return data
+
+
+def _read_json(path: Path, rel: str) -> Any:
+    if not path.exists():
+        raise PackValidationError(f"{rel}: file is missing")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise PackValidationError(f"{rel}: failed to parse JSON — {exc}") from exc
+
+
+def validate_pack(path: Path | str) -> None:
+    """Run structural checks against the pack at ``path``.
+
+    Raises :class:`PackValidationError` on any failure.
+    """
+    root = Path(path)
+    if not root.exists() or not root.is_dir():
+        raise PackValidationError(f"pack directory does not exist or is not a directory: {root}")
+
+    # --- pack.yaml ---
+    pack_yaml_path = root / "pack.yaml"
+    pack_data = _read_yaml(pack_yaml_path, "pack.yaml")
+    missing = [k for k in REQUIRED_PACK_YAML_KEYS if k not in pack_data]
+    if missing:
+        raise PackValidationError(f"pack.yaml: missing required keys: {missing}")
+    profile = pack_data["profile"]
+    if profile not in KNOWN_PROFILES:
+        raise PackValidationError(
+            f"pack.yaml: profile {profile!r} (undeclared_profile is not allowed unless registered) "
+            f"is not in the known profile set {sorted(KNOWN_PROFILES)}; "
+            f"got profile={profile!r}"
+        )
+    try:
+        meta = PackMeta(**pack_data)
+    except ValidationError as exc:
+        raise PackValidationError(f"pack.yaml: schema validation failed — {exc}") from exc
+
+    # --- corpus/manifest.json ---
+    manifest_path = root / "corpus" / "manifest.json"
+    manifest_data = _read_json(manifest_path, "corpus/manifest.json")
+    if not isinstance(manifest_data, dict) or "entries" not in manifest_data:
+        raise PackValidationError(
+            "corpus/manifest.json: must be a JSON object with an 'entries' list"
+        )
+    raw_entries = manifest_data["entries"]
+    if not isinstance(raw_entries, list) or not raw_entries:
+        raise PackValidationError("corpus/manifest.json: 'entries' must be a non-empty list")
+    try:
+        entries = [ManifestEntry(**e) for e in raw_entries]
+    except ValidationError as exc:
+        raise PackValidationError(
+            f"corpus/manifest.json: entry schema validation failed — {exc}"
+        ) from exc
+    for e in entries:
+        doc_path = root / "corpus" / e.path
+        if not doc_path.exists():
+            raise PackValidationError(
+                f"corpus/manifest.json: declared document {e.path!r} does not exist on disk"
+            )
+
+    expected_pin = compute_corpus_pin(entries)
+    if meta.corpus_pin != expected_pin:
+        raise PackValidationError(
+            f"pack.yaml: corpus_pin mismatch — declared {meta.corpus_pin!r}, "
+            f"recomputed {expected_pin!r} from corpus/manifest.json"
+        )
+
+    # --- goldens/*.jsonl ---
+    goldens_dir = root / "goldens"
+    if not goldens_dir.exists() or not goldens_dir.is_dir():
+        raise PackValidationError("goldens/: directory is missing")
+    golden_files = sorted(goldens_dir.glob("*.jsonl"))
+    if not golden_files:
+        raise PackValidationError("goldens/: no *.jsonl files found")
+    for gf in golden_files:
+        qtype = gf.stem
+        rel = f"goldens/{gf.name}"
+        for line_no, line in enumerate(gf.read_text().splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise PackValidationError(
+                    f"{rel}:line {line_no}: invalid JSON — {exc}"
+                ) from exc
+            if not isinstance(row, dict):
+                raise PackValidationError(
+                    f"{rel}:line {line_no}: each line must be a JSON object"
+                )
+            qid = row.get("qid", "<missing-qid>")
+            row_qtype = row.get("qtype")
+            if row_qtype != qtype:
+                raise PackValidationError(
+                    f"{rel}:line {line_no}: golden qid={qid!r} has qtype={row_qtype!r} "
+                    f"but the file's qtype (filename stem) is {qtype!r}; "
+                    f"expected_answer_span and other per-qtype fields must match"
+                )
+            try:
+                Golden(**{**row, "raw": row})
+            except ValidationError as exc:
+                # Surface the offending qid and field names in the message.
+                fields = ", ".join(
+                    ".".join(str(p) for p in err["loc"]) for err in exc.errors()
+                )
+                raise PackValidationError(
+                    f"{rel}:line {line_no}: golden qid={qid!r} qtype={row_qtype!r} "
+                    f"failed schema validation on fields [{fields}] — {exc}"
+                ) from exc
+
+    # --- thresholds.yaml ---
+    thresholds_path = root / "thresholds.yaml"
+    th_data = _read_yaml(thresholds_path, "thresholds.yaml")
+    try:
+        thresholds = Thresholds(**th_data)
+    except ValidationError as exc:
+        raise PackValidationError(
+            f"thresholds.yaml: schema validation failed — {exc}"
+        ) from exc
+    if thresholds.profile != meta.profile:
+        raise PackValidationError(
+            f"thresholds.yaml: profile {thresholds.profile!r} does not match pack.yaml profile {meta.profile!r}"
+        )

--- a/src/ingest/cli.py
+++ b/src/ingest/cli.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # @summary
-# Developer CLI for ingesting documents into the RAG system.
+# Developer CLI for ingesting documents into the RAG system. The CLI exposes
+# a ``--collection``/``-c`` flag (P0 collection-selection slice) which is
+# threaded into IngestionConfig.target_collection so a single run can target
+# an arbitrary Weaviate collection without env-var manipulation.
 # Exports: ingest, main
 # Deps: config.settings, src.ingest, src.platform.validation
 # @end-summary
@@ -54,6 +57,7 @@ def ingest(
     vision_max_figures: Optional[int] = None,
     vision_auto_pull: Optional[bool] = None,
     vision_strict: Optional[bool] = None,
+    collection_name: Optional[str] = None,
 ) -> None:
     """Ingest documents from a directory or a single selected file.
 
@@ -101,6 +105,8 @@ def ingest(
         cfg_kwargs["vision_auto_pull"] = vision_auto_pull
     if vision_strict is not None:
         cfg_kwargs["vision_strict"] = vision_strict
+    if collection_name:
+        cfg_kwargs["target_collection"] = collection_name
 
     cfg = IngestionConfig(
         **cfg_kwargs,
@@ -161,6 +167,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "-y",
         action="store_true",
         help="Skip confirmation prompt for --fresh (use with care, e.g. in CI).",
+    )
+    parser.add_argument(
+        "--collection",
+        "-c",
+        dest="collection",
+        type=str,
+        default=None,
+        help="Target Weaviate collection name. Overrides RAG_VECTOR_COLLECTION_DEFAULT "
+             "for this run; defaults to that env var (or 'RAGDocuments') when omitted.",
     )
     parser.add_argument(
         "--no-semantic",
@@ -316,8 +331,9 @@ def main() -> None:
     update_mode = not fresh_mode
 
     if fresh_mode and not args.yes:
-        from config.settings import WEAVIATE_COLLECTION_NAME
-        if not _confirm_fresh(WEAVIATE_COLLECTION_NAME):
+        from config.settings import VECTOR_COLLECTION_DEFAULT
+        target = args.collection or VECTOR_COLLECTION_DEFAULT
+        if not _confirm_fresh(target):
             print("Aborted: --fresh not confirmed.", file=sys.stderr)
             sys.exit(2)
 
@@ -343,6 +359,7 @@ def main() -> None:
         vision_max_figures=args.vision_max_figures,
         vision_auto_pull=not args.no_vision_auto_pull,
         vision_strict=args.vision_strict,
+        collection_name=args.collection,
     )
 
 

--- a/src/ingest/impl.py
+++ b/src/ingest/impl.py
@@ -764,16 +764,18 @@ def ingest_directory(
       )
 
       with get_client() as client:
+          _ingest_collection = config.target_collection or None
           if fresh:
-              delete_collection(client)
+              delete_collection(client, collection=_ingest_collection)
               manifest = {}
-          ensure_collection(client)
+          ensure_collection(client, collection=_ingest_collection)
 
           for source in removed_sources:
               delete_by_source_key(
                   client,
                   source,
                   legacy_source=str(manifest.get(source, {}).get("source", "")),
+                  collection=_ingest_collection,
               )
               # Clean up debug export artifacts if they exist.
               if config.clean_store_dir:

--- a/src/retrieval/pipeline/rag_chain.py
+++ b/src/retrieval/pipeline/rag_chain.py
@@ -7,6 +7,11 @@
 # composite confidence is below the high threshold and retry budget remains, the chain
 # re-runs search+rerank+generate+score with broader params (alpha-=0.15, limit+=5) and
 # returns whichever attempt scores higher. Surfaces both scores in RAGResponse.
+# RAGChain.__init__ accepts an optional ``collection_name`` kwarg (P0
+# collection-selection slice) so callers can route reads/writes to an arbitrary
+# Weaviate collection without env-var manipulation; resolved value lives on
+# ``self._collection_name`` and is threaded through every internal call site
+# via ``self._resolve_collection()`` (defends against __new__-bypassed init).
 # Main classes: RAGChain, RAGResponse. Deps: src.vector_db, src.guardrails, src.retrieval.generation.nodes.generator, src.retrieval.query.nodes.query_processor, src.retrieval.common.schemas, src.core, src.platform
 # @end-summary
 """Main RAG chain that orchestrates the full retrieval pipeline."""
@@ -65,6 +70,7 @@ from src.retrieval.pipeline.deep_research import (
     KGSnippet,
     TopicPool,
 )
+from config.settings import VECTOR_COLLECTION_DEFAULT
 from config.settings import (
     HYBRID_SEARCH_ALPHA, SEARCH_LIMIT, RERANK_TOP_K,
     KG_ENABLED, GENERATION_ENABLED,
@@ -155,8 +161,18 @@ logger = logging.getLogger("rag.rag_chain")
 class RAGChain:
     """End-to-end RAG pipeline: query processing -> KG expansion -> hybrid search -> reranking."""
 
-    def __init__(self, persistent_weaviate: bool = True):
+    def __init__(
+        self,
+        persistent_weaviate: bool = True,
+        collection_name: Optional[str] = None,
+    ):
         from concurrent.futures import ThreadPoolExecutor, Future
+
+        # Resolve target collection: explicit arg wins, otherwise fall back to
+        # the configured default. Threaded through every internal vector-store
+        # call site below so callers can route reads/writes to an arbitrary
+        # collection without env-var manipulation. (P0-collection-selection.)
+        self._collection_name: str = collection_name or VECTOR_COLLECTION_DEFAULT
 
         self.tracer = get_tracer()
         self.retry_provider = get_retry_provider()
@@ -173,7 +189,7 @@ class RAGChain:
         if persistent_weaviate:
             logger.info("Opening persistent Weaviate connection...")
             self._weaviate_client = create_persistent_client()
-            ensure_collection(self._weaviate_client)
+            ensure_collection(self._weaviate_client, collection=self._collection_name)
             logger.info("Weaviate connected (persistent mode).")
 
         # GPU models must load sequentially (parallel .to(cuda) causes meta
@@ -303,6 +319,16 @@ class RAGChain:
         self.xref_max_total: int = RAG_XREF_MAX_TOTAL
 
         logger.info("RAG chain ready.")
+
+    def _resolve_collection(self) -> str:
+        """Return the configured target collection, defending against bypassed __init__.
+
+        Several tests build a RAGChain via ``__new__`` to skip the heavy
+        initialiser. Those instances never set ``_collection_name``; the
+        default behaviour should be identical to passing no collection_name.
+        See memory ``project_rag_chain_defensive_init``.
+        """
+        return getattr(self, "_collection_name", None) or VECTOR_COLLECTION_DEFAULT
 
     def close(self) -> None:
         """Release persistent resources (database connection, visual model)."""
@@ -497,12 +523,11 @@ class RAGChain:
         if getattr(self, "_weaviate_client", None) is None:
             return reranked
         try:
-            from config.settings import VECTOR_COLLECTION_DEFAULT
             dict_hits = self._ranked_to_dicts(reranked)
             expanded = expand_xref_hits(
                 dict_hits,
                 client=self._weaviate_client,
-                collection=VECTOR_COLLECTION_DEFAULT,
+                collection=self._resolve_collection(),
                 enabled=True,
                 max_per_hit=getattr(self, "xref_max_per_hit", 2),
                 max_total=getattr(self, "xref_max_total", 6),
@@ -531,12 +556,11 @@ class RAGChain:
         if getattr(self, "_weaviate_client", None) is None:
             return reranked
         try:
-            from config.settings import VECTOR_COLLECTION_DEFAULT
             dict_hits = self._ranked_to_dicts(reranked)
             expanded = expand_table_group_hits(
                 dict_hits,
                 client=self._weaviate_client,
-                collection=VECTOR_COLLECTION_DEFAULT,
+                collection=self._resolve_collection(),
                 max_rows_per_group=getattr(self, "table_expansion_max_rows", 0),
                 fetch_summary_for_row_hits=getattr(
                     self, "table_expansion_fetch_summary", True,
@@ -569,10 +593,11 @@ class RAGChain:
                         alpha=alpha,
                         limit=search_limit,
                         filters=filters,
+                        collection=self._resolve_collection(),
                     )
                 else:
                     with get_client() as client:
-                        ensure_collection(client)
+                        ensure_collection(client, collection=self._resolve_collection())
                         results = search(
                             client=client,
                             query=bm25_query,
@@ -580,6 +605,7 @@ class RAGChain:
                             alpha=alpha,
                             limit=search_limit,
                             filters=filters,
+                            collection=self._resolve_collection(),
                         )
                 _span.set_attribute("result_count", len(results))
                 logger.debug(

--- a/src/vector_db/__init__.py
+++ b/src/vector_db/__init__.py
@@ -3,7 +3,7 @@
 # single-collection search, multi-collection fan-out, aggregation, re-exported schemas,
 # and visual collection operations for the visual embedding pipeline.
 # Exports: create_persistent_client, get_client, close_client, ensure_collection,
-#          delete_collection, add_documents, update_chunk_content,
+#          collection_exists, delete_collection, add_documents, update_chunk_content,
 #          delete_by_source, delete_by_source_key,
 #          search, multi_search, aggregate_by_source, get_collection_stats, list_collections,
 #          ensure_visual_collection, add_visual_documents, delete_visual_by_source_key,
@@ -122,6 +122,19 @@ def ensure_collection(client: Any, collection: Optional[str] = None) -> None:
         collection: Target collection name. ``None`` uses the default.
     """
     _get_vector_backend().ensure_collection(client, collection)
+
+
+def collection_exists(client: Any, collection: Optional[str] = None) -> bool:
+    """Return True iff the named collection exists on the backend.
+
+    Args:
+        client: Vector store client handle.
+        collection: Target collection name. ``None`` uses the default.
+
+    Returns:
+        True if the collection exists, False otherwise.
+    """
+    return _get_vector_backend().collection_exists(client, collection)
 
 
 def delete_collection(client: Any, collection: Optional[str] = None) -> None:
@@ -453,6 +466,7 @@ __all__ = [
     "close_client",
     # Collection management
     "ensure_collection",
+    "collection_exists",
     "delete_collection",
     # Document operations
     "add_documents",

--- a/src/vector_db/backend.py
+++ b/src/vector_db/backend.py
@@ -60,6 +60,13 @@ class VectorBackend(ABC):
         ...
 
     @abstractmethod
+    def collection_exists(
+        self, client: Any, collection: Optional[str] = None
+    ) -> bool:
+        """Return True iff the named collection exists on the server."""
+        ...
+
+    @abstractmethod
     def add_documents(
         self,
         client: Any,

--- a/src/vector_db/weaviate/backend.py
+++ b/src/vector_db/weaviate/backend.py
@@ -30,6 +30,7 @@ from src.vector_db.weaviate.store import (
     create_persistent_client as _wv_create_persistent,
     get_weaviate_client as _wv_get_ephemeral,
     ensure_collection as _wv_ensure_collection,
+    collection_exists as _wv_collection_exists,
     add_documents as _wv_add_documents,
     hybrid_search as _wv_hybrid_search,
     delete_collection as _wv_delete_collection,
@@ -67,6 +68,11 @@ class WeaviateBackend(VectorBackend):
 
     def ensure_collection(self, client: Any, collection: Optional[str] = None) -> None:
         _wv_ensure_collection(client, collection=self._col(collection))
+
+    def collection_exists(
+        self, client: Any, collection: Optional[str] = None
+    ) -> bool:
+        return _wv_collection_exists(client, collection=self._col(collection))
 
     def add_documents(
         self,

--- a/src/vector_db/weaviate/store.py
+++ b/src/vector_db/weaviate/store.py
@@ -272,7 +272,9 @@ def ensure_collection(
             Property(name="heading", data_type=DataType.TEXT),
             Property(name="heading_level", data_type=DataType.INT),
             Property(name="tenant_id", data_type=DataType.TEXT),
-            Property(name="document_id", data_type=DataType.TEXT),
+            # NOTE: ``document_id`` is declared in ``TABLE_AWARE_PROPERTIES``
+            # (above) and intentionally not redeclared here — Weaviate rejects
+            # duplicate property names with HTTP 422.
             # -- Tree retrieval (TREE_RETRIEVAL_DESIGN.md §3.1) --
             Property(
                 name="node_kind",
@@ -678,6 +680,18 @@ def hybrid_search(
     span.set_attribute("result_count", len(documents))
     span.end(status="ok")
     return documents
+
+
+def collection_exists(
+    client: weaviate.WeaviateClient,
+    collection: str = WEAVIATE_COLLECTION_NAME,
+) -> bool:
+    """Return True iff the named collection exists on the server.
+
+    Thin wrapper around ``client.collections.exists(name)`` used by callers
+    that want to branch on collection presence without a full schema fetch.
+    """
+    return bool(client.collections.exists(collection))
 
 
 def delete_collection(

--- a/tests/eval/test_opentitan_pack_ingest.py
+++ b/tests/eval/test_opentitan_pack_ingest.py
@@ -1,0 +1,218 @@
+# @summary
+# Tests for the opentitan_riscv eval_pack: P0.5 loader validation,
+# dry-run script behavior, and isolated live ingest into Weaviate.
+# Exports: test_pack_validates_under_p0_5_loader, test_eval_ingest_script_dry_run,
+#          test_ingest_into_isolated_collection
+# Deps: src.eval.pack, scripts/eval_ingest.py, config.settings
+# @end-summary
+"""P1 — OpenTitan/Ibex/RISC-V reference pack ingest tests."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACK_DIR = REPO_ROOT / "evals" / "packs" / "opentitan_riscv"
+EVAL_INGEST_SCRIPT = REPO_ROOT / "scripts" / "eval_ingest.py"
+
+
+def _recompute_corpus_pin(manifest_entries: list[dict]) -> str:
+    lines = sorted(f"{e['path']}:{e['sha256']}" for e in manifest_entries)
+    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+
+
+def test_pack_validates_under_p0_5_loader() -> None:
+    """The opentitan_riscv pack loads under the P0.5 loader with the expected
+    meta fields, manifest size, and template-resolved collection name."""
+    from src.eval.pack import EvalPack, load_pack
+
+    pack = load_pack(PACK_DIR)
+    assert isinstance(pack, EvalPack)
+
+    assert pack.meta.name == "opentitan_riscv"
+    assert pack.meta.profile == "asic_riscv_soc"
+    assert pack.meta.version == 1
+
+    assert len(pack.manifest) >= 3
+    assert len(pack.manifest) == 5  # five-doc corpus per slice spec
+
+    # Recompute corpus_pin from the manifest on disk (anti-gaming: no hardcoded hex).
+    raw = json.loads((PACK_DIR / "corpus" / "manifest.json").read_text())
+    recomputed = _recompute_corpus_pin(raw["entries"])
+    assert pack.meta.corpus_pin == recomputed
+
+    # P0.5 loader requires at least one goldens/*.jsonl file; we ship an empty
+    # placeholder, so the rows list is empty.  P2 owns golden authoring.
+    for qtype, rows in pack.goldens.items():
+        assert rows == [], f"P1 declares no goldens; qtype={qtype} unexpectedly populated"
+
+    short = pack.meta.corpus_pin[:8]
+    assert pack.collection_name == f"ragweave_test_opentitan_riscv_{short}"
+
+
+def test_eval_ingest_script_dry_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`python scripts/eval_ingest.py --pack opentitan_riscv --dry-run` emits a
+    JSON envelope on stdout, exits 0, and does NOT import the Weaviate/ingest
+    engine along its dry-run path (structural import-check)."""
+    from src.eval.pack import load_pack
+
+    pack = load_pack(PACK_DIR)
+    expected_collection = pack.collection_name
+
+    # Run the script as a subprocess so we exercise the real entrypoint.
+    proc = subprocess.run(
+        [sys.executable, str(EVAL_INGEST_SCRIPT), "--pack", "opentitan_riscv", "--dry-run"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"dry-run exit={proc.returncode}; stderr={proc.stderr}"
+
+    envelope = json.loads(proc.stdout)
+    assert set(envelope.keys()) >= {"pack", "collection", "manifest_pin", "files_to_ingest"}
+    assert envelope["pack"] == "opentitan_riscv"
+    assert envelope["collection"] == expected_collection
+    assert envelope["manifest_pin"] == pack.meta.corpus_pin
+    assert isinstance(envelope["files_to_ingest"], list)
+    assert len(envelope["files_to_ingest"]) == len(pack.manifest)
+
+    # Anti-gaming structural import-check: ensure the script source defers the
+    # heavy ingest/weaviate imports behind the dry-run gate.  We assert the
+    # gating pattern appears in the script source and only AFTER that gate do
+    # we see any reference to weaviate/src.vector_db/src.ingest.impl.
+    src = EVAL_INGEST_SCRIPT.read_text()
+    assert "if not args.dry_run:" in src, "expected dry-run gate `if not args.dry_run:`"
+    gate_index = src.index("if not args.dry_run:")
+    head, tail = src[:gate_index], src[gate_index:]
+    forbidden_in_head = ("import weaviate", "from weaviate", "src.vector_db", "src.ingest.impl")
+    for token in forbidden_in_head:
+        assert token not in head, (
+            f"forbidden token {token!r} found before the dry-run gate "
+            f"(must be deferred behind `if not args.dry_run:`)"
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_ingest_into_isolated_collection(tmp_path: Path) -> None:
+    """Live test: ingest the pack into an isolated Weaviate collection via
+    `scripts/eval_ingest.py`, asserting (a) the target collection exists with
+    chunks, (b) `VECTOR_COLLECTION_DEFAULT` is unaffected (zero leakage), and
+    (c) the target collection is cleaned up in try/finally."""
+    pytest.importorskip("weaviate")
+    import socket
+
+    from config.settings import MINIO_ENDPOINT, VECTOR_COLLECTION_DEFAULT
+    from src.eval.pack import load_pack
+    from src.vector_db import close_client, create_persistent_client
+
+    try:
+        client = create_persistent_client()
+    except Exception as exc:  # pragma: no cover - infra-dependent
+        pytest.skip(f"Live Weaviate not reachable: {exc}")
+
+    # The ingest CLI also depends on MinIO (object store) and Temporal.
+    # Probe MinIO with a short TCP connect; skip cleanly on infra absence.
+    try:
+        host, _, port = MINIO_ENDPOINT.partition(":")
+        with socket.create_connection((host or "localhost", int(port or "9000")), timeout=2):
+            pass
+    except Exception as exc:  # pragma: no cover - infra-dependent
+        try:
+            close_client(client)
+        except Exception:
+            pass
+        pytest.skip(f"Live MinIO ({MINIO_ENDPOINT}) not reachable: {exc}")
+
+    # Copy the pack into a temporary location INSIDE the worktree so that
+    # `src.ingest.cli` `validate_documents_dir` (project-root containment
+    # check) accepts the per-document --file path. Cleaned up in finally.
+    unique_suffix = uuid.uuid4().hex[:8]
+    unique_name = f"opentitan_riscv_test_{unique_suffix}"
+    packs_root = REPO_ROOT / "evals" / "packs" / f"_p1_live_test_{unique_suffix}"
+    target_pack_dir = packs_root / unique_name
+    shutil.copytree(PACK_DIR, target_pack_dir)
+
+    pack_yaml_path = target_pack_dir / "pack.yaml"
+    pack_data = yaml.safe_load(pack_yaml_path.read_text())
+    pack_data["name"] = unique_name
+    pack_yaml_path.write_text(yaml.safe_dump(pack_data, sort_keys=False))
+
+    # Resolve the expected collection name through the loader.
+    reloaded = load_pack(target_pack_dir)
+    target_collection = reloaded.collection_name
+
+    def _count(coll: str) -> int:
+        if not client.collections.exists(coll):
+            return 0
+        return client.collections.get(coll).aggregate.over_all(total_count=True).total_count
+
+    default_count_before = _count(VECTOR_COLLECTION_DEFAULT)
+
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(EVAL_INGEST_SCRIPT),
+                "--pack",
+                unique_name,
+                "--pack-root",
+                str(packs_root),
+            ],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, (
+            f"live ingest exit={proc.returncode}\n"
+            f"stdout={proc.stdout}\nstderr={proc.stderr}"
+        )
+
+        # 5s settle loop for indexer consistency.
+        target_count = 0
+        for _ in range(10):
+            if client.collections.exists(target_collection):
+                target_count = (
+                    client.collections.get(target_collection)
+                    .aggregate.over_all(total_count=True)
+                    .total_count
+                )
+                if target_count > 0:
+                    break
+            time.sleep(0.5)
+
+        assert client.collections.exists(target_collection), (
+            f"expected target collection {target_collection!r} to exist after ingest"
+        )
+        assert target_count > 0, (
+            f"expected target collection {target_collection!r} to have chunks; got 0"
+        )
+
+        default_count_after = _count(VECTOR_COLLECTION_DEFAULT)
+        assert default_count_after == default_count_before, (
+            f"prod collection leakage: {VECTOR_COLLECTION_DEFAULT} "
+            f"went {default_count_before} -> {default_count_after}"
+        )
+    finally:
+        try:
+            if client.collections.exists(target_collection):
+                client.collections.delete(target_collection)
+        finally:
+            try:
+                close_client(client)
+            except Exception:
+                pass
+            # Always clean up the temporary pack copy (project-root location).
+            shutil.rmtree(packs_root, ignore_errors=True)

--- a/tests/eval/test_pack_loader.py
+++ b/tests/eval/test_pack_loader.py
@@ -1,0 +1,123 @@
+"""Tests for the eval_pack loader (P0.5 keystone).
+
+Tests observe behaviour through the public loader API only:
+    from src.eval.pack import EvalPack, load_pack, validate_pack, PackValidationError
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from src.eval.pack import EvalPack, PackValidationError, load_pack, validate_pack
+
+EXAMPLE_PACK = Path("evals/packs/_example_")
+
+
+def _compute_corpus_pin(manifest_path: Path) -> str:
+    """Recompute corpus_pin from manifest.json — sha256 of sorted '{path}:{sha256}' lines."""
+    data = json.loads(manifest_path.read_text())
+    entries = data["entries"]
+    lines = sorted(f"{e['path']}:{e['sha256']}" for e in entries)
+    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+
+
+def _copy_pack(tmp_path: Path) -> Path:
+    dst = tmp_path / "pack"
+    shutil.copytree(EXAMPLE_PACK, dst)
+    return dst
+
+
+def test_load_valid_pack() -> None:
+    pack = load_pack(EXAMPLE_PACK)
+
+    assert isinstance(pack, EvalPack)
+    assert pack.meta.name == "_example_"
+    assert pack.meta.version == 1
+    assert pack.meta.profile == "asic_riscv_soc"
+
+    expected_pin = _compute_corpus_pin(EXAMPLE_PACK / "corpus" / "manifest.json")
+    assert pack.meta.corpus_pin == expected_pin
+
+    factoids = pack.goldens["factoid"]
+    assert isinstance(factoids, list) and len(factoids) >= 1
+    first = factoids[0]
+    # Typed Golden record — required fields surface as attributes
+    assert first.qid
+    assert first.qtype == "factoid"
+    assert first.query
+    assert first.expected_answer_span
+
+    r5 = pack.thresholds.defaults["factoid"]["recall_at_5"]
+    assert isinstance(r5, float)
+    assert 0.0 <= r5 <= 1.0
+
+    expected_collection = f"ragweave_test__example__{expected_pin[:8]}"
+    assert pack.collection_name == expected_collection
+
+
+def test_rejects_missing_manifest(tmp_path: Path) -> None:
+    pack_dir = _copy_pack(tmp_path)
+    (pack_dir / "corpus" / "manifest.json").unlink()
+
+    with pytest.raises(PackValidationError) as exc_info:
+        load_pack(pack_dir)
+
+    msg = str(exc_info.value)
+    assert "corpus/manifest.json" in msg
+    # Must not be FileNotFoundError or KeyError leaking through
+    assert not isinstance(exc_info.value, FileNotFoundError)
+    assert not isinstance(exc_info.value, KeyError)
+
+
+def test_rejects_schema_invalid_golden(tmp_path: Path) -> None:
+    pack_dir = _copy_pack(tmp_path)
+    goldens_path = pack_dir / "goldens" / "factoid.jsonl"
+    bad_line = json.dumps(
+        {
+            "qid": "f-bad-001",
+            "qtype": "qfs",  # mismatch — file is factoid.jsonl
+            "query": "What is broken?",
+            # NOTE: expected_answer_span deliberately missing
+            "expected_source_docs": ["docs/intro.md"],
+        }
+    )
+    goldens_path.write_text(bad_line + "\n")
+
+    with pytest.raises(PackValidationError) as exc_info:
+        load_pack(pack_dir)
+
+    msg = str(exc_info.value)
+    assert "f-bad-001" in msg, f"error message must reference the offending qid; got: {msg}"
+    assert "expected_answer_span" in msg or "qtype" in msg, (
+        f"error message must reference the failing field; got: {msg}"
+    )
+    # Must be re-raised as PackValidationError, not a bare pydantic ValidationError
+    import pydantic
+
+    assert not isinstance(exc_info.value, pydantic.ValidationError)
+
+
+def test_rejects_unknown_profile(tmp_path: Path) -> None:
+    pack_dir = _copy_pack(tmp_path)
+    pack_yaml = pack_dir / "pack.yaml"
+    text = pack_yaml.read_text()
+    text = text.replace("profile: asic_riscv_soc", "profile: undeclared_profile")
+    pack_yaml.write_text(text)
+
+    # thresholds.yaml still says asic_riscv_soc — make it match the new profile
+    # so that the profile-unknown check is what fires (not the profile-mismatch check).
+    th_path = pack_dir / "thresholds.yaml"
+    th_path.write_text(
+        th_path.read_text().replace("profile: asic_riscv_soc", "profile: undeclared_profile")
+    )
+
+    with pytest.raises(PackValidationError) as exc_info:
+        load_pack(pack_dir)
+
+    msg = str(exc_info.value)
+    assert "profile" in msg
+    assert "undeclared_profile" in msg

--- a/tests/vector_db/test_collection_selection.py
+++ b/tests/vector_db/test_collection_selection.py
@@ -1,0 +1,266 @@
+# @summary
+# P0 slice — collection selection plumbing tests.
+# Validates: collection_exists helper, RAGChain.__init__ collection_name kwarg,
+# ingest CLI --collection flag, and live-Weaviate write isolation between two
+# collections selected programmatically.
+# Deps: pytest, src.vector_db, src.retrieval.pipeline.rag_chain, src.ingest.cli
+# @end-summary
+"""Tests for the P0 collection-selection slice.
+
+Four tests, two flavours:
+  - test_isolation_writes_do_not_leak and test_collection_exists_helper carry
+    pytestmark=[slow, integration] because they exercise a live Weaviate.
+  - test_rag_chain_accepts_collection_name and test_ingest_cli_accepts_collection_flag
+    are unit-level and run in the default sweep.
+"""
+
+from __future__ import annotations
+
+# Force the real ``weaviate`` package into sys.modules BEFORE tests/conftest.py
+# installs its stub module. Without this the live-Weaviate tests below would
+# end up holding a stubbed client and silently lose isolation guarantees.
+try:  # pragma: no cover - import-side-effect only
+    import src.vector_db.weaviate.store  # noqa: F401
+    import weaviate  # noqa: F401
+except Exception:  # pragma: no cover - infra-dependent fallback
+    pass
+
+import os
+import uuid
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Unit-level tests (default sweep)
+# ---------------------------------------------------------------------------
+
+def test_rag_chain_accepts_collection_name() -> None:
+    """RAGChain(collection_name=...) resolves the requested collection.
+
+    Observes the chosen value through ``self._collection_name`` — the same
+    attribute the chain internals will read when threading the value through
+    ensure_collection / search / expansion call sites.
+    """
+    custom = f"custom_foo_{uuid.uuid4().hex[:8]}"
+
+    with patch("src.retrieval.pipeline.rag_chain.create_persistent_client"), \
+         patch("src.retrieval.pipeline.rag_chain.ensure_collection"), \
+         patch("src.retrieval.pipeline.rag_chain.get_embedding_provider"), \
+         patch("src.retrieval.pipeline.rag_chain.get_reranker_provider"), \
+         patch("src.retrieval.pipeline.rag_chain.OllamaGenerator"), \
+         patch("src.retrieval.pipeline.rag_chain._get_kg_client"), \
+         patch("src.retrieval.pipeline.rag_chain.KG_ENABLED", False):
+        from src.retrieval.pipeline.rag_chain import RAGChain  # noqa: PLC0415
+
+        chain = RAGChain(persistent_weaviate=False, collection_name=custom)
+
+    assert chain._collection_name == custom
+
+
+def test_rag_chain_default_collection_name_unchanged() -> None:
+    """Default behaviour: no collection_name kwarg falls back to VECTOR_COLLECTION_DEFAULT.
+
+    Regression guard — the slice must not change default-path behaviour.
+    """
+    from config.settings import VECTOR_COLLECTION_DEFAULT  # noqa: PLC0415
+
+    with patch("src.retrieval.pipeline.rag_chain.create_persistent_client"), \
+         patch("src.retrieval.pipeline.rag_chain.ensure_collection"), \
+         patch("src.retrieval.pipeline.rag_chain.get_embedding_provider"), \
+         patch("src.retrieval.pipeline.rag_chain.get_reranker_provider"), \
+         patch("src.retrieval.pipeline.rag_chain.OllamaGenerator"), \
+         patch("src.retrieval.pipeline.rag_chain._get_kg_client"), \
+         patch("src.retrieval.pipeline.rag_chain.KG_ENABLED", False):
+        from src.retrieval.pipeline.rag_chain import RAGChain  # noqa: PLC0415
+
+        chain = RAGChain(persistent_weaviate=False)
+
+    assert chain._collection_name == VECTOR_COLLECTION_DEFAULT
+
+
+def test_ingest_cli_accepts_collection_flag() -> None:
+    """CLI parser accepts --collection custom_foo and surfaces it as args.collection."""
+    from src.ingest.cli import _build_parser  # noqa: PLC0415
+
+    parser = _build_parser()
+    args = parser.parse_args(
+        ["--file", "/tmp/dummy.pdf", "--collection", "custom_foo"]
+    )
+    assert args.collection == "custom_foo"
+
+
+def test_ingest_cli_collection_flag_short_form() -> None:
+    """-c is an alias for --collection."""
+    from src.ingest.cli import _build_parser  # noqa: PLC0415
+
+    parser = _build_parser()
+    args = parser.parse_args(["--file", "/tmp/dummy.pdf", "-c", "bar_x"])
+    assert args.collection == "bar_x"
+
+
+# ---------------------------------------------------------------------------
+# Live-Weaviate tests (slow + integration)
+# ---------------------------------------------------------------------------
+
+# Dual-marker per project memory feedback_dual_marker_gating: both slow AND
+# integration so `-m "not slow and not integration"` reliably excludes them.
+_live_pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
+
+@pytest.fixture
+def _live_weaviate_client() -> Any:
+    """Yield a real persistent Weaviate client.
+
+    The root tests/conftest.py installs an in-memory ``weaviate`` stub when
+    weaviate is not already in sys.modules. For live-Weaviate tests we must
+    swap the stub out for the real package and reload the vector_db modules
+    that captured the stub at import time. Skips if the live instance is
+    unreachable so the test doesn't pretend-pass when infra is down.
+    """
+    import sys  # noqa: PLC0415
+    import importlib  # noqa: PLC0415
+
+    # Drop the conftest stub (and any sub-stubs) and re-import the real one.
+    for mod_name in list(sys.modules):
+        if mod_name == "weaviate" or mod_name.startswith("weaviate."):
+            del sys.modules[mod_name]
+    try:
+        import weaviate  # noqa: F401, PLC0415
+    except Exception as exc:  # pragma: no cover - infra-dependent
+        pytest.skip(f"Real weaviate package not importable: {exc}")
+
+    # Reload the store and backend modules so they bind to the real
+    # weaviate.classes.{config,query} symbols rather than the stubs.
+    for mod_name in [
+        "src.vector_db.weaviate.store",
+        "src.vector_db.weaviate.backend",
+        "src.vector_db.weaviate.visual_store",
+        "src.vector_db.weaviate",
+        "src.vector_db",
+    ]:
+        if mod_name in sys.modules:
+            try:
+                importlib.reload(sys.modules[mod_name])
+            except Exception:
+                # Reload failures here are non-fatal: if the module isn't
+                # safely reloadable we fall through to the original binding.
+                pass
+
+    from src.vector_db import create_persistent_client, close_client  # noqa: PLC0415
+
+    try:
+        client = create_persistent_client()
+    except Exception as exc:  # pragma: no cover - infra-dependent
+        pytest.skip(f"Live Weaviate not reachable: {exc}")
+
+    try:
+        yield client
+    finally:
+        try:
+            close_client(client)
+        except Exception:
+            pass
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_collection_exists_helper(_live_weaviate_client) -> None:
+    """collection_exists(client, name) returns True for live coll, False otherwise."""
+    from src.vector_db import (  # noqa: PLC0415
+        collection_exists,
+        delete_collection,
+        ensure_collection,
+    )
+
+    client = _live_weaviate_client
+    name = f"ragweave_test_exists_{uuid.uuid4().hex[:10]}"
+    absent = f"ragweave_test_absent_{uuid.uuid4().hex[:10]}"
+
+    try:
+        ensure_collection(client, name)
+        assert collection_exists(client, name) is True
+        assert collection_exists(client, absent) is False
+    finally:
+        try:
+            delete_collection(client, name)
+        except Exception:
+            pass
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_isolation_writes_do_not_leak(_live_weaviate_client) -> None:
+    """Writes to collection A do not appear in collection B (full isolation).
+
+    Uses the real Weaviate add_documents write path through the public
+    vector_db API — no mocking of ensure_collection or add_documents.
+    """
+    import time as _time  # noqa: PLC0415
+
+    from src.vector_db import (  # noqa: PLC0415
+        DocumentRecord,
+        add_documents,
+        delete_collection,
+        ensure_collection,
+    )
+
+    def _count(client_: Any, coll: str) -> int:
+        """Count objects in a collection directly via the low-level client.
+
+        Uses aggregate.over_all(total_count=True) — the same primitive
+        ``get_collection_stats`` is built on, but skipped because we don't
+        need the per-source/per-connector group-bys for this assertion.
+        """
+        return int(
+            client_.collections.get(coll).aggregate.over_all(
+                total_count=True
+            ).total_count or 0
+        )
+
+    suffix = uuid.uuid4().hex[:10]
+    coll_a = f"ragweave_test_a_{suffix}"
+    coll_b = f"ragweave_test_b_{suffix}"
+    client = _live_weaviate_client
+
+    try:
+        ensure_collection(client, coll_a)
+        ensure_collection(client, coll_b)
+
+        # Real write path. 1024-dim zero vector matches the schema's vector dim
+        # config (vectorizer=none expects caller-provided vectors of arbitrary
+        # length; the schema does not enforce dim at insert time).
+        record = DocumentRecord(
+            text="hello collection A",
+            embedding=[0.0] * 1024,
+            metadata={
+                "source": "test://isolation",
+                "source_key": f"isolation-{suffix}",
+                "chunk_index": 0,
+            },
+        )
+
+        n_added = add_documents(client, [record], collection=coll_a)
+        assert n_added == 1, f"add_documents returned {n_added}, expected 1"
+
+        # Weaviate aggregate is eventually consistent — give the indexer up to
+        # ~5s to catch up before asserting (real production loads do not hit
+        # this; the loop is conservative for CI timing variance only).
+        count_a = 0
+        for _ in range(10):
+            count_a = _count(client, coll_a)
+            if count_a > 0:
+                break
+            _time.sleep(0.5)
+        count_b = _count(client, coll_b)
+
+        assert count_a > 0, f"Collection A should have chunks; got {count_a}"
+        assert count_b == 0, f"Collection B should be empty; got {count_b}"
+    finally:
+        for name in (coll_a, coll_b):
+            try:
+                delete_collection(client, name)
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
- Adds `evals/packs/opentitan_riscv/` — OpenTitan/Ibex/RISC-V reference corpus (5 markdown docs covering HMAC, UART, Ibex overview, privileged CSRs, ISA intro) with `manifest.json`, `pack.yaml`, and `thresholds.yaml`.
- Adds `scripts/eval_ingest.py` — pack-aware ingest helper that resolves the pack, validates it, and drives the existing ingest pipeline into a named collection.
- Ships a placeholder empty `goldens/factoid.jsonl` so the P0.5 validator accepts the corpus-only pack (goldens authored in P2).

## Test plan
- [x] `uv run pytest tests/eval/test_opentitan_pack_ingest.py -q` — 2 fast passed + 1 live-Weaviate skipped (gated by `slow + integration`).
- [x] Full regression sweep — 607 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)