### PR TITLE
feat(eval): P8a — nightly eval orchestrator (run_nightly + script + alert stub)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ docker-compose.override.yml
 docker-compose.cpu-embed-off.yml
 .gitignore.local
 .tei_cache
+
+# Persisted nightly eval reports (P8a orchestrator) — generated, not source.
+eval_reports/
+evals/*/reports/

--- a/scripts/run_nightly_eval.py
+++ b/scripts/run_nightly_eval.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# @summary
+# P8a — thin CLI shim for the nightly eval orchestrator. Parses argv (pack-root,
+# pack glob, output-dir, k, fresh, verbose), resolves packs via
+# discover_packs, and delegates to run_nightly. NO business logic — everything
+# lives in src.eval.orchestrator. Exit codes: run_nightly's 0/1, or 2 when no
+# packs are discovered (pack error).
+# Exports: main
+# Deps: stdlib (argparse, logging, sys); src.eval.orchestrator.
+# @end-summary
+"""Nightly eval orchestrator CLI shim (P8a).
+
+Usage::
+
+    python scripts/run_nightly_eval.py --pack opentitan_riscv --output-dir eval_reports
+
+This is a thin argparse adapter over :mod:`src.eval.orchestrator`. It discovers
+the requested pack(s), runs the nightly loop, and returns the orchestrator's
+exit code (0 = all passed, 1 = a gate failed or a pack errored). When no packs
+are discovered it prints to stderr and returns 2 (pack error).
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+# Make the repo importable when this file is run directly
+# (``python scripts/run_nightly_eval.py``); harmless when imported as a module.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.eval.orchestrator import discover_packs, run_nightly  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse argv, resolve packs, run the nightly loop, return its exit code."""
+    parser = argparse.ArgumentParser(
+        prog="run_nightly_eval",
+        description="Run the nightly eval loop over discovered eval pack(s).",
+    )
+    parser.add_argument(
+        "--pack-root",
+        default="evals/packs",
+        help="Directory containing eval pack subdirectories (default: evals/packs).",
+    )
+    parser.add_argument(
+        "--pack",
+        default="*",
+        help="Pack name or glob to select (default: '*' = all packs).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="eval_reports",
+        help="Directory to write persisted report JSON files (default: eval_reports).",
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        default=5,
+        help="Top-k retrieval cutoff per query (default: 5).",
+    )
+    parser.add_argument(
+        "--no-fresh",
+        dest="fresh",
+        action="store_false",
+        help="Incremental update mode; do not drop the collection before ingest.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose (DEBUG) logging.",
+    )
+    parser.set_defaults(fresh=True)
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+
+    pack_paths = discover_packs(args.pack_root, args.pack)
+    if not pack_paths:
+        print(
+            f"no eval packs found under {args.pack_root!r} matching {args.pack!r}",
+            file=sys.stderr,
+        )
+        return 2
+
+    return run_nightly(
+        pack_paths,
+        output_dir=args.output_dir,
+        k=args.k,
+        fresh=args.fresh,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/eval/orchestrator.py
+++ b/src/eval/orchestrator.py
@@ -1,0 +1,148 @@
+# @summary
+# P8a — nightly eval orchestrator (testable core; the scripts/ shim is thin).
+# discover_packs globs pack dirs (those containing pack.yaml) under a root.
+# run_nightly iterates packs sequentially: run_eval → persist_eval_report →
+# build AlertPayload from the gate → alert_fn; resilient batch (one pack erroring
+# does not abort the rest); returns 0 iff EVERY pack ran AND passed, else 1.
+# NOTE: NO baseline/diff comparison here — deferred to P8b.
+# Exports: discover_packs, run_nightly
+# Deps: stdlib (json, logging, pathlib, datetime); src.eval.cli.run_eval;
+#       src.eval.runner.persistence.persist_eval_report;
+#       src.eval.runner.alert (AlertPayload, send_alert).
+# @end-summary
+"""Nightly eval orchestrator core (P8a).
+
+Two public functions, both importable and unit-testable (the
+``scripts/run_nightly_eval.py`` shim only does argparse + delegation):
+
+* :func:`discover_packs` — find eval pack directories under a root.
+* :func:`run_nightly` — run the full eval loop over a list of packs, persist
+  each report, alert on each gate result, and return a binary batch exit code.
+
+Per-pack granularity (which pack passed / failed / errored) goes to the logs and
+the persisted JSON files; the batch return value is binary pass/fail. ``alert_fn``
+is the injection seam tests use to capture the shaped :class:`AlertPayload`.
+
+NOTE: baseline/diff comparison against a prior run is NOT part of this slice —
+it is deferred to P8b. This orchestrator only runs → persists → gates → alerts.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from src.eval.cli import run_eval
+from src.eval.runner.alert import AlertPayload, send_alert
+from src.eval.runner.persistence import persist_eval_report
+
+logger = logging.getLogger("rag.eval.orchestrator")
+
+
+def discover_packs(pack_root: str | Path, pack: str = "*") -> list[Path]:
+    """Return eval pack directories under ``pack_root`` matching ``pack``.
+
+    A pack directory is one that contains a ``pack.yaml``. ``pack`` may be an
+    exact name or a glob (default ``"*"`` = all). Results are sorted
+    deterministically by path. Returns ``[]`` if none match — the caller decides
+    whether an empty result is an error.
+    """
+    root = Path(pack_root)
+    if not root.is_dir():
+        return []
+    candidates = [
+        child
+        for child in root.glob(pack)
+        if child.is_dir() and (child / "pack.yaml").is_file()
+    ]
+    return sorted(candidates)
+
+
+def run_nightly(
+    pack_paths: list[Path | str],
+    *,
+    output_dir: str | Path,
+    k: int = 5,
+    fresh: bool = True,
+    chat_model_factory: Callable[..., Any] | None = None,
+    alert_fn: Callable[[AlertPayload], None] = send_alert,
+    now: datetime | None = None,
+    stderr: Any = None,
+) -> int:
+    """Run the full eval loop over ``pack_paths`` and return a batch exit code.
+
+    For EACH pack (sequentially):
+
+    1. :func:`~src.eval.cli.run_eval` — ingest → retrieve → judge → gate.
+    2. :func:`~src.eval.runner.persistence.persist_eval_report` — write the
+       report JSON under ``output_dir``.
+    3. Build an :class:`AlertPayload` from the gate result and hand it to
+       ``alert_fn`` (defaults to the real log-only :func:`send_alert`; tests
+       inject a capturing function).
+    4. Log a one-line summary.
+
+    **Resilient batch:** each pack is wrapped in try/except, so one pack raising
+    in ``run_eval`` does NOT abort the rest — the error is logged, the pack is
+    marked errored, and the loop continues.
+
+    **Exit code:** ``0`` iff EVERY pack ran AND passed its gate; ``1`` if any
+    pack's gate failed OR any pack errored.
+
+    :param now: injected timestamp for deterministic persisted filenames.
+    """
+    # Resolve ``now`` ONCE so the persisted-filename timestamp and the alert
+    # timestamp are the SAME value (and timezone-aware) on the production
+    # default path. Threading the same resolved ``now`` to both
+    # persist_eval_report and AlertPayload avoids desync / tz-naive drift.
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    all_passed = True
+
+    for pack_path in pack_paths:
+        pack_label = str(pack_path)
+        try:
+            result = run_eval(
+                str(pack_path),
+                k=k,
+                fresh=fresh,
+                chat_model_factory=chat_model_factory,
+                stderr=stderr,
+            )
+            report_path = persist_eval_report(result, output_dir, now=now)
+
+            failures = [
+                {
+                    "qtype": f.qtype,
+                    "metric": f.metric,
+                    "expected": f.expected,
+                    "actual": f.actual,
+                    "qid": f.qid,
+                }
+                for f in result.gate.failures
+            ]
+            payload = AlertPayload(
+                pack_name=result.pack.meta.name,
+                collection_name=result.collection_name,
+                gate_passed=result.gate.passed,
+                failures=failures,
+                report_path=str(report_path),
+                timestamp=now.isoformat(),
+            )
+            alert_fn(payload)
+
+            logger.info(
+                "pack=%s gate=%s failures=%d report=%s",
+                result.pack.meta.name,
+                "PASS" if result.gate.passed else "FAIL",
+                len(failures),
+                report_path,
+            )
+            if not result.gate.passed:
+                all_passed = False
+        except Exception as exc:  # noqa: BLE001 — resilient batch: log + continue.
+            all_passed = False
+            logger.error("pack=%s errored: %s: %s", pack_label, type(exc).__name__, exc)
+
+    return 0 if all_passed else 1

--- a/src/eval/runner/__init__.py
+++ b/src/eval/runner/__init__.py
@@ -8,7 +8,8 @@
 #          aggregate_faithfulness_by_qtype,
 #          score_goldens, build_eval_report, build_judge_client,
 #          load_judge_prompt, render_judge_prompt, read_samples_per_claim,
-#          read_max_parallel_judges, render_ci_summary, persist_eval_report.
+#          read_max_parallel_judges, render_ci_summary, persist_eval_report,
+#          AlertPayload, send_alert.
 # Deps: .plan (pure), .report (frozen dataclasses + build_eval_report),
 #       .execute (ingest + vector_db), .retrieve (vector_db search +
 #       embeddings), .metrics (pure recall@k), .judge (pluggable judge
@@ -27,6 +28,7 @@ the executor (``score_goldens`` + ``aggregate_faithfulness_by_qtype`` +
 """
 from __future__ import annotations
 
+from .alert import AlertPayload, send_alert
 from .ci import render_ci_summary
 from .execute import execute_plan
 from .gate import GateFailure, GateResult, validate_eval_report
@@ -58,6 +60,7 @@ from .report import EvalReport, IngestReport, build_eval_report
 from .retrieve import QueryRetrievalResult, RetrievalResults, retrieve_for_goldens
 
 __all__ = [
+    "AlertPayload",
     "EvalReport",
     "FaithfulnessResults",
     "GateFailure",
@@ -87,5 +90,6 @@ __all__ = [
     "render_judge_prompt",
     "retrieve_for_goldens",
     "score_goldens",
+    "send_alert",
     "validate_eval_report",
 ]

--- a/src/eval/runner/alert.py
+++ b/src/eval/runner/alert.py
@@ -1,0 +1,79 @@
+# @summary
+# P8a — eval alert payload + log-only sink. AlertPayload is the frozen,
+# transport-agnostic shape of a nightly gate result (pack/collection/passed/
+# failures/report_path/timestamp). send_alert is a LOG-ONLY stub: info on pass,
+# warning (per-failure) on fail. Real Slack/webhook wiring is a later slice.
+# Exports: AlertPayload, send_alert
+# Deps: stdlib (dataclasses, logging).
+# @end-summary
+"""Eval alert payload + log-only sink (P8a).
+
+:class:`AlertPayload` is the transport-agnostic shape the nightly orchestrator
+builds from each pack's :class:`~src.eval.runner.gate.GateResult`.
+:func:`send_alert` is the current sink — a log-only stub so the orchestrator's
+alert seam is exercised end-to-end now while the real Slack/webhook delivery is
+deferred to a later slice. Tests inject a capturing ``alert_fn`` instead.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger("rag.eval.alert")
+
+
+@dataclass(frozen=True)
+class AlertPayload:
+    """Immutable, transport-agnostic snapshot of one pack's gate outcome.
+
+    :param pack_name: the eval pack's name (``pack.meta.name``).
+    :param collection_name: the Weaviate collection the run targeted.
+    :param gate_passed: ``True`` iff the gate had no failures.
+    :param failures: the GateFailure dicts
+        (``{qtype, metric, expected, actual, qid}``); empty on pass.
+    :param report_path: filesystem path of the persisted report JSON.
+    :param timestamp: ISO-8601 timestamp of the run.
+    """
+
+    pack_name: str
+    collection_name: str
+    gate_passed: bool
+    failures: list[dict]
+    report_path: str
+    timestamp: str
+
+
+def send_alert(payload: AlertPayload) -> None:
+    """Emit ``payload`` to the log (the current, log-only alert sink).
+
+    On pass: a single ``INFO`` line. On fail: a ``WARNING`` line naming the pack
+    plus one ``WARNING`` line per failure (qtype/metric/expected/actual). Real
+    delivery (Slack/webhook) is wired in a later slice; this keeps the
+    orchestrator's alert seam observable today.
+    """
+    if payload.gate_passed:
+        logger.info(
+            "eval gate PASSED: pack=%s collection=%s report=%s",
+            payload.pack_name,
+            payload.collection_name,
+            payload.report_path,
+        )
+        return
+
+    logger.warning(
+        "eval gate FAILED: pack=%s collection=%s failures=%d report=%s",
+        payload.pack_name,
+        payload.collection_name,
+        len(payload.failures),
+        payload.report_path,
+    )
+    for failure in payload.failures:
+        logger.warning(
+            "  pack=%s FAIL qtype=%s metric=%s expected>=%s actual=%s qid=%s",
+            payload.pack_name,
+            failure.get("qtype", ""),
+            failure.get("metric", ""),
+            failure.get("expected"),
+            failure.get("actual"),
+            failure.get("qid", ""),
+        )

--- a/tests/eval/test_orchestrator_e2e.py
+++ b/tests/eval/test_orchestrator_e2e.py
@@ -1,0 +1,311 @@
+# @summary
+# P8a — nightly orchestrator e2e + unit tests.
+# Drives src.eval.orchestrator.run_nightly / discover_packs end-to-end over
+# synthetic pack(s) with monkeypatched infra (reusing tests.eval.test_cli's
+# _make_synthetic_pack / _patch_full_chain), plus a direct send_alert log test.
+# Headline red: test_full_loop_with_injected_regression (run→persist→gate-fail
+# →alert-shape, rc==1). NOTE: baseline/diff comparison is NOT in this slice —
+# deferred to P8b; the e2e only asserts run→persist→gate-fail→alert-shape.
+# Mutation targets:
+#   M-A run_nightly returns 0 unconditionally → test_full_loop_with_injected_regression
+#   M-B remove per-pack try/except          → test_run_nightly_continues_after_pack_error
+#   M-C send_alert info-only on failure     → test_send_alert_logs_failure
+#   M-D discover_packs returns all subdirs  → test_discover_packs_globs_pack_dirs
+# Exports: test_full_loop_with_injected_regression,
+#          test_full_loop_all_pass_returns_zero,
+#          test_run_nightly_continues_after_pack_error,
+#          test_discover_packs_globs_pack_dirs,
+#          test_send_alert_logs_failure, test_send_alert_pass_no_warning
+# Deps: src.eval.orchestrator, src.eval.runner.alert, tests.eval.test_cli
+# @end-summary
+"""P8a — nightly orchestrator tests."""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+# Reuse the CLI test fixtures — do NOT duplicate the synthetic pack / infra patch.
+from tests.eval.test_cli import _make_synthetic_pack, _patch_full_chain
+
+FIXED_NOW = datetime(2026, 5, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# run_nightly e2e
+# ---------------------------------------------------------------------------
+
+
+def test_full_loop_with_injected_regression(tmp_path: Path, monkeypatch) -> None:
+    """Full loop over a regressed pack: run→persist→gate-fail→alert-shape, rc==1.
+
+    HEADLINE RED. High recall floor (0.9) + retrieval returning a WRONG source
+    (recall=0) → the gate MUST fail. We assert the orchestrator persists exactly
+    one report JSON (passed=False, >=1 failure) and shapes an AlertPayload with
+    gate_passed=False, non-empty failures, and report_path pointing at the file.
+
+    NOTE: NO baseline comparison here — that is P8b. This slice only proves the
+    run→persist→gate-fail→alert wiring.
+
+    MUTATION A TARGET: run_nightly returning 0 unconditionally reds this.
+    """
+    from src.eval.orchestrator import run_nightly
+
+    pack_dir = _make_synthetic_pack(
+        tmp_path, recall_floor=0.9, faithfulness_floor=0.5
+    )
+    # Retrieval returns the WRONG source → recall=0.0 < 0.9 floor → gate fails.
+    _patch_full_chain(monkeypatch, retrieved_source="other.md", judge_score=0.9)
+
+    captured: list = []
+    out_dir = tmp_path / "reports"
+
+    rc = run_nightly(
+        [pack_dir],
+        output_dir=out_dir,
+        now=FIXED_NOW,
+        alert_fn=captured.append,
+    )
+
+    assert rc == 1
+
+    written = list(out_dir.glob("*.json"))
+    assert len(written) == 1, f"expected exactly one report, got {written!r}"
+    persisted = json.loads(written[0].read_text())
+    assert persisted["passed"] is False
+    assert len(persisted["failures"]) >= 1
+
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload.gate_passed is False
+    assert payload.failures, "alert payload should carry the gate failures"
+    assert payload.report_path == str(written[0])
+
+
+def test_full_loop_all_pass_returns_zero(tmp_path: Path, monkeypatch) -> None:
+    """Discriminating partner: LOW floors + good retrieval → gate PASSES, rc==0.
+
+    Persisted report has passed=True; captured AlertPayload gate_passed=True.
+    """
+    from src.eval.orchestrator import run_nightly
+
+    pack_dir = _make_synthetic_pack(
+        tmp_path, recall_floor=0.5, faithfulness_floor=0.5
+    )
+    _patch_full_chain(monkeypatch, retrieved_source="doc1.md", judge_score=0.9)
+
+    captured: list = []
+    out_dir = tmp_path / "reports"
+
+    rc = run_nightly(
+        [pack_dir],
+        output_dir=out_dir,
+        now=FIXED_NOW,
+        alert_fn=captured.append,
+    )
+
+    assert rc == 0
+    written = list(out_dir.glob("*.json"))
+    assert len(written) == 1
+    persisted = json.loads(written[0].read_text())
+    assert persisted["passed"] is True
+
+    assert len(captured) == 1
+    assert captured[0].gate_passed is True
+
+
+def test_run_nightly_default_now_syncs_alert_and_persist_timestamp(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Default path (no ``now``): alert timestamp is tz-aware AND equals persist's.
+
+    Exercises the PRODUCTION default (``now=None``), which earlier resolved the
+    persisted-filename timestamp and the alert timestamp INDEPENDENTLY — the
+    alert side via a tz-naive ``datetime.now()`` — so the two desynced and the
+    alert timestamp lost its timezone. We pin both invariants:
+
+    * the captured AlertPayload.timestamp is non-empty and timezone-AWARE, and
+    * it EQUALS the persisted report's ``timestamp`` field.
+
+    REGRESSION GUARD: reintroducing a separate ``datetime.now().isoformat()`` for
+    the alert reds this (timestamps differ and/or the alert is tz-naive).
+    """
+    from src.eval.orchestrator import run_nightly
+
+    pack_dir = _make_synthetic_pack(
+        tmp_path, recall_floor=0.5, faithfulness_floor=0.5
+    )
+    _patch_full_chain(monkeypatch, retrieved_source="doc1.md", judge_score=0.9)
+
+    captured: list = []
+    out_dir = tmp_path / "reports"
+
+    # NO `now` argument — exercise the real production default.
+    rc = run_nightly(
+        [pack_dir],
+        output_dir=out_dir,
+        alert_fn=captured.append,
+    )
+
+    assert rc == 0
+    assert len(captured) == 1
+    alert_ts = captured[0].timestamp
+    assert alert_ts, "alert timestamp must be non-empty on the default path"
+
+    # Timezone-aware: fromisoformat must yield a tzinfo-bearing datetime.
+    parsed = datetime.fromisoformat(alert_ts)
+    assert parsed.tzinfo is not None, "alert timestamp must be timezone-aware"
+
+    # The persisted report's timestamp must EQUAL the alert's timestamp.
+    written = list(out_dir.glob("*.json"))
+    assert len(written) == 1, f"expected exactly one report, got {written!r}"
+    persisted = json.loads(written[0].read_text())
+    assert persisted["timestamp"] == alert_ts, (
+        "persisted-filename timestamp and alert timestamp must be the SAME value"
+    )
+
+
+def test_run_nightly_continues_after_pack_error(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Resilient batch: pack A raises in run_eval, pack B still runs; rc==1.
+
+    Pins the "one bad pack doesn't abort the batch" contract: B is persisted and
+    alerted even though A errored, and an errored batch returns non-zero.
+
+    MUTATION B TARGET: removing the per-pack try/except reds this (A's error
+    aborts the batch before B runs).
+    """
+    import src.eval.orchestrator as orch
+
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    pack_a = _make_synthetic_pack(dir_a, recall_floor=0.5)
+    pack_b = _make_synthetic_pack(dir_b, recall_floor=0.5)
+    _patch_full_chain(monkeypatch, retrieved_source="doc1.md", judge_score=0.9)
+
+    real_run_eval = orch.run_eval
+
+    def flaky_run_eval(pack_path, **kwargs):
+        if str(pack_a) in str(pack_path):
+            raise RuntimeError("pack A blew up")
+        return real_run_eval(pack_path, **kwargs)
+
+    monkeypatch.setattr(orch, "run_eval", flaky_run_eval)
+
+    captured: list = []
+    out_dir = tmp_path / "reports"
+
+    rc = orch.run_nightly(
+        [pack_a, pack_b],
+        output_dir=out_dir,
+        now=FIXED_NOW,
+        alert_fn=captured.append,
+    )
+
+    assert rc == 1, "an errored batch must return non-zero"
+    written = list(out_dir.glob("*.json"))
+    assert len(written) == 1, f"only pack B should persist, got {written!r}"
+    persisted = json.loads(written[0].read_text())
+    assert persisted["pack_name"] == "synpack"
+    # Pack B's alert was emitted (pack A errored before producing a payload).
+    assert len(captured) == 1
+    assert captured[0].gate_passed is True
+
+
+def test_discover_packs_globs_pack_dirs(tmp_path: Path) -> None:
+    """discover_packs finds only dirs containing pack.yaml, sorted.
+
+    MUTATION D TARGET: returning all subdirs (ignoring pack.yaml) reds this.
+    """
+    from src.eval.orchestrator import discover_packs
+
+    root = tmp_path / "packs"
+    root.mkdir()
+    (root / "zebra").mkdir()
+    (root / "zebra" / "pack.yaml").write_text("name: zebra\n")
+    (root / "alpha").mkdir()
+    (root / "alpha" / "pack.yaml").write_text("name: alpha\n")
+    (root / "not_a_pack").mkdir()  # no pack.yaml → excluded
+    (root / "not_a_pack" / "readme.txt").write_text("nope\n")
+
+    found = discover_packs(root)
+    assert [p.name for p in found] == ["alpha", "zebra"]
+
+
+def test_discover_packs_respects_glob(tmp_path: Path) -> None:
+    """A specific pack name selects exactly that pack dir."""
+    from src.eval.orchestrator import discover_packs
+
+    root = tmp_path / "packs"
+    root.mkdir()
+    for name in ("alpha", "beta"):
+        (root / name).mkdir()
+        (root / name / "pack.yaml").write_text(f"name: {name}\n")
+
+    found = discover_packs(root, pack="alpha")
+    assert [p.name for p in found] == ["alpha"]
+
+
+# ---------------------------------------------------------------------------
+# send_alert log stub
+# ---------------------------------------------------------------------------
+
+
+def test_send_alert_logs_failure(caplog) -> None:
+    """A failing AlertPayload logs a WARNING naming the pack + failing metric.
+
+    MUTATION C TARGET: logging at info even on failure reds this.
+    """
+    from src.eval.runner.alert import AlertPayload, send_alert
+
+    payload = AlertPayload(
+        pack_name="opentitan_riscv",
+        collection_name="test_coll",
+        gate_passed=False,
+        failures=[
+            {
+                "qtype": "factoid",
+                "metric": "recall_at_5",
+                "expected": 0.9,
+                "actual": 0.0,
+                "qid": "g1",
+            }
+        ],
+        report_path="/tmp/report.json",
+        timestamp=FIXED_NOW.isoformat(),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="rag.eval.alert"):
+        send_alert(payload)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "a failing gate must emit a WARNING"
+    text = " ".join(r.getMessage() for r in warnings)
+    assert "opentitan_riscv" in text
+    assert "recall_at_5" in text
+
+
+def test_send_alert_pass_no_warning(caplog) -> None:
+    """Partner: a passing AlertPayload emits no WARNING (info-only)."""
+    from src.eval.runner.alert import AlertPayload, send_alert
+
+    payload = AlertPayload(
+        pack_name="opentitan_riscv",
+        collection_name="test_coll",
+        gate_passed=True,
+        failures=[],
+        report_path="/tmp/report.json",
+        timestamp=FIXED_NOW.isoformat(),
+    )
+
+    with caplog.at_level(logging.INFO, logger="rag.eval.alert"):
+        send_alert(payload)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not warnings, "a passing gate must not emit a WARNING"


### PR DESCRIPTION
## Stack

Second slice of the **P8 — Orchestrator + baseline diff** mini-stack. Base: **P8a.0** (#131).

- P8a.0 — run_eval() + persist_eval_report (#131)
- **P8a — nightly orchestrator** ← this PR
- P8b — baseline store + diff + promotion command → P8a (next)

## What

The plan's "P7 — Orchestrator", **cron-script form** (Temporal `NightlyEvalWorkflow` deferred to a later slice once the script is stable). Composes P8a.0's `run_eval`/`persist_eval_report` into an end-to-end nightly loop.

- **`src/eval/orchestrator.py`** (testable logic — `scripts/` isn't a package, so logic lives in `src/` per CLAUDE.md):
  - `discover_packs(pack_root, pack="*") -> list[Path]` — globs dirs containing `pack.yaml`, sorted.
  - `run_nightly(pack_paths, *, output_dir, k=5, fresh=True, chat_model_factory=None, alert_fn=send_alert, now=None, stderr=None) -> int` — per pack: `run_eval` → `persist_eval_report` → build `AlertPayload` → `alert_fn` → log. **Resilient batch** (one pack erroring doesn't abort the others). Returns **0 iff every pack ran AND passed** its gate, else **1**.
- **`src/eval/runner/alert.py`** — frozen `AlertPayload` + log-only `send_alert` (info on pass; warning + per-failure on fail). Real Slack/webhook wiring deferred.
- **`scripts/run_nightly_eval.py`** — thin argparse shim (`--pack-root/--pack/--output-dir/--k/--no-fresh/--verbose`); no-packs-found → exit 2; delegates to `run_nightly`.
- **`.gitignore`** += `eval_reports/`, `evals/*/reports/`.

## Scope

Baseline diff is **NOT** in this slice — deferred to P8b. The e2e asserts run → persist → gate-fail → alert-shape only (no baseline comparison).

## Test plan

- [x] +8 tests (`test_orchestrator_e2e.py`), reusing `_make_synthetic_pack`/`_patch_full_chain`:
  - injected-regression e2e: rc==1, persisted JSON `passed:false` + ≥1 failure, captured `AlertPayload.gate_passed=False` with `report_path`
  - all-pass partner: rc==0, same structure (proves the regression test isn't trivially red)
  - resilient batch: pack B persists + runs after pack A errors; rc==1
  - `discover_packs` glob/pack.yaml-only/sorted; `send_alert` warning-on-fail/info-on-pass
  - **default-now timestamp pin**: `run_nightly` with no `now` → alert timestamp is tz-aware AND equals the persisted report's timestamp (caught + fixed a desync/tz-naive bug on the production default path)
- [x] Eval suite: **186 passed / 4 skipped** (was 178)
- [x] Mutations: return-0-always→reds regression e2e; remove try/except→reds resilient-batch; alert info-on-fail→reds send_alert test; discover-all-subdirs→reds discover test; reintroduce-separate-now→reds the timestamp-sync pin
- [x] Shim smoke: `python scripts/run_nightly_eval.py --help` exits 0 with all flags
- [x] Scope fence: orchestrator.py + alert.py + shim + 1 export + .gitignore + 1 test file; ZERO P8a.0/stage-logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)