### PR TITLE
feat(eval): P8c — orchestrator baseline-diff wiring + fail-on-regression

### DIFF
--- a/scripts/run_nightly_eval.py
+++ b/scripts/run_nightly_eval.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 # @summary
-# P8a — thin CLI shim for the nightly eval orchestrator. Parses argv (pack-root,
-# pack glob, output-dir, k, fresh, verbose), resolves packs via
-# discover_packs, and delegates to run_nightly. NO business logic — everything
-# lives in src.eval.orchestrator. Exit codes: run_nightly's 0/1, or 2 when no
-# packs are discovered (pack error).
+# P8a/P8c — thin CLI shim for the nightly eval orchestrator. Parses argv
+# (pack-root, pack glob, output-dir, k, fresh, verbose, plus the P8c
+# baseline-diff flags --fail-on-regression / --regression-epsilon), resolves
+# packs via discover_packs, and delegates to run_nightly. NO business logic —
+# everything lives in src.eval.orchestrator. Exit codes: run_nightly's 0/1, or 2
+# when no packs are discovered (pack error).
 # Exports: main
 # Deps: stdlib (argparse, logging, sys); src.eval.orchestrator.
 # @end-summary
@@ -18,6 +19,10 @@ This is a thin argparse adapter over :mod:`src.eval.orchestrator`. It discovers
 the requested pack(s), runs the nightly loop, and returns the orchestrator's
 exit code (0 = all passed, 1 = a gate failed or a pack errored). When no packs
 are discovered it prints to stderr and returns 2 (pack error).
+
+``--fail-on-regression`` flips the exit to 1 when any metric regressed vs the
+pack's committed ``baseline.json`` (even if the absolute gate passed), and
+``--regression-epsilon`` tunes the regression tolerance band (default 0.05).
 """
 from __future__ import annotations
 
@@ -69,6 +74,21 @@ def main(argv: list[str] | None = None) -> int:
         help="Incremental update mode; do not drop the collection before ingest.",
     )
     parser.add_argument(
+        "--fail-on-regression",
+        action="store_true",
+        default=False,
+        help=(
+            "Exit 1 if any metric regressed vs the pack's baseline.json, even if "
+            "the absolute gate passed."
+        ),
+    )
+    parser.add_argument(
+        "--regression-epsilon",
+        type=float,
+        default=0.05,
+        help="Regression tolerance band vs baseline (default 0.05).",
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="Enable verbose (DEBUG) logging.",
@@ -91,6 +111,8 @@ def main(argv: list[str] | None = None) -> int:
         output_dir=args.output_dir,
         k=args.k,
         fresh=args.fresh,
+        fail_on_regression=args.fail_on_regression,
+        regression_epsilon=args.regression_epsilon,
     )
 
 

--- a/src/eval/orchestrator.py
+++ b/src/eval/orchestrator.py
@@ -1,14 +1,18 @@
 # @summary
-# P8a — nightly eval orchestrator (testable core; the scripts/ shim is thin).
+# P8a/P8c — nightly eval orchestrator (testable core; the scripts/ shim is thin).
 # discover_packs globs pack dirs (those containing pack.yaml) under a root.
 # run_nightly iterates packs sequentially: run_eval → persist_eval_report →
-# build AlertPayload from the gate → alert_fn; resilient batch (one pack erroring
-# does not abort the rest); returns 0 iff EVERY pack ran AND passed, else 1.
-# NOTE: NO baseline/diff comparison here — deferred to P8b.
+# (P8c) if a committed `baseline.json` sibling exists, load it + read the
+# just-persisted report back, compute_baseline_diff, attach to AlertPayload →
+# alert_fn; resilient batch (one pack erroring does not abort the rest). Returns
+# 0 iff EVERY pack ran AND passed, else 1; when fail_on_regression=True a
+# regression vs baseline flips the exit to 1 even if the absolute gate passed.
+# Packs with no baseline behave exactly as pre-P8c (baseline_diff=None, no flip).
 # Exports: discover_packs, run_nightly
 # Deps: stdlib (json, logging, pathlib, datetime); src.eval.cli.run_eval;
 #       src.eval.runner.persistence.persist_eval_report;
-#       src.eval.runner.alert (AlertPayload, send_alert).
+#       src.eval.runner.alert (AlertPayload, send_alert);
+#       src.eval.runner.baseline.compute_baseline_diff.
 # @end-summary
 """Nightly eval orchestrator core (P8a).
 
