### PR TITLE
feat(eval): P8a.0 — run_eval() library core + persist_eval_report (orchestrator foundation)

### DIFF
--- a/src/eval/__init__.py
+++ b/src/eval/__init__.py
@@ -15,6 +15,7 @@
 #       runner.retrieve adds src.core.embeddings + src.vector_db;
 #       runner.judge adds src.common.llm.provider at first use).
 # @end-summary
+from .cli import EvalRunResult, run_eval
 from .pack import EvalPack, PackValidationError, load_pack, validate_pack
 from .runner import (
     EvalReport,
@@ -51,6 +52,7 @@ from .runner import (
 __all__ = [
     "EvalPack",
     "EvalReport",
+    "EvalRunResult",
     "FaithfulnessResults",
     "GateFailure",
     "GateResult",
@@ -79,6 +81,7 @@ __all__ = [
     "render_ci_summary",
     "render_judge_prompt",
     "retrieve_for_goldens",
+    "run_eval",
     "score_goldens",
     "validate_eval_report",
     "validate_pack",

--- a/src/eval/cli.py
+++ b/src/eval/cli.py
@@ -10,7 +10,13 @@
 # P7d adds the CI summary write seam: --summary-file / $GITHUB_STEP_SUMMARY
 # auto-detect, rendering via src.eval.runner.render_ci_summary on BOTH the
 # gate-pass and gate-fail paths (never on exit-2/exit-3 paths).
-# Exports: _build_parser, run_cli, main
+# P8a.0 extracts a reusable, return-the-objects core: run_eval(...) performs
+# Phase 1+2 and RETURNS an EvalRunResult (pack/report/gate/collection_name/
+# faithfulness_results); run_cli is now a thin wrapper that maps run_eval's
+# raised errors to exit codes (2/3) and runs Phase 3 (emit + CI summary)
+# unchanged. _report_payload single-sources the JSON shape shared by
+# _emit_json and runner.persistence.persist_eval_report.
+# Exports: _build_parser, _report_payload, run_eval, EvalRunResult, run_cli, main
 # Deps: argparse, json, logging, os, sys; src.eval.pack (errors, loader);
 #       src.eval.runner (lazy) — execute_plan, retrieve_for_goldens,
 #       score_goldens, build_judge_client, build_eval_report,
@@ -34,6 +40,7 @@ import json
 import logging
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
@@ -172,21 +179,15 @@ def _emit_text(report, gate, *, stdout, stderr) -> None:
             )
 
 
-def _emit_json(
-    report,
-    gate,
-    *,
-    stdout,
-    faithfulness_results=None,
-    show_samples: bool = False,
-) -> None:
-    """Emit a single-line JSON payload with the report + gate outcome.
+def _report_payload(report, gate) -> dict[str, Any]:
+    """Build the canonical report+gate JSON payload dict (single source).
 
-    When *show_samples* is True AND *faithfulness_results* is provided,
-    the payload also carries ``per_query_samples``: a mapping from qid
-    to a list of ``{score, reasoning}`` dicts (one per judge sample).
+    Both :func:`_emit_json` and :func:`persist_eval_report
+    <src.eval.runner.persistence.persist_eval_report>` consume this so the
+    serialized eval shape is single-sourced and cannot drift between the
+    stdout emission and the persisted report file.
     """
-    payload = {
+    return {
         "collection_name": report.collection_name,
         "k": report.k,
         "passed": gate.passed,
@@ -210,6 +211,23 @@ def _emit_json(
         "total_queries_skipped": report.total_queries_skipped,
         "total_queries_judged": report.total_queries_judged,
     }
+
+
+def _emit_json(
+    report,
+    gate,
+    *,
+    stdout,
+    faithfulness_results=None,
+    show_samples: bool = False,
+) -> None:
+    """Emit a single-line JSON payload with the report + gate outcome.
+
+    When *show_samples* is True AND *faithfulness_results* is provided,
+    the payload also carries ``per_query_samples``: a mapping from qid
+    to a list of ``{score, reasoning}`` dicts (one per judge sample).
+    """
+    payload = _report_payload(report, gate)
     if show_samples and faithfulness_results is not None:
         payload["per_query_samples"] = {
             qid: [
@@ -249,6 +267,163 @@ def _write_ci_summary(report, gate, summary_file, *, stderr) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Reusable eval core (library surface)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EvalRunResult:
+    """Immutable bundle of everything a single eval run produces.
+
+    Returned by :func:`run_eval` so callers (the CLI, and the P8a
+    orchestrator) can persist, alert on, or render the result objects
+    without re-deriving them. Fields are additive/trailing-friendly:
+    ``faithfulness_results`` is whatever ``score_goldens`` returns and is
+    carried so ``--show-samples`` can render per-sample judge scores.
+    """
+
+    pack: Any
+    report: Any
+    gate: Any
+    collection_name: str
+    faithfulness_results: Any
+
+
+def run_eval(
+    pack_path: str,
+    *,
+    k: int = 5,
+    fresh: bool = True,
+    samples_per_claim: int | None = None,
+    max_parallel_judges: int | None = None,
+    chat_model_factory: Callable[..., Any] | None = None,
+    verbose: bool = False,
+    stderr: Any = None,
+) -> "EvalRunResult":
+    """Run the full eval pipeline against ``pack_path`` and RETURN the results.
+
+    This is the reusable library core extracted from :func:`run_cli`. It
+    performs Phase 1 (``load_pack``) and Phase 2 (plan → execute → retrieve →
+    judge → aggregate → build report → gate) and returns the populated
+    :class:`EvalRunResult`.
+
+    Unlike :func:`run_cli`, this function does NOT map errors to exit codes:
+
+    * ``PackValidationError`` / ``FileNotFoundError`` propagate for pack
+      load/validation errors (the CLI maps these to exit 2).
+    * Any other exception propagates for runtime/infra errors (the CLI maps
+      these to exit 3).
+
+    Emission, CI-summary writing, and exit-code translation are the CLI's
+    responsibility and live in :func:`run_cli`.
+    """
+    if stderr is None:
+        stderr = sys.stderr
+
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
+    # --- Phase 1: load (PackValidationError / FileNotFoundError propagate) ---
+    from src.eval.pack import load_pack
+
+    pack = load_pack(pack_path)
+    pack_dir = Path(pack_path)
+
+    # --- Phase 2: ingest → retrieve → judge → report → gate (errors propagate) ---
+    # Lazy import: avoid pulling LLM stubs at module-top.
+    from src.eval import runner as runner_pkg
+    from src.eval.runner import (
+        aggregate_mrr_by_qtype,
+        aggregate_recall_by_qtype,
+        build_eval_report,
+        plan_pack_ingest,
+        read_max_parallel_judges,
+        read_samples_per_claim,
+        retrieve_for_goldens,
+        score_goldens,
+        validate_eval_report,
+    )
+
+    effective_samples = (
+        samples_per_claim
+        if samples_per_claim is not None
+        else read_samples_per_claim(pack)
+    )
+    effective_parallel = (
+        max_parallel_judges
+        if max_parallel_judges is not None
+        else read_max_parallel_judges(pack)
+    )
+
+    plan = plan_pack_ingest(pack, pack_dir)
+    ingest_report = runner_pkg.execute_plan(plan, fresh=fresh)
+    logger.info(
+        "Ingest complete: collection=%s docs=%d chunks=%d",
+        ingest_report.collection_name,
+        ingest_report.document_count,
+        ingest_report.stored_chunks,
+    )
+
+    retrieval_results = retrieve_for_goldens(
+        ingest_report.collection_name, pack.goldens, k=k
+    )
+
+    judge_client = runner_pkg.build_judge_client(
+        pack,
+        chat_model_factory=chat_model_factory,
+        pack_dir=pack_dir,
+    )
+    faithfulness_results = score_goldens(
+        retrieval_results,
+        pack.goldens,
+        judge_client,
+        samples_per_claim=effective_samples,
+        max_parallel_judges=effective_parallel,
+    )
+
+    recall_by_qtype = aggregate_recall_by_qtype(retrieval_results, pack.goldens)
+    mrr_by_qtype = aggregate_mrr_by_qtype(retrieval_results, pack.goldens)
+    # Per-query recall + mrr: computed in-line (mirror each other) for the
+    # per-qid threshold-override checks in the gate (P7f).
+    from src.eval.runner.metrics import recall_at_k as _recall_at_k
+    from src.eval.runner.metrics import reciprocal_rank as _reciprocal_rank
+
+    per_query_recall: dict[str, float] = {}
+    per_query_mrr: dict[str, float] = {}
+    for qtype, golden_list in pack.goldens.items():
+        for golden in golden_list:
+            if not golden.expected_source_docs:
+                continue
+            qr = retrieval_results.per_query.get(golden.qid)
+            if qr is None:
+                continue
+            per_query_recall[golden.qid] = _recall_at_k(
+                qr.retrieved_sources, golden.expected_source_docs
+            )
+            per_query_mrr[golden.qid] = _reciprocal_rank(
+                qr.retrieved_sources, golden.expected_source_docs
+            )
+
+    report = build_eval_report(
+        retrieval_results,
+        faithfulness_results,
+        recall_by_qtype,
+        per_query_recall,
+        mrr_by_qtype=mrr_by_qtype,
+        per_query_mrr=per_query_mrr,
+    )
+    gate = validate_eval_report(pack, report)
+
+    return EvalRunResult(
+        pack=pack,
+        report=report,
+        gate=gate,
+        collection_name=report.collection_name,
+        faithfulness_results=faithfulness_results,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Orchestrator
 # ---------------------------------------------------------------------------
 
@@ -284,108 +459,25 @@ def run_cli(
     if verbose:
         logging.basicConfig(level=logging.DEBUG)
 
-    # --- Phase 1: load (errors → exit 2) ---
-    from src.eval.pack import load_pack
+    # --- Phase 1+2: delegate to the reusable core, mapping errors to codes. ---
+    # Pack load/validation errors → exit 2; any other runtime/infra error → 3.
+    # The byte-identical stderr messages + return values are preserved here.
     from src.eval.pack.errors import PackValidationError
 
     try:
-        pack = load_pack(pack_path)
-    except PackValidationError as exc:
-        print(f"pack load error: {exc}", file=stderr)
-        return 2
-    except FileNotFoundError as exc:
-        print(f"pack load error: {exc}", file=stderr)
-        return 2
-
-    pack_dir = Path(pack_path)
-
-    # --- Phase 2+: ingest → retrieve → judge → report → gate (errors → exit 3) ---
-    try:
-        # Lazy import: avoid pulling LLM stubs at module-top.
-        from src.eval import runner as runner_pkg
-        from src.eval.runner import (
-            aggregate_mrr_by_qtype,
-            aggregate_recall_by_qtype,
-            build_eval_report,
-            plan_pack_ingest,
-            read_max_parallel_judges,
-            read_samples_per_claim,
-            retrieve_for_goldens,
-            score_goldens,
-            validate_eval_report,
-        )
-
-        effective_samples = (
-            samples_per_claim
-            if samples_per_claim is not None
-            else read_samples_per_claim(pack)
-        )
-        effective_parallel = (
-            max_parallel_judges
-            if max_parallel_judges is not None
-            else read_max_parallel_judges(pack)
-        )
-
-        plan = plan_pack_ingest(pack, pack_dir)
-        ingest_report = runner_pkg.execute_plan(plan, fresh=fresh)
-        logger.info(
-            "Ingest complete: collection=%s docs=%d chunks=%d",
-            ingest_report.collection_name,
-            ingest_report.document_count,
-            ingest_report.stored_chunks,
-        )
-
-        retrieval_results = retrieve_for_goldens(
-            ingest_report.collection_name, pack.goldens, k=k
-        )
-
-        judge_client = runner_pkg.build_judge_client(
-            pack,
+        result = run_eval(
+            pack_path,
+            k=k,
+            fresh=fresh,
+            samples_per_claim=samples_per_claim,
+            max_parallel_judges=max_parallel_judges,
             chat_model_factory=chat_model_factory,
-            pack_dir=pack_dir,
+            verbose=verbose,
+            stderr=stderr,
         )
-        faithfulness_results = score_goldens(
-            retrieval_results,
-            pack.goldens,
-            judge_client,
-            samples_per_claim=effective_samples,
-            max_parallel_judges=effective_parallel,
-        )
-
-        recall_by_qtype = aggregate_recall_by_qtype(
-            retrieval_results, pack.goldens
-        )
-        mrr_by_qtype = aggregate_mrr_by_qtype(retrieval_results, pack.goldens)
-        # Per-query recall + mrr: computed in-line (mirror each other) for the
-        # per-qid threshold-override checks in the gate (P7f).
-        from src.eval.runner.metrics import recall_at_k as _recall_at_k
-        from src.eval.runner.metrics import reciprocal_rank as _reciprocal_rank
-
-        per_query_recall: dict[str, float] = {}
-        per_query_mrr: dict[str, float] = {}
-        for qtype, golden_list in pack.goldens.items():
-            for golden in golden_list:
-                if not golden.expected_source_docs:
-                    continue
-                qr = retrieval_results.per_query.get(golden.qid)
-                if qr is None:
-                    continue
-                per_query_recall[golden.qid] = _recall_at_k(
-                    qr.retrieved_sources, golden.expected_source_docs
-                )
-                per_query_mrr[golden.qid] = _reciprocal_rank(
-                    qr.retrieved_sources, golden.expected_source_docs
-                )
-
-        report = build_eval_report(
-            retrieval_results,
-            faithfulness_results,
-            recall_by_qtype,
-            per_query_recall,
-            mrr_by_qtype=mrr_by_qtype,
-            per_query_mrr=per_query_mrr,
-        )
-        gate = validate_eval_report(pack, report)
+    except (PackValidationError, FileNotFoundError) as exc:
+        print(f"pack load error: {exc}", file=stderr)
+        return 2
     except Exception as exc:  # noqa: BLE001 — infra failures are bucketed to exit 3.
         print(f"eval runtime error: {type(exc).__name__}: {exc}", file=stderr)
         if verbose:
@@ -393,6 +485,10 @@ def run_cli(
 
             traceback.print_exc(file=stderr)
         return 3
+
+    report = result.report
+    gate = result.gate
+    faithfulness_results = result.faithfulness_results
 
     # --- Phase 3: emit + gate-to-exit-code ---
     if format == "json":

--- a/src/eval/runner/__init__.py
+++ b/src/eval/runner/__init__.py
@@ -8,7 +8,7 @@
 #          aggregate_faithfulness_by_qtype,
 #          score_goldens, build_eval_report, build_judge_client,
 #          load_judge_prompt, render_judge_prompt, read_samples_per_claim,
-#          read_max_parallel_judges, render_ci_summary.
+#          read_max_parallel_judges, render_ci_summary, persist_eval_report.
 # Deps: .plan (pure), .report (frozen dataclasses + build_eval_report),
 #       .execute (ingest + vector_db), .retrieve (vector_db search +
 #       embeddings), .metrics (pure recall@k), .judge (pluggable judge
@@ -52,6 +52,7 @@ from .metrics import (
     recall_at_k,
     reciprocal_rank,
 )
+from .persistence import persist_eval_report
 from .plan import IngestPlan, plan_pack_ingest
 from .report import EvalReport, IngestReport, build_eval_report
 from .retrieve import QueryRetrievalResult, RetrievalResults, retrieve_for_goldens
@@ -76,6 +77,7 @@ __all__ = [
     "build_judge_client",
     "execute_plan",
     "load_judge_prompt",
+    "persist_eval_report",
     "plan_pack_ingest",
     "read_max_parallel_judges",
     "read_samples_per_claim",

--- a/src/eval/runner/persistence.py
+++ b/src/eval/runner/persistence.py
@@ -1,0 +1,72 @@
+# @summary
+# P8a.0 — report persistence primitive. persist_eval_report writes an
+# EvalRunResult's report+gate to a JSON file under output_dir, named
+# <pack_name>_<filesafe-iso-timestamp>.json, carrying the same eval payload
+# shape _emit_json produces (single-sourced via cli._report_payload) PLUS
+# top-level pack_name + timestamp. The orchestrator (P8a) consumes these files
+# to persist and alert on eval runs.
+# Exports: persist_eval_report
+# Deps: stdlib (datetime, json, pathlib); src.eval.cli._report_payload (shared
+#       payload builder — single source for the JSON shape).
+# @end-summary
+"""Eval report persistence (P8a.0).
+
+``persist_eval_report`` is a thin I/O primitive: it serializes the
+report+gate payload (single-sourced from :func:`src.eval.cli._report_payload`)
+plus a ``pack_name`` and ISO-8601 ``timestamp`` to a deterministically named
+JSON file, and returns the written path. It performs no gating, emission, or
+exit-code logic — the next slice (P8a orchestrator) layers diff/alert on top.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def persist_eval_report(
+    result: Any,
+    output_dir: str | Path,
+    *,
+    pack_name: str | None = None,
+    now: datetime | None = None,
+) -> Path:
+    """Write ``result``'s report+gate to a JSON file and return its path.
+
+    The JSON payload is exactly the shape :func:`src.eval.cli._emit_json`
+    produces (built via the shared ``_report_payload`` helper so the two
+    cannot drift) extended with two top-level keys:
+
+    * ``pack_name`` — defaults to ``result.pack.meta.name``.
+    * ``timestamp`` — ISO-8601 string of ``now``.
+
+    :param result: an :class:`~src.eval.cli.EvalRunResult`.
+    :param output_dir: directory to write into (created if absent).
+    :param pack_name: override for the pack name (filename + payload).
+    :param now: injected timestamp for deterministic tests; defaults to
+        ``datetime.now(timezone.utc)`` (timezone-aware, not the deprecated
+        ``datetime.utcnow()``).
+    :returns: the :class:`~pathlib.Path` written.
+    """
+    # Local import to avoid a module-import cycle (cli imports run_eval which
+    # this module's sibling package re-exports); resolved lazily at call time.
+    from src.eval.cli import _report_payload
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+    if pack_name is None:
+        pack_name = result.pack.meta.name
+
+    payload = _report_payload(result.report, result.gate)
+    payload["pack_name"] = pack_name
+    payload["timestamp"] = now.isoformat()
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Filesafe timestamp: colons are illegal on some filesystems, so drop them.
+    filesafe_ts = now.isoformat().replace(":", "")
+    path = out_dir / f"{pack_name}_{filesafe_ts}.json"
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path

--- a/tests/eval/test_cli.py
+++ b/tests/eval/test_cli.py
@@ -246,6 +246,65 @@ def test_cli_gate_fail_returns_one(tmp_path: Path, monkeypatch, capsys) -> None:
     assert "recall_at_5" in err
 
 
+def test_cli_missing_pack_judge_prompt_exits_2(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """A Phase-2 FileNotFoundError (missing pack-referenced judge prompt) maps to
+    exit 2 (pack error), not exit 3 — pins the P8a.0 refactor's exit-code contract.
+
+    The pack authors a ``prompts/`` directory but omits ``judge_v1.md`` for its
+    declared ``tier1_prompt_version: v1``. Phase 1 (load_pack) succeeds — the
+    missing prompt is NOT a load-time concern — so we exercise the REAL Phase-2
+    judge path: ``build_judge_client`` → ``load_judge_prompt`` raises a genuine
+    ``FileNotFoundError`` (see src/eval/runner/judge.py: when ``prompts/`` exists
+    we do not fall back to the packaged default). The single
+    ``except (PackValidationError, FileNotFoundError)`` branch must catch it →
+    exit 2, NOT the ``except Exception`` → exit 3 branch.
+    """
+    from src.eval.cli import run_cli
+
+    pack_dir = _make_synthetic_pack(tmp_path)
+    # Author a prompts/ dir WITHOUT judge_v1.md → load_judge_prompt raises a
+    # real FileNotFoundError (no silent fallback to the packaged default).
+    (pack_dir / "prompts").mkdir()
+
+    # Patch execute_plan + retrieval infra so Phase 2 reaches the judge step
+    # WITHOUT touching Weaviate, but leave build_judge_client REAL so the
+    # FileNotFoundError originates specifically from the judge-prompt path.
+    from src.eval.runner import retrieve as retrieve_mod
+    from src.eval.runner import report as report_mod
+    from src.vector_db.common.schemas import SearchResult
+    import src.eval.runner as runner_pkg
+
+    def fake_execute_plan(plan, *, fresh: bool = True):
+        return report_mod.IngestReport(
+            collection_name=plan.collection_name,
+            processed=1, skipped=0, failed=0, stored_chunks=1,
+            document_count=1, plan=plan, errors=(),
+        )
+
+    def fake_search(client, query, query_embedding, alpha, limit, **kwargs):
+        return [SearchResult(text="alpha", score=1.0, metadata={"source": "doc1.md"})]
+
+    monkeypatch.setattr(runner_pkg, "execute_plan", fake_execute_plan)
+    monkeypatch.setattr(retrieve_mod, "search", fake_search)
+    monkeypatch.setattr(retrieve_mod, "get_embedding_provider", lambda: _FakeEmbedder())
+    monkeypatch.setattr(retrieve_mod, "create_persistent_client", lambda: object())
+    monkeypatch.setattr(retrieve_mod, "close_client", lambda _c: None)
+
+    # Real build_judge_client constructs a chat model BEFORE loading the prompt;
+    # inject a no-op factory so no live LLM is touched and the FileNotFoundError
+    # comes solely from load_judge_prompt.
+    def noop_factory(*, model_alias, temperature):
+        return object()
+
+    rc = run_cli(str(pack_dir), chat_model_factory=noop_factory)
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "pack load error" in err
+    assert "judge_v1.md" in err
+
+
 def test_cli_runtime_error_exits_3(tmp_path: Path, monkeypatch, capsys) -> None:
     """execute_plan raises → exit 3 (infra error)."""
     from src.eval.cli import run_cli

--- a/tests/eval/test_persistence.py
+++ b/tests/eval/test_persistence.py
@@ -1,0 +1,114 @@
+# @summary
+# P8a.0 — tests for persist_eval_report: writes a parseable JSON report file
+# whose eval payload matches _emit_json's shape (single-source proof), plus
+# top-level pack_name + timestamp, with a deterministic injected-now filename.
+# Reuses _make_synthetic_pack / _patch_full_chain from tests.eval.test_cli.
+# Exports: test_persist_writes_parseable_json_with_full_shape,
+#          test_persist_path_uses_pack_name_and_injected_timestamp,
+#          test_persist_payload_matches_emit_json_shape
+# Deps: src.eval.run (run_eval); src.eval.runner (persist_eval_report);
+#       src.eval.cli (_emit_json); tests.eval.test_cli
+# @end-summary
+"""P8a.0 — persist_eval_report tests."""
+from __future__ import annotations
+
+import io
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.eval.test_cli import _make_synthetic_pack, _patch_full_chain
+
+
+def _run(tmp_path: Path, monkeypatch, *, judge_score: float = 0.9):
+    from src.eval import run_eval
+
+    pack_dir = _make_synthetic_pack(
+        tmp_path, recall_floor=0.5, faithfulness_floor=0.5
+    )
+    _patch_full_chain(monkeypatch, judge_score=judge_score)
+    return run_eval(str(pack_dir))
+
+
+def test_persist_writes_parseable_json_with_full_shape(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """persist_eval_report writes a parseable JSON file carrying the full key
+    set INCLUDING pack_name, timestamp, mrr_by_qtype, the three per_query maps,
+    and failures[].qid."""
+    from src.eval.runner import persist_eval_report
+
+    result = _run(tmp_path, monkeypatch)
+    out_dir = tmp_path / "reports"
+    path = persist_eval_report(result, out_dir)
+
+    assert path.exists()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    for key in (
+        "pack_name",
+        "timestamp",
+        "collection_name",
+        "k",
+        "passed",
+        "failures",
+        "recall_by_qtype",
+        "faithfulness_by_qtype",
+        "mrr_by_qtype",
+        "per_query_recall",
+        "per_query_mrr",
+        "per_query_faithfulness",
+        "total_queries_scored",
+        "total_queries_skipped",
+        "total_queries_judged",
+    ):
+        assert key in payload, f"persisted payload missing key {key!r}: {payload}"
+
+    # failures entries must carry a qid field (empty for qtype-level failures).
+    for failure in payload["failures"]:
+        assert "qid" in failure
+
+
+def test_persist_path_uses_pack_name_and_injected_timestamp(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An injected now=<fixed datetime> makes the filename deterministic and
+    embeds the pack name."""
+    from src.eval.runner import persist_eval_report
+
+    result = _run(tmp_path, monkeypatch)
+    out_dir = tmp_path / "reports"
+    fixed = datetime(2026, 5, 30, 12, 34, 56, tzinfo=timezone.utc)
+
+    path = persist_eval_report(result, out_dir, now=fixed)
+
+    # pack name from the synthetic pack is "synpack".
+    assert "synpack" in path.name
+    # The fixed timestamp is embedded in a filesafe form (no colons).
+    assert "2026" in path.name
+    assert ":" not in path.name
+    # Deterministic: a second call with the same now lands on the same path.
+    path2 = persist_eval_report(result, out_dir, now=fixed)
+    assert path2 == path
+
+
+def test_persist_payload_matches_emit_json_shape(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The persisted eval payload's keys equal _emit_json's payload keys (minus
+    the persistence-only pack_name/timestamp). Single-source drift guard."""
+    from src.eval.cli import _emit_json
+    from src.eval.runner import persist_eval_report
+
+    result = _run(tmp_path, monkeypatch)
+
+    out_dir = tmp_path / "reports"
+    path = persist_eval_report(result, out_dir)
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+
+    buf = io.StringIO()
+    _emit_json(result.report, result.gate, stdout=buf)
+    emitted = json.loads(buf.getvalue())
+
+    persisted_eval_keys = set(persisted) - {"pack_name", "timestamp"}
+    assert persisted_eval_keys == set(emitted)

--- a/tests/eval/test_run_eval.py
+++ b/tests/eval/test_run_eval.py
@@ -1,0 +1,73 @@
+# @summary
+# P8a.0 — tests for the reusable run_eval(...) core extracted from run_cli.
+# Asserts run_eval RETURNS an EvalRunResult (report + gate + collection_name +
+# faithfulness_results + pack) rather than an exit code, and that it RAISES on
+# pack errors instead of mapping them to exit codes.
+# Reuses _make_synthetic_pack / _patch_full_chain from tests.eval.test_cli.
+# Exports: test_run_eval_returns_report_and_gate,
+#          test_run_eval_gate_fails_on_low_metrics,
+#          test_run_eval_raises_on_bad_pack
+# Deps: src.eval.run (run_eval, EvalRunResult); src.eval.runner; tests.eval.test_cli
+# @end-summary
+"""P8a.0 — run_eval core tests (returns result objects, raises on bad pack)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.eval.test_cli import _make_synthetic_pack, _patch_full_chain
+
+
+def test_run_eval_returns_report_and_gate(tmp_path: Path, monkeypatch) -> None:
+    """run_eval returns an EvalRunResult with a populated report + passing gate."""
+    from src.eval import EvalRunResult, run_eval
+    from src.eval.runner import EvalReport, GateResult
+
+    pack_dir = _make_synthetic_pack(
+        tmp_path, recall_floor=0.5, faithfulness_floor=0.5
+    )
+    _patch_full_chain(monkeypatch, judge_score=0.9)
+
+    result = run_eval(str(pack_dir))
+
+    assert isinstance(result, EvalRunResult)
+    assert isinstance(result.report, EvalReport)
+    assert isinstance(result.gate, GateResult)
+    # recall=1.0 (retrieval hits doc1.md), faithfulness=0.9 → both above floor.
+    assert result.report.recall_by_qtype["factoid"] == 1.0
+    assert result.gate.passed is True
+    assert result.collection_name
+    assert result.collection_name == result.report.collection_name
+    # faithfulness_results is threaded through (needed for --show-samples).
+    assert result.faithfulness_results is not None
+
+
+def test_run_eval_gate_fails_on_low_metrics(tmp_path: Path, monkeypatch) -> None:
+    """A retrieval miss drives recall below floor → gate fails (one-step-below
+    partner to the pass test)."""
+    from src.eval import run_eval
+
+    pack_dir = _make_synthetic_pack(
+        tmp_path, recall_floor=0.5, faithfulness_floor=0.5
+    )
+    # Retrieval returns the wrong source → recall=0.0 < 0.5 floor.
+    _patch_full_chain(monkeypatch, retrieved_source="other.md", judge_score=0.9)
+
+    result = run_eval(str(pack_dir))
+
+    assert result.gate.passed is False
+    assert result.gate.failures, "expected at least one GateFailure"
+    metrics = {f.metric for f in result.gate.failures}
+    assert "recall_at_5" in metrics
+
+
+def test_run_eval_raises_on_bad_pack(tmp_path: Path) -> None:
+    """A nonexistent pack path RAISES (PackValidationError/FileNotFoundError),
+    it does NOT return an int exit code."""
+    from src.eval import run_eval
+    from src.eval.pack import PackValidationError
+
+    bogus = tmp_path / "no_such_pack"
+    with pytest.raises((PackValidationError, FileNotFoundError)):
+        run_eval(str(bogus))


### PR DESCRIPTION
## Stack

First slice of the **P8 — Orchestrator + baseline diff** mini-stack (the plan's P7→P8). Base: develop (eval loop P0–P7g fully landed).

- **P8a.0 — eval-as-library + persistence** ← this PR
- P8a — `scripts/run_nightly_eval.py` (orchestrator) + alert stub + injected-regression e2e → P8a.0
- P8b — baseline store + diff + promotion command → P8a

## Why

The orchestrator (P8a) and baseline diff (P8b) both need the eval pipeline's **result objects** (`EvalReport`, `GateResult`), but `run_cli` only returns an `int` exit code and emits to stdout. P8a.0 extracts a reusable core, following CLAUDE.md's "separate orchestration from business logic; thin facade."

## What

- **`run_eval(...) -> EvalRunResult`** — performs the old `run_cli` Phase 1+2 (load → plan → execute → retrieve → judge → aggregate → build_report → gate) **verbatim** and **raises** on error (no exit-code mapping). `EvalRunResult` (frozen): `pack, report, gate, collection_name, faithfulness_results`.
- **`run_cli` is now a thin wrapper** over `run_eval` — same try/except → exit codes, Phase 3 (emit + CI summary + `return 0/1`) **unchanged**. All 15 `test_cli.py` tests green = behavior-preserving on every tested path.
- **`persist_eval_report(result, output_dir, *, pack_name=None, now=None) -> Path`** (new `src/eval/runner/persistence.py`) — writes `<pack_name>_<filesafe-iso>.json` with the full report payload + `pack_name` + `timestamp`. Injectable `now` for deterministic tests; `datetime.now(timezone.utc)` (not deprecated `utcnow`).
- **`_report_payload(report, gate)`** — single-sourced helper now used by BOTH `_emit_json` and `persist_eval_report` so the JSON shape can't drift.

## Exit-code contract (intentional, pinned)

A Phase-2 `FileNotFoundError` from a missing pack-referenced judge prompt now maps to exit **2** (pack error), not 3 — a missing pack resource is a pack problem, not infra. `test_cli_missing_pack_judge_prompt_exits_2` pins it (verified: narrowing the catch → test reds at rc=3; `test_cli_runtime_error_exits_3` confirms `RuntimeError` still → 3, proving the catch is correctly typed).

## Test plan

- [x] +7 tests: `test_run_eval.py` (returns real report/gate; gate-fail partner; raises-on-bad-pack), `test_persistence.py` (full-shape JSON, injected-timestamp path, payload==`_emit_json` single-source proof), exit-code pin
- [x] Eval suite: **178 passed / 4 skipped** (was 171)
- [x] Behavior-preserving: all 15 `test_cli.py` tests green; `_emit_json` output still single-line
- [x] Mutations: run_eval-swallows→reds raises-test; drop pack_name→reds shape-test; ignore injected now→reds path-test; `_report_payload` drops mrr→reds BOTH persist AND `_emit_json` tests (single-source proof); narrow exit-catch→reds the pin
- [x] Scope fence: cli.py + 2 `__init__` exports + new persistence.py + 2 new test files; ZERO pipeline-stage-logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)