### PR TITLE
feat(eval): P8b — baseline diff + regression-callout reporting + promote-baseline

### DIFF
--- a/src/eval/cli.py
+++ b/src/eval/cli.py
@@ -16,7 +16,11 @@
 # raised errors to exit codes (2/3) and runs Phase 3 (emit + CI summary)
 # unchanged. _report_payload single-sources the JSON shape shared by
 # _emit_json and runner.persistence.persist_eval_report.
-# Exports: _build_parser, _report_payload, run_eval, EvalRunResult, run_cli, main
+# P8b adds the promote-baseline subcommand: promote_baseline(pack, ...) writes
+# the latest (or given) report JSON to <packs_root>/<pack>/baseline.json (the
+# git-tracked baseline that runner.baseline diffs against); no git-commit.
+# Exports: _build_parser, _report_payload, run_eval, EvalRunResult, run_cli,
+#          promote_baseline, main
 # Deps: argparse, json, logging, os, sys; src.eval.pack (errors, loader);
 #       src.eval.runner (lazy) — execute_plan, retrieve_for_goldens,
 #       score_goldens, build_judge_client, build_eval_report,
@@ -26,9 +30,11 @@
 # @end-summary
 """Eval CLI runner (P6b).
 
-Single subcommand ``run`` that chains the full eval pipeline against a
-loaded eval_pack and exits with a deterministic code reflecting the
-gate outcome. The CLI is a thin orchestrator — no business logic.
+The ``run`` subcommand chains the full eval pipeline against a loaded
+eval_pack and exits with a deterministic code reflecting the gate outcome.
+The ``promote-baseline`` subcommand (P8b) writes a report to the pack's
+committed ``baseline.json``. The CLI is a thin orchestrator — no business
+logic.
 
 Lazy imports for heavy modules keep argparse-time work to a minimum and
 sidestep langchain_core stub-timing hazards in the test environment.
@@ -138,6 +144,33 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Incremental update mode; do not drop the collection.",
     )
     run_parser.set_defaults(fresh=True)
+
+    # --- promote-baseline subcommand (P8b) ---
+    promote_parser = subparsers.add_parser(
+        "promote-baseline",
+        help="Promote an eval report to the pack's committed baseline.json.",
+    )
+    promote_parser.add_argument(
+        "pack",
+        help="Pack name (directory under --packs-root).",
+    )
+    promote_parser.add_argument(
+        "--report-json",
+        default=None,
+        help="Report JSON to promote. If omitted, the latest "
+        "<reports-dir>/<pack>_*.json (by filename) is used.",
+    )
+    promote_parser.add_argument(
+        "--packs-root",
+        default="evals/packs",
+        help="Root directory containing pack directories (default: evals/packs).",
+    )
+    promote_parser.add_argument(
+        "--reports-dir",
+        default="eval_reports",
+        help="Directory of persisted reports for latest-discovery "
+        "(default: eval_reports).",
+    )
     return parser
 
 
@@ -514,8 +547,72 @@ def run_cli(
 # ---------------------------------------------------------------------------
 
 
+def promote_baseline(
+    pack: str,
+    *,
+    report_json: str | None = None,
+    packs_root: str = "evals/packs",
+    reports_dir: str = "eval_reports",
+    stdout: Any = None,
+    stderr: Any = None,
+) -> int:
+    """Promote an eval report to ``<packs_root>/<pack>/baseline.json``.
+
+    Resolves the report to promote (explicit ``report_json`` or the latest
+    ``<reports_dir>/<pack>_*.json`` by sorted filename — ISO timestamps in the
+    filename sort chronologically), then writes it verbatim to the pack's
+    committed ``baseline.json``. Does NOT git-commit — versioning the baseline
+    is the caller's deliberate step.
+
+    Returns 0 on success; 2 on a pack/report resolution error (no git side
+    effects). Deterministic and side-effect-light beyond the single write.
+    """
+    out = stdout if stdout is not None else sys.stdout
+    err = stderr if stderr is not None else sys.stderr
+
+    pack_dir = Path(packs_root) / pack
+    if not pack_dir.is_dir():
+        print(f"promote-baseline: pack not found: {pack_dir}", file=err)
+        return 2
+
+    if report_json is not None:
+        report_path = Path(report_json)
+        if not report_path.is_file():
+            print(
+                f"promote-baseline: report not found: {report_path}", file=err
+            )
+            return 2
+    else:
+        candidates = sorted(Path(reports_dir).glob(f"{pack}_*.json"))
+        if not candidates:
+            print(
+                f"promote-baseline: no reports found for {pack!r} under "
+                f"{reports_dir}",
+                file=err,
+            )
+            return 2
+        report_path = candidates[-1]  # latest by sorted (ISO) filename
+
+    try:
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"promote-baseline: cannot read report: {exc}", file=err)
+        return 2
+    if not isinstance(payload, dict) or "passed" not in payload:
+        print(
+            f"promote-baseline: malformed report (missing keys): {report_path}",
+            file=err,
+        )
+        return 2
+
+    baseline_path = pack_dir / "baseline.json"
+    baseline_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"Promoted baseline -> {baseline_path}", file=out)
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
-    """Parse argv, dispatch to ``run_cli``, return its exit code."""
+    """Parse argv, dispatch to a subcommand, return its exit code."""
     parser = _build_parser()
     args = parser.parse_args(argv)
     if args.command == "run":
@@ -529,6 +626,13 @@ def main(argv: list[str] | None = None) -> int:
             max_parallel_judges=args.max_parallel_judges,
             show_samples=getattr(args, "show_samples", False),
             summary_file=getattr(args, "summary_file", None),
+        )
+    if args.command == "promote-baseline":
+        return promote_baseline(
+            args.pack,
+            report_json=args.report_json,
+            packs_root=args.packs_root,
+            reports_dir=args.reports_dir,
         )
     parser.error(f"unknown command: {args.command}")
     return 2  # pragma: no cover — parser.error() exits.

--- a/src/eval/runner/__init__.py
+++ b/src/eval/runner/__init__.py
@@ -29,6 +29,7 @@ the executor (``score_goldens`` + ``aggregate_faithfulness_by_qtype`` +
 from __future__ import annotations
 
 from .alert import AlertPayload, send_alert
+from .baseline import BaselineDiff, MetricDelta, compute_baseline_diff
 from .ci import render_ci_summary
 from .execute import execute_plan
 from .gate import GateFailure, GateResult, validate_eval_report
@@ -57,10 +58,15 @@ from .metrics import (
 from .persistence import persist_eval_report
 from .plan import IngestPlan, plan_pack_ingest
 from .report import EvalReport, IngestReport, build_eval_report
+from .reporting import (
+    render_baseline_diff_markdown,
+    render_regression_section,
+)
 from .retrieve import QueryRetrievalResult, RetrievalResults, retrieve_for_goldens
 
 __all__ = [
     "AlertPayload",
+    "BaselineDiff",
     "EvalReport",
     "FaithfulnessResults",
     "GateFailure",
@@ -70,6 +76,7 @@ __all__ = [
     "JudgeClient",
     "JudgeQuestion",
     "JudgmentScore",
+    "MetricDelta",
     "QueryFaithfulnessResult",
     "QueryRetrievalResult",
     "RetrievalResults",
@@ -78,6 +85,7 @@ __all__ = [
     "aggregate_recall_by_qtype",
     "build_eval_report",
     "build_judge_client",
+    "compute_baseline_diff",
     "execute_plan",
     "load_judge_prompt",
     "persist_eval_report",
@@ -86,8 +94,10 @@ __all__ = [
     "read_samples_per_claim",
     "recall_at_k",
     "reciprocal_rank",
+    "render_baseline_diff_markdown",
     "render_ci_summary",
     "render_judge_prompt",
+    "render_regression_section",
     "retrieve_for_goldens",
     "score_goldens",
     "send_alert",

--- a/src/eval/runner/baseline.py
+++ b/src/eval/runner/baseline.py
@@ -1,0 +1,160 @@
+# @summary
+# P8b — pure baseline-diff engine. compute_baseline_diff(baseline_json,
+# current_json, *, epsilon=0.05) diffs the three per-qtype metric maps
+# (recall/mrr/faithfulness) from two persisted eval-report JSON payloads,
+# classifying each (qtype, metric) into regressions / improvements / unchanged,
+# and surfacing new/dropped qtypes plus a gate flip (pass -> fail). No I/O.
+# A metric "regressed" iff current < baseline - epsilon (delta == -epsilon is
+# NOT a regression); "improved" iff delta > epsilon; else unchanged.
+# Exports: MetricDelta, BaselineDiff, compute_baseline_diff
+# Deps: stdlib only (dataclasses).
+# @end-summary
+"""Pure baseline-diff engine (P8b).
+
+:func:`compute_baseline_diff` is a deterministic, side-effect-free function
+that consumes two persisted eval-report JSON payloads (the shape produced by
+:func:`src.eval.cli._report_payload` + ``pack_name``/``timestamp``) and returns
+an immutable :class:`BaselineDiff` describing how the *current* run moved
+relative to the *baseline*.
+
+Diff semantics
+--------------
+- The three per-qtype metric maps are diffed under stable metric labels:
+  ``recall_by_qtype`` -> ``"recall"``, ``mrr_by_qtype`` -> ``"mrr"``,
+  ``faithfulness_by_qtype`` -> ``"faithfulness"``.
+- A ``(qtype, metric)`` pair present on BOTH sides yields a numeric
+  ``delta = current - baseline`` and is classified:
+    * ``regressed`` iff ``current < baseline - epsilon`` (strict; a delta of
+      exactly ``-epsilon`` is NOT a regression),
+    * ``improvement`` iff ``delta > epsilon``,
+    * ``unchanged`` otherwise (``|delta| <= epsilon``).
+- A pair present on only one side does NOT count as a regression/improvement;
+  instead its qtype contributes to ``new_qtypes`` (present in current's maps
+  only) or ``dropped_qtypes`` (present in baseline's maps only).
+- ``gate_flipped_to_fail`` is ``True`` iff the baseline passed and the current
+  failed.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Map the persisted per-qtype JSON map name to the stable metric label used in
+# the diff (and downstream markdown). Order is load-bearing for determinism.
+_METRIC_MAPS: tuple[tuple[str, str], ...] = (
+    ("recall_by_qtype", "recall"),
+    ("mrr_by_qtype", "mrr"),
+    ("faithfulness_by_qtype", "faithfulness"),
+)
+
+
+@dataclass(frozen=True)
+class MetricDelta:
+    """One ``(qtype, metric)`` movement between baseline and current.
+
+    ``baseline_value`` / ``current_value`` are ``None`` when the pair is absent
+    on that side. ``delta`` is ``current - baseline`` (only meaningful — and
+    only computed — when both sides are present; ``0.0`` otherwise). ``regressed``
+    is ``True`` iff both present and ``current < baseline - epsilon``.
+    """
+
+    qtype: str
+    metric: str
+    baseline_value: float | None
+    current_value: float | None
+    delta: float
+    regressed: bool
+
+
+@dataclass(frozen=True)
+class BaselineDiff:
+    """Immutable result of :func:`compute_baseline_diff`."""
+
+    pack_name: str
+    baseline_timestamp: str
+    current_timestamp: str
+    passed_baseline: bool
+    passed_current: bool
+    regressions: tuple[MetricDelta, ...]
+    improvements: tuple[MetricDelta, ...]
+    unchanged: tuple[MetricDelta, ...]
+    new_qtypes: tuple[str, ...]
+    dropped_qtypes: tuple[str, ...]
+    gate_flipped_to_fail: bool
+
+
+def _qtypes_in(payload: dict) -> set[str]:
+    """Union of qtypes across the three per-qtype metric maps of ``payload``."""
+    qtypes: set[str] = set()
+    for map_name, _label in _METRIC_MAPS:
+        qtypes |= set(payload.get(map_name) or {})
+    return qtypes
+
+
+def compute_baseline_diff(
+    baseline_json: dict,
+    current_json: dict,
+    *,
+    epsilon: float = 0.05,
+) -> BaselineDiff:
+    """Diff two persisted eval-report payloads. See module docstring.
+
+    :param baseline_json: the persisted baseline report payload.
+    :param current_json: the persisted current report payload.
+    :param epsilon: regression/improvement tolerance band (default ``0.05``).
+    :returns: an immutable :class:`BaselineDiff`.
+    """
+    regressions: list[MetricDelta] = []
+    improvements: list[MetricDelta] = []
+    unchanged: list[MetricDelta] = []
+
+    for map_name, label in _METRIC_MAPS:
+        base_map = baseline_json.get(map_name) or {}
+        cur_map = current_json.get(map_name) or {}
+        # Iterate the union of qtypes for this metric, sorted for determinism.
+        for qtype in sorted(set(base_map) | set(cur_map)):
+            base_val = base_map.get(qtype)
+            cur_val = cur_map.get(qtype)
+            if base_val is None or cur_val is None:
+                # One-sided pair: handled via new/dropped qtypes, not buckets.
+                continue
+            base_f = float(base_val)
+            cur_f = float(cur_val)
+            delta = cur_f - base_f
+            regressed = cur_f < base_f - epsilon
+            md = MetricDelta(
+                qtype=qtype,
+                metric=label,
+                baseline_value=base_f,
+                current_value=cur_f,
+                delta=delta,
+                regressed=regressed,
+            )
+            if regressed:
+                regressions.append(md)
+            elif delta > epsilon:
+                improvements.append(md)
+            else:
+                unchanged.append(md)
+
+    base_qtypes = _qtypes_in(baseline_json)
+    cur_qtypes = _qtypes_in(current_json)
+    new_qtypes = tuple(sorted(cur_qtypes - base_qtypes))
+    dropped_qtypes = tuple(sorted(base_qtypes - cur_qtypes))
+
+    passed_baseline = bool(baseline_json.get("passed"))
+    passed_current = bool(current_json.get("passed"))
+    gate_flipped_to_fail = passed_baseline and not passed_current
+
+    return BaselineDiff(
+        pack_name=current_json.get("pack_name", baseline_json.get("pack_name", "")),
+        baseline_timestamp=baseline_json.get("timestamp", ""),
+        current_timestamp=current_json.get("timestamp", ""),
+        passed_baseline=passed_baseline,
+        passed_current=passed_current,
+        regressions=tuple(regressions),
+        improvements=tuple(improvements),
+        unchanged=tuple(unchanged),
+        new_qtypes=new_qtypes,
+        dropped_qtypes=dropped_qtypes,
+        gate_flipped_to_fail=gate_flipped_to_fail,
+    )

--- a/src/eval/runner/reporting.py
+++ b/src/eval/runner/reporting.py
@@ -1,0 +1,140 @@
+# @summary
+# P8b — baseline-diff markdown reporting. render_baseline_diff_markdown(
+# current_json, baseline_json, *, epsilon=0.05) reconstructs the CURRENT
+# EvalReport+GateResult from a persisted JSON payload, reuses the existing
+# render_ci_summary (NO duplication of the per-qtype/failures tables), and
+# APPENDS a deterministic "### Regressions vs Baseline" callout produced by
+# render_regression_section(diff). _reconstruct_report_and_gate rebuilds the
+# frozen dataclasses from the persisted payload keys. No I/O.
+# Exports: render_baseline_diff_markdown, render_regression_section,
+#          _reconstruct_report_and_gate
+# Deps: stdlib only; src.eval.runner.ci (render_ci_summary, _fmt),
+#       src.eval.runner.report (EvalReport), src.eval.runner.gate
+#       (GateResult, GateFailure), src.eval.runner.baseline
+#       (compute_baseline_diff, BaselineDiff).
+# @end-summary
+"""Baseline-diff markdown reporting (P8b).
+
+This module renders a deterministic markdown report comparing a *current* eval
+run against a promoted *baseline*. It REUSES the existing
+:func:`src.eval.runner.ci.render_ci_summary` for the current-run tables (status
+line, per-qtype metrics, failures, run-facts footer) and only ADDS a new
+regression-callout section — so the per-qtype/failures rendering is never
+duplicated.
+
+The current ``EvalReport`` + ``GateResult`` are reconstructed from a persisted
+report JSON payload (the shape produced by :func:`src.eval.cli._report_payload`)
+via :func:`_reconstruct_report_and_gate`.
+"""
+from __future__ import annotations
+
+from .baseline import BaselineDiff, compute_baseline_diff
+from .ci import _fmt, render_ci_summary
+
+
+def _reconstruct_report_and_gate(payload: dict):
+    """Rebuild ``(EvalReport, GateResult)`` from a persisted report payload.
+
+    Reads the additive-default fields off ``payload`` (the
+    :func:`src.eval.cli._report_payload` shape). Missing optional maps default
+    to empty so partial payloads still reconstruct.
+    """
+    from .gate import GateFailure, GateResult
+    from .report import EvalReport
+
+    report = EvalReport(
+        collection_name=payload.get("collection_name", ""),
+        k=int(payload.get("k", 0)),
+        per_query_recall=dict(payload.get("per_query_recall") or {}),
+        recall_by_qtype=dict(payload.get("recall_by_qtype") or {}),
+        total_queries_scored=int(payload.get("total_queries_scored", 0)),
+        total_queries_skipped=int(payload.get("total_queries_skipped", 0)),
+        faithfulness_by_qtype=dict(payload.get("faithfulness_by_qtype") or {}),
+        total_queries_judged=int(payload.get("total_queries_judged", 0)),
+        mrr_by_qtype=dict(payload.get("mrr_by_qtype") or {}),
+        per_query_mrr=dict(payload.get("per_query_mrr") or {}),
+        per_query_faithfulness=dict(payload.get("per_query_faithfulness") or {}),
+    )
+    failures = tuple(
+        GateFailure(
+            qtype=f.get("qtype", ""),
+            metric=f.get("metric", ""),
+            expected=float(f.get("expected", 0.0)),
+            actual=float(f.get("actual", 0.0)),
+            qid=f.get("qid", ""),
+        )
+        for f in (payload.get("failures") or [])
+    )
+    gate = GateResult(passed=bool(payload.get("passed")), failures=failures)
+    return report, gate
+
+
+def render_regression_section(diff: BaselineDiff) -> str:
+    """Render the deterministic ``### Regressions vs Baseline`` markdown section.
+
+    Layout:
+      * a ``### Regressions vs Baseline`` heading,
+      * a baseline -> current provenance line (pack + timestamps),
+      * a regressions table (or a "no regressions" line if empty),
+      * a one-line gate-flip note when ``gate_flipped_to_fail``,
+      * new/dropped qtype lines when present.
+
+    Reuses :func:`src.eval.runner.ci._fmt` (3 decimals, em-dash for ``None``).
+    """
+    lines: list[str] = []
+    lines.append("### Regressions vs Baseline")
+    lines.append("")
+    lines.append(
+        f"Baseline `{diff.pack_name}` @ {diff.baseline_timestamp} → "
+        f"current @ {diff.current_timestamp}"
+    )
+    lines.append("")
+
+    if diff.regressions:
+        lines.append("| qtype | metric | baseline | current | delta |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        for d in diff.regressions:
+            lines.append(
+                f"| {d.qtype} | {d.metric} | {_fmt(d.baseline_value)} | "
+                f"{_fmt(d.current_value)} | {d.delta:+.3f} |"
+            )
+    else:
+        lines.append("No regressions vs baseline.")
+
+    if diff.gate_flipped_to_fail:
+        lines.append("")
+        lines.append("Gate flipped PASS → FAIL vs baseline.")
+
+    if diff.new_qtypes:
+        lines.append("")
+        lines.append(f"New qtypes (no baseline): {', '.join(diff.new_qtypes)}")
+    if diff.dropped_qtypes:
+        # No blank line when it directly follows a new-qtypes line; keep one
+        # leading blank only when this is the first trailing block.
+        if not diff.new_qtypes:
+            lines.append("")
+        lines.append(
+            f"Dropped qtypes (in baseline, absent now): "
+            f"{', '.join(diff.dropped_qtypes)}"
+        )
+
+    return "\n".join(lines)
+
+
+def render_baseline_diff_markdown(
+    current_json: dict,
+    baseline_json: dict,
+    *,
+    epsilon: float = 0.05,
+) -> str:
+    """Render the full baseline-diff markdown report (deterministic).
+
+    Reconstructs the current ``EvalReport`` + ``GateResult`` from
+    ``current_json``, renders the standard CI summary via
+    :func:`render_ci_summary`, then appends the regression-callout section for
+    ``compute_baseline_diff(baseline_json, current_json, epsilon=epsilon)``.
+    """
+    report, gate = _reconstruct_report_and_gate(current_json)
+    ci = render_ci_summary(report, gate)
+    diff = compute_baseline_diff(baseline_json, current_json, epsilon=epsilon)
+    return ci + "\n\n" + render_regression_section(diff)

--- a/tests/eval/test_reporting.py
+++ b/tests/eval/test_reporting.py
@@ -1,0 +1,394 @@
+# @summary
+# P8b — tests for baseline diff + reporting + promote-baseline CLI.
+# Covers the pure diff engine (compute_baseline_diff: regression/improvement/
+# unchanged bucketing, strict epsilon boundary, new/dropped qtypes, gate flip),
+# the deterministic markdown snapshot (render_baseline_diff_markdown reuses
+# render_ci_summary + appends a regression callout), and the promote-baseline
+# command (writes evals/packs/<pack>/baseline.json, discovers latest report,
+# error exit codes).
+# Mutation A target: test_compute_diff_epsilon_boundary
+# Mutation B target: test_compute_diff_regression_vs_improvement_vs_unchanged
+# Mutation C target: test_markdown_snapshot
+# Mutation D target: test_promote_baseline_writes_to_pack_dir
+# Mutation E target: test_promote_baseline_discovers_latest_report
+# Exports: test_markdown_snapshot,
+#          test_compute_diff_regression_vs_improvement_vs_unchanged,
+#          test_compute_diff_epsilon_boundary,
+#          test_compute_diff_new_and_dropped_qtypes,
+#          test_compute_diff_gate_flip,
+#          test_compute_diff_gate_not_flipped_when_both_pass,
+#          test_promote_baseline_writes_to_pack_dir,
+#          test_promote_baseline_missing_pack_exits_2,
+#          test_promote_baseline_no_report_found_exits_2,
+#          test_promote_baseline_discovers_latest_report
+# Deps: src.eval.runner.baseline, src.eval.runner.reporting, src.eval.cli
+# @end-summary
+"""P8b — baseline diff + reporting + promote-baseline tests."""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixed JSON payload fixtures (control the snapshot exactly)
+# ---------------------------------------------------------------------------
+
+
+def _baseline_payload() -> dict:
+    """Baseline report: PASSING, qtypes {factoid, dropme}."""
+    return {
+        "pack_name": "synpack",
+        "timestamp": "2026-05-01T00:00:00+00:00",
+        "collection_name": "test_coll",
+        "k": 5,
+        "passed": True,
+        "failures": [],
+        "recall_by_qtype": {"factoid": 0.90, "dropme": 0.80},
+        "mrr_by_qtype": {"factoid": 0.70},
+        "faithfulness_by_qtype": {"factoid": 0.80},
+        "per_query_recall": {},
+        "per_query_mrr": {},
+        "per_query_faithfulness": {},
+        "total_queries_scored": 10,
+        "total_queries_skipped": 1,
+        "total_queries_judged": 5,
+    }
+
+
+def _current_payload() -> dict:
+    """Current report: FAILING (gate flip), qtypes {factoid, newbie}.
+
+    Designed so exactly:
+      * factoid recall 0.90 -> 0.80  (delta -0.10) => REGRESSION
+      * factoid mrr    0.70 -> 0.85  (delta +0.15) => IMPROVEMENT
+      * factoid faith  0.80 -> 0.78  (delta -0.02) => UNCHANGED (within eps)
+      * newbie  => NEW qtype (absent from baseline)
+      * dropme  => DROPPED qtype (absent from current)
+    """
+    return {
+        "pack_name": "synpack",
+        "timestamp": "2026-05-30T00:00:00+00:00",
+        "collection_name": "test_coll",
+        "k": 5,
+        "passed": False,
+        "failures": [
+            {
+                "qtype": "factoid",
+                "metric": "recall_at_5",
+                "expected": 0.90,
+                "actual": 0.80,
+                "qid": "",
+            }
+        ],
+        "recall_by_qtype": {"factoid": 0.80, "newbie": 0.95},
+        "mrr_by_qtype": {"factoid": 0.85},
+        "faithfulness_by_qtype": {"factoid": 0.78},
+        "per_query_recall": {},
+        "per_query_mrr": {},
+        "per_query_faithfulness": {},
+        "total_queries_scored": 10,
+        "total_queries_skipped": 1,
+        "total_queries_judged": 5,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Headline snapshot
+# ---------------------------------------------------------------------------
+
+
+EXPECTED_MARKDOWN = """## Eval Gate Summary
+
+**Status: FAIL**
+
+| qtype | recall@5 | mrr | faithfulness | status |
+| --- | --- | --- | --- | --- |
+| factoid | 0.800 | 0.850 | 0.780 | FAIL |
+| newbie | 0.950 | — | — | PASS |
+
+### Failures
+
+| qtype | qid | metric | expected | actual |
+| --- | --- | --- | --- | --- |
+| factoid | — | recall_at_5 | 0.900 | 0.800 |
+
+_Collection `test_coll` · k=5 · scored=10 · judged=5 · skipped=1_
+
+### Regressions vs Baseline
+
+Baseline `synpack` @ 2026-05-01T00:00:00+00:00 → current @ 2026-05-30T00:00:00+00:00
+
+| qtype | metric | baseline | current | delta |
+| --- | --- | --- | --- | --- |
+| factoid | recall | 0.900 | 0.800 | -0.100 |
+
+Gate flipped PASS → FAIL vs baseline.
+
+New qtypes (no baseline): newbie
+Dropped qtypes (in baseline, absent now): dropme"""
+
+
+def test_markdown_snapshot() -> None:
+    """render_baseline_diff_markdown equals the explicit expected snapshot."""
+    from src.eval.runner.reporting import render_baseline_diff_markdown
+
+    out = render_baseline_diff_markdown(_current_payload(), _baseline_payload())
+    assert out == EXPECTED_MARKDOWN
+
+
+# ---------------------------------------------------------------------------
+# 2. Regression vs improvement vs unchanged (mutation-aware, distinct values)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_diff_regression_vs_improvement_vs_unchanged() -> None:
+    """Each metric lands in the right bucket with the right delta."""
+    from src.eval.runner.baseline import compute_baseline_diff
+
+    baseline = {
+        "pack_name": "p",
+        "timestamp": "t0",
+        "passed": True,
+        "recall_by_qtype": {"factoid": 0.90},
+        "mrr_by_qtype": {"factoid": 0.70},
+        "faithfulness_by_qtype": {"factoid": 0.80},
+    }
+    current = {
+        "pack_name": "p",
+        "timestamp": "t1",
+        "passed": True,
+        "recall_by_qtype": {"factoid": 0.80},  # -0.10 regression
+        "mrr_by_qtype": {"factoid": 0.85},  # +0.15 improvement
+        "faithfulness_by_qtype": {"factoid": 0.78},  # -0.02 unchanged
+    }
+    diff = compute_baseline_diff(baseline, current)
+
+    reg = {(d.qtype, d.metric): d for d in diff.regressions}
+    imp = {(d.qtype, d.metric): d for d in diff.improvements}
+    unc = {(d.qtype, d.metric): d for d in diff.unchanged}
+
+    assert set(reg) == {("factoid", "recall")}
+    assert set(imp) == {("factoid", "mrr")}
+    assert set(unc) == {("factoid", "faithfulness")}
+
+    assert reg[("factoid", "recall")].regressed is True
+    assert abs(reg[("factoid", "recall")].delta - (-0.10)) < 1e-9
+    assert abs(imp[("factoid", "mrr")].delta - 0.15) < 1e-9
+    assert imp[("factoid", "mrr")].regressed is False
+    assert abs(unc[("factoid", "faithfulness")].delta - (-0.02)) < 1e-9
+    assert unc[("factoid", "faithfulness")].regressed is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Epsilon boundary (discriminating pair: -0.05 NOT regressed, -0.06 regressed)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_diff_epsilon_boundary() -> None:
+    """Strict ``current < baseline - epsilon``: -0.05 passes, -0.06 regresses."""
+    from src.eval.runner.baseline import compute_baseline_diff
+
+    baseline = {
+        "pack_name": "p",
+        "timestamp": "t0",
+        "passed": True,
+        "recall_by_qtype": {"edge": 0.80, "over": 0.80},
+        "mrr_by_qtype": {},
+        "faithfulness_by_qtype": {},
+    }
+    current = {
+        "pack_name": "p",
+        "timestamp": "t1",
+        "passed": True,
+        "recall_by_qtype": {"edge": 0.75, "over": 0.74},  # -0.05 / -0.06
+        "mrr_by_qtype": {},
+        "faithfulness_by_qtype": {},
+    }
+    diff = compute_baseline_diff(baseline, current, epsilon=0.05)
+
+    regressed = {(d.qtype, d.metric) for d in diff.regressions}
+    # -0.06 regresses; -0.05 does NOT (boundary partner just one step below).
+    assert ("over", "recall") in regressed
+    assert ("edge", "recall") not in regressed
+    # The -0.05 one is within tolerance (|delta| <= eps) -> unchanged bucket.
+    unchanged = {(d.qtype, d.metric) for d in diff.unchanged}
+    assert ("edge", "recall") in unchanged
+
+
+# ---------------------------------------------------------------------------
+# 4. New + dropped qtypes do not pollute regressions
+# ---------------------------------------------------------------------------
+
+
+def test_compute_diff_new_and_dropped_qtypes() -> None:
+    """One-sided qtypes feed new_qtypes/dropped_qtypes, not regressions."""
+    from src.eval.runner.baseline import compute_baseline_diff
+
+    baseline = {
+        "pack_name": "p",
+        "timestamp": "t0",
+        "passed": True,
+        "recall_by_qtype": {"gone": 0.90},
+        "mrr_by_qtype": {},
+        "faithfulness_by_qtype": {},
+    }
+    current = {
+        "pack_name": "p",
+        "timestamp": "t1",
+        "passed": True,
+        "recall_by_qtype": {"fresh": 0.10},  # low, but new -> not a regression
+        "mrr_by_qtype": {},
+        "faithfulness_by_qtype": {},
+    }
+    diff = compute_baseline_diff(baseline, current)
+
+    assert diff.new_qtypes == ("fresh",)
+    assert diff.dropped_qtypes == ("gone",)
+    assert diff.regressions == ()
+
+
+# ---------------------------------------------------------------------------
+# 5. Gate flip
+# ---------------------------------------------------------------------------
+
+
+def test_compute_diff_gate_flip() -> None:
+    """baseline passed + current failed => gate_flipped_to_fail True."""
+    from src.eval.runner.baseline import compute_baseline_diff
+
+    base = {
+        "pack_name": "p", "timestamp": "t0", "passed": True,
+        "recall_by_qtype": {}, "mrr_by_qtype": {}, "faithfulness_by_qtype": {},
+    }
+    cur = {
+        "pack_name": "p", "timestamp": "t1", "passed": False,
+        "recall_by_qtype": {}, "mrr_by_qtype": {}, "faithfulness_by_qtype": {},
+    }
+    diff = compute_baseline_diff(base, cur)
+    assert diff.gate_flipped_to_fail is True
+    assert diff.passed_baseline is True
+    assert diff.passed_current is False
+
+
+def test_compute_diff_gate_not_flipped_when_both_pass() -> None:
+    """Partner: both pass => gate_flipped_to_fail False."""
+    from src.eval.runner.baseline import compute_baseline_diff
+
+    base = {
+        "pack_name": "p", "timestamp": "t0", "passed": True,
+        "recall_by_qtype": {}, "mrr_by_qtype": {}, "faithfulness_by_qtype": {},
+    }
+    cur = {
+        "pack_name": "p", "timestamp": "t1", "passed": True,
+        "recall_by_qtype": {}, "mrr_by_qtype": {}, "faithfulness_by_qtype": {},
+    }
+    diff = compute_baseline_diff(base, cur)
+    assert diff.gate_flipped_to_fail is False
+
+
+# ---------------------------------------------------------------------------
+# 6. promote-baseline writes to pack dir
+# ---------------------------------------------------------------------------
+
+
+def _write_fake_pack(packs_root: Path, name: str) -> Path:
+    pack_dir = packs_root / name
+    pack_dir.mkdir(parents=True)
+    (pack_dir / "pack.yaml").write_text("name: " + name + "\n", encoding="utf-8")
+    return pack_dir
+
+
+def _write_report(reports_dir: Path, fname: str, payload: dict) -> Path:
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    path = reports_dir / fname
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def test_promote_baseline_writes_to_pack_dir(tmp_path: Path) -> None:
+    """promote_baseline writes <pack_dir>/baseline.json equal to the report."""
+    from src.eval.cli import promote_baseline
+
+    packs_root = tmp_path / "packs"
+    reports_dir = tmp_path / "reports"
+    pack_dir = _write_fake_pack(packs_root, "synpack")
+    payload = _current_payload()
+    report_path = _write_report(reports_dir, "synpack_2026.json", payload)
+
+    out = io.StringIO()
+    rc = promote_baseline(
+        "synpack",
+        report_json=str(report_path),
+        packs_root=str(packs_root),
+        reports_dir=str(reports_dir),
+        stdout=out,
+    )
+    assert rc == 0
+    baseline_path = pack_dir / "baseline.json"
+    assert baseline_path.exists()
+    assert json.loads(baseline_path.read_text(encoding="utf-8")) == payload
+    assert "Promoted baseline" in out.getvalue()
+
+
+def test_promote_baseline_missing_pack_exits_2(tmp_path: Path) -> None:
+    """Nonexistent pack dir => exit 2."""
+    from src.eval.cli import promote_baseline
+
+    packs_root = tmp_path / "packs"
+    packs_root.mkdir()
+    err = io.StringIO()
+    rc = promote_baseline(
+        "ghost", packs_root=str(packs_root), reports_dir=str(tmp_path / "r"),
+        stderr=err,
+    )
+    assert rc == 2
+
+
+def test_promote_baseline_no_report_found_exits_2(tmp_path: Path) -> None:
+    """No matching report file => exit 2."""
+    from src.eval.cli import promote_baseline
+
+    packs_root = tmp_path / "packs"
+    reports_dir = tmp_path / "reports"
+    _write_fake_pack(packs_root, "synpack")
+    reports_dir.mkdir(parents=True)
+    err = io.StringIO()
+    rc = promote_baseline(
+        "synpack", packs_root=str(packs_root), reports_dir=str(reports_dir),
+        stderr=err,
+    )
+    assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# 7. Latest-report discovery
+# ---------------------------------------------------------------------------
+
+
+def test_promote_baseline_discovers_latest_report(tmp_path: Path) -> None:
+    """With no --report-json, the LATEST report (by sorted filename) is promoted."""
+    from src.eval.cli import promote_baseline
+
+    packs_root = tmp_path / "packs"
+    reports_dir = tmp_path / "reports"
+    pack_dir = _write_fake_pack(packs_root, "synpack")
+
+    older = _baseline_payload()
+    older["timestamp"] = "2026-05-01T00:00:00+00:00"
+    newer = _current_payload()
+    newer["timestamp"] = "2026-05-30T00:00:00+00:00"
+    # Timestamp embedded in name; sorted ascending => last is newest.
+    _write_report(reports_dir, "synpack_2026-05-01T000000+0000.json", older)
+    _write_report(reports_dir, "synpack_2026-05-30T000000+0000.json", newer)
+
+    out = io.StringIO()
+    rc = promote_baseline(
+        "synpack", packs_root=str(packs_root), reports_dir=str(reports_dir),
+        stdout=out,
+    )
+    assert rc == 0
+    promoted = json.loads((pack_dir / "baseline.json").read_text(encoding="utf-8"))
+    assert promoted == newer
+    assert promoted["timestamp"] == "2026-05-30T00:00:00+00:00"


### PR DESCRIPTION
## Stack

Final slice of the **P8 — Orchestrator + baseline diff** mini-stack (the plan's P7→P8). Base: **P8a** (#132).

- P8a.0 — run_eval() + persist_eval_report (#131)
- P8a — nightly orchestrator (#132)
- **P8b — baseline diff + reporting + promote-baseline** ← this PR

## What

The plan's "P8 — Reporting & baseline diff". Consumes the persisted report JSON (P8a.0) to detect regressions vs a committed per-pack baseline.

- **`src/eval/runner/baseline.py`** (pure): `MetricDelta` + `BaselineDiff` frozen dataclasses; `compute_baseline_diff(baseline_json, current_json, *, epsilon=0.05) -> BaselineDiff`. Diffs recall/mrr/faithfulness per qtype; **regressed iff `current < baseline - epsilon`** (strict); buckets into regressions/improvements/unchanged; tracks new/dropped qtypes + a gate pass→fail flip.
- **`src/eval/runner/reporting.py`**: `render_baseline_diff_markdown` reconstructs the current `EvalReport`+`GateResult` from the persisted payload, **reuses the existing `render_ci_summary`** (no table duplication), then appends a regression-callout section. `_reconstruct_report_and_gate` is round-trip faithful (render of reconstructed == render of original — SA3-verified).
- **`promote-baseline` CLI subcommand** + `promote_baseline(pack, *, report_json=None, packs_root="evals/packs", reports_dir="eval_reports") -> int` — writes the latest (or given) report to `<packs_root>/<pack>/baseline.json`. Exit 2 on pack/report resolution error. No git-commit (versioning is deliberate).

## Decisions

- **Baseline storage = git-tracked `evals/packs/<pack>/baseline.json`** (sibling to `thresholds.yaml`) — reviewable in PR diffs, survives clone. An ignored baseline would make the diff inert in CI. Pack validator confirmed to tolerate the extra file (reads only known pack files).
- **Orchestrator auto-diff wiring deferred to P8c** — this slice does NOT touch `run_nightly`/`AlertPayload`. P8's DoD is "snapshot test green + promotion command documented"; nightly-integration is a separate concern.

## Test plan

- [x] +10 tests (`tests/eval/test_reporting.py`):
  - **full-string markdown snapshot** (1 regression + 1 improvement + 1 within-tolerance + new/dropped qtype + gate flip)
  - **epsilon-boundary discriminating pair**: -0.05 NOT regressed / -0.06 regressed (pins the strict `<` boundary)
  - bucket correctness (regression/improvement/unchanged mutually exclusive); new/dropped qtypes; gate-flip
  - promote: writes-to-pack-dir / missing-pack→2 / no-report→2 / latest-discovery
- [x] Eval suite: **196 passed / 4 skipped** (was 186)
- [x] Mutations: `<`→`<=`→reds boundary; misroute regression→reds bucket; drop regression section→reds snapshot; promote wrong-path→reds write test; discovery first-not-last→reds latest test
- [x] Reconstruction fidelity verified (SA3): reconstructed render == live render
- [x] Scope fence: baseline.py + reporting.py + cli.py(subcommand) + 1 export + 1 test file; `run_nightly`/`AlertPayload`/stage-logic UNCHANGED

## Process note

SA3's adversarial pass clobbered the (uncommitted) `cli.py` promote work via a `git checkout` mutation-revert; it was reconstructed verbatim against the surviving tests (TDD), with the promote teeth (latest-discovery, write-path) re-verified. Lesson captured in memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)