@@ -23,11 +27,20 @@ Per-pack granularity (which pack passed / failed / errored) goes to the logs and
 the persisted JSON files; the batch return value is binary pass/fail. ``alert_fn``
 is the injection seam tests use to capture the shaped :class:`AlertPayload`.
 
-NOTE: baseline/diff comparison against a prior run is NOT part of this slice —
-it is deferred to P8b. This orchestrator only runs → persists → gates → alerts.
+Baseline diff (P8c): after persisting each pack's report, the orchestrator looks
+for a committed ``baseline.json`` sibling inside the pack directory. When present
+it loads the baseline + reads the just-persisted current report back and calls
+:func:`~src.eval.runner.baseline.compute_baseline_diff`, attaching the result to
+``AlertPayload.baseline_diff``. With ``fail_on_regression=True`` any regression
+flips the batch exit to ``1`` even if the absolute gate passed. Packs with no
+baseline — or with an UNUSABLE (corrupt/unparseable) ``baseline.json`` — behave
+exactly as before (``baseline_diff=None``, no exit flip); a bad baseline file is
+a baseline problem, not an eval error, so it is logged and skipped rather than
+marking the pack errored.
 """
 from __future__ import annotations
 
+import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -35,6 +48,7 @@ from typing import Any, Callable
 
 from src.eval.cli import run_eval
 from src.eval.runner.alert import AlertPayload, send_alert
+from src.eval.runner.baseline import compute_baseline_diff
 from src.eval.runner.persistence import persist_eval_report
 
 logger = logging.getLogger("rag.eval.orchestrator")
@@ -68,6 +82,8 @@ def run_nightly(
     chat_model_factory: Callable[..., Any] | None = None,
     alert_fn: Callable[[AlertPayload], None] = send_alert,
     now: datetime | None = None,
+    fail_on_regression: bool = False,
+    regression_epsilon: float = 0.05,
     stderr: Any = None,
 ) -> int:
     """Run the full eval loop over ``pack_paths`` and return a batch exit code.
@@ -86,10 +102,24 @@ def run_nightly(
     in ``run_eval`` does NOT abort the rest — the error is logged, the pack is
     marked errored, and the loop continues.
 
+    Between steps 2 and 3, when a committed ``baseline.json`` sibling exists in
+    the pack directory, the orchestrator loads it + reads the just-persisted
+    report back and computes a :class:`~src.eval.runner.baseline.BaselineDiff`
+    (attached to the :class:`AlertPayload` as ``baseline_diff``).
+
     **Exit code:** ``0`` iff EVERY pack ran AND passed its gate; ``1`` if any
-    pack's gate failed OR any pack errored.
+    pack's gate failed OR any pack errored. When ``fail_on_regression`` is set,
+    any pack whose baseline diff carries regressions ALSO flips the exit to
+    ``1`` — even if that pack's absolute gate passed.
 
     :param now: injected timestamp for deterministic persisted filenames.
+    :param fail_on_regression: when ``True``, a regression vs the pack's
+        committed ``baseline.json`` flips the batch exit to ``1`` even if the
+        absolute gate passed. Default ``False`` (regressions are logged/attached
+        but do not affect the exit code).
+    :param regression_epsilon: tolerance band passed to
+        :func:`~src.eval.runner.baseline.compute_baseline_diff` (default
+        ``0.05``).
     """
     # Resolve ``now`` ONCE so the persisted-filename timestamp and the alert
     # timestamp are the SAME value (and timezone-aware) on the production
@@ -112,6 +142,35 @@ def run_nightly(
             )
             report_path = persist_eval_report(result, output_dir, now=now)
 
+            baseline_diff = None
+            baseline_path = Path(pack_path) / "baseline.json"
+            if baseline_path.is_file():
+                # An UNUSABLE committed baseline (corrupt JSON, merge-conflict
+                # markers, truncation) must degrade like an ABSENT baseline — it
+                # is a baseline-file problem, not an eval-pipeline error, so it
+                # is caught HERE (narrow) rather than by the per-pack handler,
+                # which would wrongly mark the pack errored and suppress its
+                # alert even though the eval itself succeeded.
+                try:
+                    baseline_json = json.loads(
+                        baseline_path.read_text(encoding="utf-8")
+                    )
+                    current_json = json.loads(
+                        Path(report_path).read_text(encoding="utf-8")
+                    )
+                    baseline_diff = compute_baseline_diff(
+                        baseline_json, current_json, epsilon=regression_epsilon
+                    )
+                except (json.JSONDecodeError, OSError) as exc:
+                    logger.warning(
+                        "pack=%s unusable baseline.json (%s: %s) — treating as "
+                        "no baseline",
+                        pack_label,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    baseline_diff = None
+
             failures = [
                 {
                     "qtype": f.qtype,
@@ -129,8 +188,12 @@ def run_nightly(
                 failures=failures,
                 report_path=str(report_path),
                 timestamp=now.isoformat(),
+                baseline_diff=baseline_diff,
             )
             alert_fn(payload)
+
+            if fail_on_regression and baseline_diff is not None and baseline_diff.regressions:
+                all_passed = False
 
             logger.info(
                 "pack=%s gate=%s failures=%d report=%s",

--- a/src/eval/runner/alert.py
+++ b/src/eval/runner/alert.py
@@ -1,10 +1,13 @@
 # @summary
-# P8a — eval alert payload + log-only sink. AlertPayload is the frozen,
+# P8a/P8c — eval alert payload + log-only sink. AlertPayload is the frozen,
 # transport-agnostic shape of a nightly gate result (pack/collection/passed/
-# failures/report_path/timestamp). send_alert is a LOG-ONLY stub: info on pass,
-# warning (per-failure) on fail. Real Slack/webhook wiring is a later slice.
+# failures/report_path/timestamp) plus an optional trailing baseline_diff
+# (BaselineDiff | None) attached by the orchestrator when a baseline exists.
+# send_alert is a LOG-ONLY stub: info on pass, warning (per-failure) on fail,
+# AND a warning per regression when baseline_diff carries regressions (logged
+# even on gate pass). Real Slack/webhook wiring is a later slice.
 # Exports: AlertPayload, send_alert
-# Deps: stdlib (dataclasses, logging).
+# Deps: stdlib (dataclasses, logging); src.eval.runner.baseline (BaselineDiff).
 # @end-summary
 """Eval alert payload + log-only sink (P8a).
 
@@ -18,6 +21,8 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+
+from .baseline import BaselineDiff
 
 logger = logging.getLogger("rag.eval.alert")
 
@@ -33,6 +38,10 @@ class AlertPayload:
         (``{qtype, metric, expected, actual, qid}``); empty on pass.
     :param report_path: filesystem path of the persisted report JSON.
     :param timestamp: ISO-8601 timestamp of the run.
+    :param baseline_diff: the :class:`~src.eval.runner.baseline.BaselineDiff`
+        the orchestrator computed against the pack's committed
+        ``baseline.json`` sibling, or ``None`` when no baseline exists. Trailing
+        additive field (defaults to ``None`` so prior call sites are unaffected).
     """
 
     pack_name: str
@@ -41,15 +50,20 @@ class AlertPayload:
     failures: list[dict]
     report_path: str
     timestamp: str
+    baseline_diff: BaselineDiff | None = None
 
 
 def send_alert(payload: AlertPayload) -> None:
     """Emit ``payload`` to the log (the current, log-only alert sink).
 
     On pass: a single ``INFO`` line. On fail: a ``WARNING`` line naming the pack
-    plus one ``WARNING`` line per failure (qtype/metric/expected/actual). Real
-    delivery (Slack/webhook) is wired in a later slice; this keeps the
-    orchestrator's alert seam observable today.
+    plus one ``WARNING`` line per failure (qtype/metric/expected/actual).
+
+    Independently of the gate outcome, if ``payload.baseline_diff`` carries any
+    regressions, a ``WARNING`` summary line plus one ``WARNING`` line per
+    regressed metric are emitted — so a regression vs baseline is surfaced even
+    when the absolute gate passed. Real delivery (Slack/webhook) is wired in a
+    later slice; this keeps the orchestrator's alert seam observable today.
     """
     if payload.gate_passed:
         logger.info(
@@ -58,22 +72,34 @@ def send_alert(payload: AlertPayload) -> None:
             payload.collection_name,
             payload.report_path,
         )
-        return
-
-    logger.warning(
-        "eval gate FAILED: pack=%s collection=%s failures=%d report=%s",
-        payload.pack_name,
-        payload.collection_name,
-        len(payload.failures),
-        payload.report_path,
-    )
-    for failure in payload.failures:
+    else:
         logger.warning(
-            "  pack=%s FAIL qtype=%s metric=%s expected>=%s actual=%s qid=%s",
+            "eval gate FAILED: pack=%s collection=%s failures=%d report=%s",
             payload.pack_name,
-            failure.get("qtype", ""),
-            failure.get("metric", ""),
-            failure.get("expected"),
-            failure.get("actual"),
-            failure.get("qid", ""),
+            payload.collection_name,
+            len(payload.failures),
+            payload.report_path,
         )
+        for failure in payload.failures:
+            logger.warning(
+                "  pack=%s FAIL qtype=%s metric=%s expected>=%s actual=%s qid=%s",
+                payload.pack_name,
+                failure.get("qtype", ""),
+                failure.get("metric", ""),
+                failure.get("expected"),
+                failure.get("actual"),
+                failure.get("qid", ""),
+            )
+
+    diff = payload.baseline_diff
+    if diff is not None and diff.regressions:
+        logger.warning(
+            "eval REGRESSION vs baseline: pack=%s regressions=%d report=%s",
+            payload.pack_name, len(diff.regressions), payload.report_path,
+        )
+        for md in diff.regressions:
+            logger.warning(
+                "  pack=%s REGRESSION qtype=%s metric=%s baseline=%s current=%s delta=%s",
+                payload.pack_name, md.qtype, md.metric,
+                md.baseline_value, md.current_value, md.delta,
+            )

--- a/tests/eval/test_orchestrator_e2e.py
+++ b/tests/eval/test_orchestrator_e2e.py
@@ -309,3 +309,244 @@ def test_send_alert_pass_no_warning(caplog) -> None:
 
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert not warnings, "a passing gate must not emit a WARNING"
+
+
+# ---------------------------------------------------------------------------
+# P8c — baseline-diff wiring
+# ---------------------------------------------------------------------------
+
+
+def _write_baseline(pack_dir: Path, baseline: dict) -> Path:
+    """Dump ``baseline`` as the pack's committed ``baseline.json`` sibling."""
+    path = Path(pack_dir) / "baseline.json"
+    path.write_text(json.dumps(baseline), encoding="utf-8")
+    return path
+
+
+# A baseline where recall is steady (1.0) but faithfulness was higher (1.0) than
+# the current run (0.9) → faithfulness is the SOLE regression past epsilon 0.05.
+_BASELINE_FAITHFULNESS_REGRESSED = {
+    "pack_name": "synpack",
+    "timestamp": "2025-01-01T00:00:00+00:00",
+    "passed": True,
+    "recall_by_qtype": {"factoid": 1.0},
+    "mrr_by_qtype": {"factoid": 1.0},
+    "faithfulness_by_qtype": {"factoid": 1.0},
+}
+
+
+def test_baseline_present_attaches_diff_with_regressions(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A committed baseline.json → AlertPayload.baseline_diff carries the diff.
+
+    Gate PASSES (recall 1.0 >= 0.5, faithfulness 0.9 >= 0.5) but faithfulness
+    REGRESSED vs the baseline's 1.0 (delta -0.1, past epsilon). Default
+    fail_on_regression=False → rc stays 0 (no flip).
+    """
+    from src.eval.orchestrator import run_nightly
+
+    pack_dir = _make_synthetic_pack(
+        tmp_path, recall_floor=0.5, faithfulness_floor=0.5
+    )
+    _patch_full_chain(monkeypatch, retrieved_source="doc1.md", judge_score=0.9)
+    _write_baseline(pack_dir, _BASELINE_FAITHFULNESS_REGRESSED)
+
+    captured: list = []
+    out_dir = tmp_path / "reports"
+
+    rc = run_nightly(
+        [pack_dir],
+        output_dir=out_dir,
+        now=FIXED_NOW,
+        alert_fn=captured.append,
+    )
+
+    assert rc == 0, "gate passed and fail_on_regression is False by default"
+    assert len(captured) == 1
+    diff = captured[0].baseline_diff
+    assert diff is not None, "a committed baseline.json must attach a diff"
+    assert diff.regressions, "faithfulness 0.9 vs baseline 1.0 must regress"
+    metrics = {md.metric for md in diff.regressions}
+    assert metrics == {"faithfulness"}, (
+        f"faithfulness is the sole regression; recall (1.0==1.0) is not: {metrics}"
+    )
+    (faith,) = [md for md in diff.regressions if md.metric == "faithfulness"]
+    assert faith.delta == pytest.approx(-0.1)
+
+
+def test_no_baseline_leaves_diff_none_and_unchanged_exit(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """No baseline.json → baseline_diff is None and rc is unchanged (pre-P8c)."""
+    from src.eval.orchestrator import run_nightly
+
+    pack_dir = _make_synthetic_pack(
+        tmp_path, recall_floor=0.5, faithfulness_floor=0.5
+    )
+    _patch_full_chain(monkeypatch, retrieved_source="doc1.md", judge_score=0.9)
+    # Intentionally DO NOT write baseline.json.
+
+    captured: list = []
+    out_dir = tmp_path / "reports"
+
+    rc = run_nightly(
+        [pack_dir],
+        output_dir=out_dir,
+        now=FIXED_NOW,
+        alert_fn=captured.append,
+    )
+
+    assert rc == 0
+    assert len(captured) == 1
+    assert captured[0].baseline_diff is None
+
+
+def test_fail_on_regression_flips_exit_despite_gate_pass(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """fail_on_regression=True flips rc to 1 on a regression even when gate passes.
+
+    DISCRIMINATING PARTNER to test_baseline_present_attaches_diff_with_regressions:
+    identical setup (gate passes, faithfulness regresses), only the flag flips.
+    Proves the flip is regression-driven (gate_passed is still True) and kills a
+    "default True" mutation of fail_on_regression.
+    """
+    from src.eval.orchestrator import run_nightly
+
+    pack_dir = _make_synthetic_pack(
+        tmp_path, recall_floor=0.5, faithfulness_floor=0.5
+    )
+    _patch_full_chain(monkeypatch, retrieved_source="doc1.md", judge_score=0.9)
+    _write_baseline(pack_dir, _BASELINE_FAITHFULNESS_REGRESSED)
+
+    captured: list = []
+    out_dir = tmp_path / "reports"
+
+    rc = run_nightly(
+        [pack_dir],
+        output_dir=out_dir,
+        now=FIXED_NOW,
+        alert_fn=captured.append,
+        fail_on_regression=True,
+    )
+
+    assert rc == 1, "a regression with fail_on_regression=True must flip the exit"
+    assert len(captured) == 1
+    assert captured[0].gate_passed is True, (
+        "the flip is regression-driven, not gate-driven"
+    )
+    assert captured[0].baseline_diff is not None
+    assert captured[0].baseline_diff.regressions
+
+
+def test_send_alert_logs_regression_even_on_gate_pass(caplog) -> None:
+    """send_alert logs a REGRESSION WARNING when the diff has regressions.
+
+    Partner assertion: a passing payload with baseline_diff=None emits NO
+    REGRESSION warning (only the INFO pass line).
+    """
+    from src.eval.runner.alert import AlertPayload, send_alert
+    from src.eval.runner.baseline import BaselineDiff, MetricDelta
+
+    md = MetricDelta(
+        qtype="factoid",
+        metric="faithfulness",
+        baseline_value=1.0,
+        current_value=0.9,
+        delta=-0.1,
+        regressed=True,
+    )
+    diff = BaselineDiff(
+        pack_name="synpack",
+        baseline_timestamp="2025-01-01T00:00:00+00:00",
+        current_timestamp=FIXED_NOW.isoformat(),
+        passed_baseline=True,
+        passed_current=True,
+        regressions=(md,),
+        improvements=(),
+        unchanged=(),
+        new_qtypes=(),
+        dropped_qtypes=(),
+        gate_flipped_to_fail=False,
+    )
+    payload = AlertPayload(
+        pack_name="synpack",
+        collection_name="test_coll",
+        gate_passed=True,
+        failures=[],
+        report_path="/tmp/report.json",
+        timestamp=FIXED_NOW.isoformat(),
+        baseline_diff=diff,
+    )
+
+    with caplog.at_level(logging.INFO, logger="rag.eval.alert"):
+        send_alert(payload)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "a regression must emit a WARNING even on gate pass"
+    assert any("REGRESSION" in r.getMessage() for r in warnings)
+
+    # Partner: gate-pass + no diff → no REGRESSION warning.
+    caplog.clear()
+    no_diff_payload = AlertPayload(
+        pack_name="synpack",
+        collection_name="test_coll",
+        gate_passed=True,
+        failures=[],
+        report_path="/tmp/report.json",
+        timestamp=FIXED_NOW.isoformat(),
+        baseline_diff=None,
+    )
+    with caplog.at_level(logging.INFO, logger="rag.eval.alert"):
+        send_alert(no_diff_payload)
+
+    regression_warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "REGRESSION" in r.getMessage()
+    ]
+    assert not regression_warnings, "no diff → no REGRESSION warning"
+
+
+def test_corrupt_baseline_degrades_gracefully_not_errored(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A malformed/corrupt baseline.json must NOT mark the pack errored.
+
+    A committed baseline that won't parse as JSON (hand-edit, merge-conflict
+    markers, truncation) should degrade like an ABSENT baseline: the pack's eval
+    still ran and persisted, so its alert must still fire with baseline_diff=None
+    and the exit code must reflect the GATE only — never a spurious error-exit.
+    """
+    from src.eval.orchestrator import run_nightly
+
+    pack_dir = _make_synthetic_pack(
+        tmp_path, recall_floor=0.5, faithfulness_floor=0.5
+    )
+    _patch_full_chain(monkeypatch, retrieved_source="doc1.md", judge_score=0.9)
+    # Garbage that json.loads cannot parse (e.g. a merge-conflict leftover).
+    (Path(pack_dir) / "baseline.json").write_text(
+        "<<<<<<< HEAD\nnot json\n", encoding="utf-8"
+    )
+
+    captured: list = []
+    out_dir = tmp_path / "reports"
+
+    rc = run_nightly(
+        [pack_dir],
+        output_dir=out_dir,
+        now=FIXED_NOW,
+        # fail_on_regression on to prove a corrupt baseline can't flip either.
+        fail_on_regression=True,
+        alert_fn=captured.append,
+    )
+
+    # Gate passes (recall 1.0, faithfulness 0.9 ≥ floors) → rc 0, NOT errored.
+    assert rc == 0
+    # The pack's alert still fired (not swallowed by an exception) ...
+    assert len(captured) == 1
+    # ... and the unusable baseline is treated as absent.
+    assert captured[0].baseline_diff is None
+    # The report was still persisted.
+    assert len(list(out_dir.glob("*.json"))) == 1


### PR DESCRIPTION
## Stack

Follow-on to the **P8 — Orchestrator + baseline diff** mini-stack. Base: **P8b** (#133).

- P8a.0 — run_eval() + persist_eval_report (#131)
- P8a — nightly orchestrator (#132)
- P8b — baseline diff + reporting + promote-baseline (#133)
- **P8c — orchestrator baseline-diff wiring** ← this PR

## Why

P8a built the orchestrator; P8b built the diff engine + `promote-baseline` command — but nothing connected them. P8c **closes the loop**: `promote-baseline` writes `evals/packs/<pack>/baseline.json`; `run_nightly` now reads that exact file and diffs every nightly run against it.

## What

- **`src/eval/orchestrator.py`** — `run_nightly` gains keyword-only `fail_on_regression: bool = False` and `regression_epsilon: float = 0.05`. Per pack, after persisting the report: if a committed `baseline.json` sibling exists, load it + read the just-persisted report back from disk (persistence stays the single source of the diff input), call `compute_baseline_diff(...)`, and attach the `BaselineDiff` to the alert. When `fail_on_regression=True`, any regression flips the batch exit to `1` **even if the absolute gate passed** (catches slow erosion the fixed floor misses).
- **`src/eval/runner/alert.py`** — `AlertPayload` gains a trailing `baseline_diff: BaselineDiff | None = None`; `send_alert` logs a per-metric REGRESSION warning when the diff carries regressions, on gate-pass **and** gate-fail.
- **`scripts/run_nightly_eval.py`** — `--fail-on-regression` / `--regression-epsilon` flags, threaded through.

## Decisions

- **`fail_on_regression` defaults OFF** — preserves P8a's tested batch semantics exactly (regressions are logged/attached but advisory until a pack opts in). Optional behavior toggled via typed flag per CLAUDE.md.
- **Baseline read back from the persisted file**, not re-derived from the in-memory result — the diff input is byte-for-byte what landed on disk.
- **Unusable baseline degrades like an absent one** — a corrupt/unparseable `baseline.json` (hand-edit, merge-conflict markers, truncation) is caught by a NARROW `JSONDecodeError`/`OSError` guard and treated as no-baseline (logged), rather than falling to the per-pack handler which would wrongly mark the pack *errored* and suppress its alert even though the eval itself succeeded. (Hardening added after the adversarial pass flagged the footgun.)

## Test plan

- [x] +5 e2e tests (`tests/eval/test_orchestrator_e2e.py`):
  - baseline-present → diff attached, faithfulness is the **sole** regression (recall 1.0==1.0 is not), rc 0 with flag off
  - no-baseline → `baseline_diff is None`, rc unchanged (pre-P8c behavior preserved)
  - **discriminating partner**: identical regression setup + `fail_on_regression=True` → rc 1 with `gate_passed is True` (proves the flip is regression-driven, kills a default-True mutation)
  - `send_alert` logs REGRESSION on gate-pass; no-diff → no REGRESSION warning
  - **corrupt baseline.json** (conflict markers) → degrades gracefully: rc 0, alert still fires, `baseline_diff None`, report still persisted
- [x] Eval suite: **201 passed / 4 skipped** (was 196)
- [x] CI cross-area command (`-m "not slow and not integration"` over ingest + 14 listed files): **2245 passed / 4 skipped** — green
- [x] Mutations (inverse-edit revert, SA3-verified): never-attach → reds attach+flip; remove flip → reds flip only (partner stays green); default-True → reds flag-off test; remove alert log → reds send_alert test; swap diff args → reds direction
- [x] Scope fence: orchestrator.py + alert.py + shim + 1 test file; `compute_baseline_diff`/persistence/cli/reporting/stage-logic UNCHANGED

## Deferred

- Real Slack/webhook alert transport (still log-only `send_alert`).
- Temporal `NightlyEvalWorkflow` (cron-script form is the current orchestrator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)