### PR TITLE
feat(eval): P9 — judge calibration loop (Cohen's κ + drift alert)

### DIFF
--- a/src/eval/runner/__init__.py
+++ b/src/eval/runner/__init__.py
@@ -9,11 +9,14 @@
 #          score_goldens, build_eval_report, build_judge_client,
 #          load_judge_prompt, render_judge_prompt, read_samples_per_claim,
 #          read_max_parallel_judges, render_ci_summary, persist_eval_report,
-#          AlertPayload, send_alert.
+#          AlertPayload, send_alert, CalibrationResult, CalibrationRecord,
+#          CalibrationAlert, cohens_kappa, binarize_score, compute_calibration,
+#          detect_drift, persist_calibration_record, send_calibration_alert.
 # Deps: .plan (pure), .report (frozen dataclasses + build_eval_report),
 #       .execute (ingest + vector_db), .retrieve (vector_db search +
 #       embeddings), .metrics (pure recall@k), .judge (pluggable judge
-#       contract; P5.0), .faithfulness (P5 executor).
+#       contract; P5.0), .faithfulness (P5 executor), .calibration (P9
+#       judge-calibration: Cohen's kappa + drift alert).
 # @end-summary
 """Eval runner — pack-to-ingest orchestration + retrieval metrics + judge
 + faithfulness scoring.
@@ -30,6 +33,17 @@ from __future__ import annotations
 
 from .alert import AlertPayload, send_alert
 from .baseline import BaselineDiff, MetricDelta, compute_baseline_diff
+from .calibration import (
+    CalibrationAlert,
+    CalibrationRecord,
+    CalibrationResult,
+    binarize_score,
+    cohens_kappa,
+    compute_calibration,
+    detect_drift,
+    persist_calibration_record,
+    send_calibration_alert,
+)
 from .ci import render_ci_summary
 from .execute import execute_plan
 from .gate import GateFailure, GateResult, validate_eval_report
@@ -67,6 +81,9 @@ from .retrieve import QueryRetrievalResult, RetrievalResults, retrieve_for_golde
 __all__ = [
     "AlertPayload",
     "BaselineDiff",
+    "CalibrationAlert",
+    "CalibrationRecord",
+    "CalibrationResult",
     "EvalReport",
     "FaithfulnessResults",
     "GateFailure",
@@ -83,11 +100,16 @@ __all__ = [
     "aggregate_faithfulness_by_qtype",
     "aggregate_mrr_by_qtype",
     "aggregate_recall_by_qtype",
+    "binarize_score",
     "build_eval_report",
     "build_judge_client",
+    "cohens_kappa",
     "compute_baseline_diff",
+    "compute_calibration",
+    "detect_drift",
     "execute_plan",
     "load_judge_prompt",
+    "persist_calibration_record",
     "persist_eval_report",
     "plan_pack_ingest",
     "read_max_parallel_judges",
@@ -101,5 +123,6 @@ __all__ = [
     "retrieve_for_goldens",
     "score_goldens",
     "send_alert",
+    "send_calibration_alert",
     "validate_eval_report",
 ]

--- a/src/eval/runner/calibration.py
+++ b/src/eval/runner/calibration.py
@@ -1,0 +1,297 @@
+# @summary
+# P9 — judge calibration loop. Quantifies agreement between the automated judge
+# and a categorical reference (human / Tier-3) via Cohen's kappa, binarizing the
+# judge's continuous scores at a threshold. compute_calibration returns a frozen
+# CalibrationResult (kappa, agreement_rate=po, confusion tp/tn/fp/fn vs the
+# reference, n, threshold, timestamp). detect_drift flags kappa strictly below a
+# floor; persist_calibration_record mirrors persistence.persist_eval_report's
+# deterministic {pack}_{filesafe-ts}.json layout; send_calibration_alert is a
+# log-only sink (WARNING on drift, INFO otherwise), mirroring alert.send_alert.
+# Exports: cohens_kappa, binarize_score, detect_drift, compute_calibration,
+#          persist_calibration_record, send_calibration_alert, CalibrationResult,
+#          CalibrationRecord, CalibrationAlert.
+# Deps: stdlib only (dataclasses, json, logging, datetime, pathlib, typing).
+# @end-summary
+"""P9 — judge calibration loop.
+
+The automated eval judge emits continuous faithfulness scores; periodically we
+re-check it against a categorical reference label set (human adjudication or a
+stronger Tier-3 model). This module binarizes the judge scores at a threshold
+and measures inter-rater reliability via Cohen's kappa, persists a deterministic
+calibration record, and raises a log-only drift alert when kappa falls below a
+configured floor.
+
+All helpers (:func:`cohens_kappa`, :func:`binarize_score`, :func:`detect_drift`)
+are pure and side-effect-free. I/O is confined to
+:func:`persist_calibration_record`; logging to :func:`send_calibration_alert`.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+logger = logging.getLogger("rag.eval.calibration")
+
+
+def cohens_kappa(labels_a: Sequence[str], labels_b: Sequence[str]) -> float:
+    """Return Cohen's kappa for two equal-length categorical label sequences.
+
+    ``kappa = (po - pe) / (1 - pe)`` where ``po`` is the observed agreement rate
+    and ``pe`` is the chance agreement implied by each rater's marginals. Works
+    for any categorical labels, not just pass/fail.
+
+    EDGE: when ``pe == 1.0`` (both raters placed everything in a single class, so
+    chance agreement is total and the denominator collapses to 0) kappa is
+    defined as ``1.0`` to avoid a ``0/0``.
+
+    :raises ValueError: if the two sequences differ in length.
+    """
+    if len(labels_a) != len(labels_b):
+        raise ValueError(
+            f"label sequences differ in length: {len(labels_a)} != {len(labels_b)}"
+        )
+
+    n = len(labels_a)
+    if n == 0:
+        # No observations: define perfect (vacuous) agreement.
+        return 1.0
+
+    # Observed agreement (po): fraction of positions where the raters agree.
+    po = sum(1 for a, b in zip(labels_a, labels_b) if a == b) / n
+
+    # Chance agreement (pe): sum over classes of the product of each rater's
+    # marginal probability for that class.
+    classes = set(labels_a) | set(labels_b)
+    pe = 0.0
+    for cls in classes:
+        p_a = sum(1 for a in labels_a if a == cls) / n
+        p_b = sum(1 for b in labels_b if b == cls) / n
+        pe += p_a * p_b
+
+    if pe == 1.0:
+        # Both raters in one class -> total chance agreement; define kappa = 1.0.
+        return 1.0
+    return (po - pe) / (1.0 - pe)
+
+
+def binarize_score(score: float, threshold: float) -> str:
+    """Map a continuous score to ``"pass"``/``"fail"`` at ``threshold``.
+
+    The boundary is INCLUSIVE: ``score == threshold`` -> ``"pass"`` (uses ``>=``).
+    """
+    return "pass" if score >= threshold else "fail"
+
+
+def detect_drift(kappa: float, *, min_kappa: float) -> bool:
+    """Return ``True`` iff ``kappa`` has drifted below the floor.
+
+    STRICT: drift is ``kappa < min_kappa``. Equality (``kappa == min_kappa``)
+    is NOT drift.
+    """
+    return kappa < min_kappa
+
+
+@dataclass(frozen=True)
+class CalibrationResult:
+    """Immutable outcome of one calibration computation.
+
+    :param kappa: Cohen's kappa between binarized judge labels and the reference.
+    :param n: number of paired observations.
+    :param agreement_rate: observed agreement ``po`` (fraction of matching
+        positions).
+    :param confusion_counts: confusion vs the reference treating ``"pass"`` as
+        positive — keys EXACTLY ``"tp"``, ``"tn"``, ``"fp"``, ``"fn"``.
+    :param threshold: the binarization threshold applied to judge scores.
+    :param timestamp: ISO-8601 timestamp of the computation.
+    """
+
+    kappa: float
+    n: int
+    agreement_rate: float
+    confusion_counts: dict[str, int]
+    threshold: float
+    timestamp: str
+
+
+@dataclass(frozen=True)
+class CalibrationRecord:
+    """Immutable, persistable calibration record for a (pack, qtype) pair.
+
+    :param pack_name: the eval pack's name.
+    :param qtype: the question type the calibration covers.
+    :param min_kappa: the configured kappa floor used for drift detection.
+    :param drift_detected: whether ``result.kappa`` fell below ``min_kappa``.
+    :param result: the underlying :class:`CalibrationResult`.
+    """
+
+    pack_name: str
+    qtype: str
+    min_kappa: float
+    drift_detected: bool
+    result: CalibrationResult
+
+
+@dataclass(frozen=True)
+class CalibrationAlert:
+    """Immutable, transport-agnostic snapshot of a calibration outcome.
+
+    :param pack_name: the eval pack's name.
+    :param qtype: the question type the calibration covers.
+    :param kappa: the measured kappa.
+    :param min_kappa: the configured kappa floor.
+    :param drift_detected: whether drift was flagged.
+    :param timestamp: ISO-8601 timestamp of the run.
+    :param record_path: filesystem path of the persisted record, or ``None``.
+        Trailing additive field (defaults to ``None`` so prior call sites are
+        unaffected) — mirrors :class:`AlertPayload.baseline_diff`.
+    """
+
+    pack_name: str
+    qtype: str
+    kappa: float
+    min_kappa: float
+    drift_detected: bool
+    timestamp: str
+    record_path: str | None = None
+
+
+def compute_calibration(
+    judge_scores: Sequence[float],
+    reference_labels: Sequence[str],
+    *,
+    threshold: float,
+    now: datetime | None = None,
+) -> CalibrationResult:
+    """Compute calibration of judge scores against categorical reference labels.
+
+    Each judge score is binarized at ``threshold`` to a ``"pass"``/``"fail"``
+    label; ``kappa`` is :func:`cohens_kappa` of those judge labels vs the
+    reference; ``agreement_rate`` is the observed agreement ``po``; the confusion
+    counts treat ``"pass"`` as the positive class.
+
+    :param judge_scores: the automated judge's continuous scores.
+    :param reference_labels: categorical ``"pass"``/``"fail"`` reference labels.
+    :param threshold: binarization threshold (inclusive ``>=`` boundary).
+    :param now: injected timestamp for deterministic tests; defaults to
+        ``datetime.now(timezone.utc)`` (timezone-aware, never ``utcnow()``).
+    :raises ValueError: if the score/label sequences differ in length.
+    """
+    if len(judge_scores) != len(reference_labels):
+        raise ValueError(
+            "judge_scores and reference_labels differ in length: "
+            f"{len(judge_scores)} != {len(reference_labels)}"
+        )
+
+    judge_labels = [binarize_score(s, threshold) for s in judge_scores]
+    kappa = cohens_kappa(judge_labels, reference_labels)
+
+    n = len(judge_labels)
+    agree = sum(1 for j, r in zip(judge_labels, reference_labels) if j == r)
+    agreement_rate = agree / n if n else 1.0
+
+    # Confusion vs the reference, "pass" treated as positive.
+    confusion = {"tp": 0, "tn": 0, "fp": 0, "fn": 0}
+    for j, r in zip(judge_labels, reference_labels):
+        if j == "pass" and r == "pass":
+            confusion["tp"] += 1
+        elif j == "pass" and r == "fail":
+            confusion["fp"] += 1
+        elif j == "fail" and r == "pass":
+            confusion["fn"] += 1
+        else:  # j == "fail" and r == "fail"
+            confusion["tn"] += 1
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    return CalibrationResult(
+        kappa=kappa,
+        n=n,
+        agreement_rate=agreement_rate,
+        confusion_counts=confusion,
+        threshold=threshold,
+        timestamp=now.isoformat(),
+    )
+
+
+def persist_calibration_record(
+    record: CalibrationRecord,
+    output_dir: str | Path,
+    *,
+    now: datetime | None = None,
+) -> Path:
+    """Write ``record`` to a deterministically named JSON file; return its path.
+
+    Mirrors :func:`src.eval.runner.persistence.persist_eval_report`: the filename
+    is ``{pack_name}_{filesafe_ts}.json`` where ``filesafe_ts`` is the ISO-8601
+    timestamp with colons stripped (illegal on some filesystems). The directory
+    is created if absent. The JSON payload fully captures the record, including a
+    nested ``result`` object.
+
+    :param record: the :class:`CalibrationRecord` to persist.
+    :param output_dir: directory to write into (created if absent).
+    :param now: injected timestamp for deterministic filenames; defaults to
+        ``datetime.now(timezone.utc)`` (timezone-aware, never ``utcnow()``).
+    :returns: the :class:`~pathlib.Path` written.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    result = record.result
+    payload = {
+        "pack_name": record.pack_name,
+        "qtype": record.qtype,
+        "min_kappa": record.min_kappa,
+        "drift_detected": record.drift_detected,
+        "result": {
+            "kappa": result.kappa,
+            "n": result.n,
+            "agreement_rate": result.agreement_rate,
+            "confusion_counts": result.confusion_counts,
+            "threshold": result.threshold,
+            "timestamp": result.timestamp,
+        },
+    }
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    filesafe_ts = now.isoformat().replace(":", "")
+    path = out_dir / f"{record.pack_name}_{filesafe_ts}.json"
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def send_calibration_alert(payload: CalibrationAlert) -> None:
+    """Emit ``payload`` to the log (the current, log-only calibration sink).
+
+    On drift: one ``WARNING`` line naming the pack/qtype, kappa and floor. On no
+    drift: one ``INFO`` line. Log-only; real delivery is a later slice. Mirrors
+    the style of :func:`src.eval.runner.alert.send_alert`.
+    """
+    if payload.drift_detected:
+        logger.warning(
+            "calibration DRIFT: pack=%s qtype=%s kappa=%.3f min_kappa=%.3f "
+            "timestamp=%s record=%s",
+            payload.pack_name,
+            payload.qtype,
+            payload.kappa,
+            payload.min_kappa,
+            payload.timestamp,
+            payload.record_path,
+        )
+    else:
+        logger.info(
+            "calibration OK: pack=%s qtype=%s kappa=%.3f min_kappa=%.3f "
+            "timestamp=%s record=%s",
+            payload.pack_name,
+            payload.qtype,
+            payload.kappa,
+            payload.min_kappa,
+            payload.timestamp,
+            payload.record_path,
+        )

--- a/src/eval/runner/calibration.py
+++ b/src/eval/runner/calibration.py
@@ -178,12 +178,25 @@ def compute_calibration(
     :param threshold: binarization threshold (inclusive ``>=`` boundary).
     :param now: injected timestamp for deterministic tests; defaults to
         ``datetime.now(timezone.utc)`` (timezone-aware, never ``utcnow()``).
-    :raises ValueError: if the score/label sequences differ in length.
+    :raises ValueError: if the score/label sequences differ in length, or if
+        ``reference_labels`` contains a label other than ``"pass"``/``"fail"``
+        (the confusion matrix is binary-only).
     """
     if len(judge_scores) != len(reference_labels):
         raise ValueError(
             "judge_scores and reference_labels differ in length: "
             f"{len(judge_scores)} != {len(reference_labels)}"
+        )
+
+    # Fail fast on a contradictory contract: the confusion matrix is defined for
+    # the binary "pass"/"fail" class set only (a stray third label would be
+    # silently absorbed into the ``tn`` bucket below). ``cohens_kappa`` itself is
+    # multi-class, but ``compute_calibration``'s confusion counts are not.
+    invalid = sorted(set(reference_labels) - {"pass", "fail"})
+    if invalid:
+        raise ValueError(
+            "reference_labels must be 'pass'/'fail' only; got unexpected "
+            f"label(s): {invalid}"
         )
 
     judge_labels = [binarize_score(s, threshold) for s in judge_scores]

--- a/tests/eval/test_calibration.py
+++ b/tests/eval/test_calibration.py
@@ -266,3 +266,36 @@ def test_calibration_result_is_frozen() -> None:
     assert dataclasses.is_dataclass(result)
     with pytest.raises(dataclasses.FrozenInstanceError):
         result.kappa = 0.99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — compute_calibration enforces the binary reference contract.
+# A stray third label would otherwise be silently absorbed into "tn".
+# ---------------------------------------------------------------------------
+def test_compute_calibration_rejects_non_binary_reference() -> None:
+    from src.eval.runner.calibration import compute_calibration
+
+    # Discriminating partner: the all-pass/fail set is accepted ...
+    ok = compute_calibration([0.9, 0.1], ["pass", "fail"], threshold=0.5)
+    assert ok.n == 2
+
+    # ... but a stray "partial" label fails fast rather than miscounting.
+    with pytest.raises(ValueError):
+        compute_calibration(
+            [0.9, 0.1, 0.5], ["pass", "fail", "partial"], threshold=0.5
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 11 — empty input is vacuous perfect agreement (no 0/0, no crash).
+# ---------------------------------------------------------------------------
+def test_empty_input_is_vacuous_agreement() -> None:
+    from src.eval.runner.calibration import cohens_kappa, compute_calibration
+
+    assert cohens_kappa([], []) == 1.0
+
+    result = compute_calibration([], [], threshold=0.5, now=FIXED_NOW)
+    assert result.kappa == 1.0
+    assert result.n == 0
+    assert result.agreement_rate == 1.0
+    assert result.confusion_counts == {"tp": 0, "tn": 0, "fp": 0, "fn": 0}

--- a/tests/eval/test_calibration.py
+++ b/tests/eval/test_calibration.py
@@ -1,0 +1,268 @@
+# @summary
+# P9 — tests for the judge calibration loop (src/eval/runner/calibration.py).
+# Pins: Cohen's kappa arithmetic against a hand-computed oracle (kappa=0.4 with
+# confusion tp=4/tn=3/fp=2/fn=1, agreement=0.7), perfect/total-disagreement and
+# the pe==1 all-one-class edge (kappa=1.0, not nan), binarize boundary
+# inclusivity, strict drift detection, log-only drift alert (WARNING on drift /
+# INFO otherwise), deterministic persistence round-trip with exact values, and
+# frozen-dataclass immutability.
+# Exports: test_kappa_on_seeded_disagreement and the rest of the P9 matrix.
+# Deps: src.eval.runner.calibration (module under test); stdlib (json,
+#       dataclasses, logging, datetime, pathlib); pytest.
+# @end-summary
+"""P9 — judge calibration loop tests (TDD-first)."""
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+# Deterministic injected clock (mirror tests/eval/test_orchestrator_e2e.py:34).
+FIXED_NOW = datetime(2026, 5, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — the kappa ORACLE: 10 seeded samples, confusion tp=4/tn=3/fp=2/fn=1.
+# ---------------------------------------------------------------------------
+def test_kappa_on_seeded_disagreement() -> None:
+    """Hand-computed oracle. With threshold=0.5 and judge passes=0.9 / fails=0.1:
+
+    Construct exactly confusion (vs reference, "pass" positive):
+      tp=4 (judge pass, ref pass), tn=3 (judge fail, ref fail),
+      fp=2 (judge pass, ref fail), fn=1 (judge fail, ref pass).
+      po (agreement) = (tp+tn)/n = 7/10 = 0.7
+      marginals: judge pass = tp+fp = 6, ref pass = tp+fn = 5
+      pe = (6/10)(5/10) + (4/10)(5/10) = 0.30 + 0.20 = 0.50
+      kappa = (0.7 - 0.5)/(1 - 0.5) = 0.2/0.5 = 0.40
+    kappa(0.4) != agreement(0.7), so an agreement-in-place-of-kappa mutation reds.
+    """
+    from src.eval.runner.calibration import compute_calibration
+
+    # 4 tp, 3 tn, 2 fp, 1 fn  -> all four quadrants distinct.
+    judge_scores = [
+        0.9, 0.9, 0.9, 0.9,   # judge pass ...
+        0.9, 0.9,             # ... (fp: judge pass)
+        0.1, 0.1, 0.1,        # judge fail (tn)
+        0.1,                  # judge fail (fn)
+    ]
+    reference_labels = [
+        "pass", "pass", "pass", "pass",  # tp x4
+        "fail", "fail",                  # fp x2 (judge pass, ref fail)
+        "fail", "fail", "fail",          # tn x3 (judge fail, ref fail)
+        "pass",                          # fn x1 (judge fail, ref pass)
+    ]
+
+    result = compute_calibration(
+        judge_scores, reference_labels, threshold=0.5, now=FIXED_NOW
+    )
+
+    assert result.kappa == pytest.approx(0.4)
+    assert result.agreement_rate == pytest.approx(0.7)
+    assert result.confusion_counts == {"tp": 4, "tn": 3, "fp": 2, "fn": 1}
+    assert result.n == 10
+    assert result.threshold == 0.5
+    assert result.timestamp == FIXED_NOW.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — perfect agreement => kappa == 1.0, incl. pe==1 all-one-class edge.
+# ---------------------------------------------------------------------------
+def test_perfect_agreement_kappa_is_one() -> None:
+    from src.eval.runner.calibration import compute_calibration
+
+    judge_scores = [0.9, 0.1, 0.9, 0.1]
+    reference_labels = ["pass", "fail", "pass", "fail"]
+    result = compute_calibration(
+        judge_scores, reference_labels, threshold=0.5
+    )
+    assert result.kappa == pytest.approx(1.0)
+    assert result.agreement_rate == pytest.approx(1.0)
+
+
+def test_all_one_class_edge_kappa_is_one_not_nan() -> None:
+    """When both raters put everything in one class, pe == 1.0; the 0/0 case is
+    defined as kappa = 1.0 (not nan / not ZeroDivisionError)."""
+    from src.eval.runner.calibration import cohens_kappa
+
+    labels = ["pass"] * 5
+    k = cohens_kappa(labels, labels)
+    assert k == 1.0  # not nan, not a raise
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — total disagreement => kappa < 0 (negative).
+# ---------------------------------------------------------------------------
+def test_total_disagreement_kappa_is_negative() -> None:
+    from src.eval.runner.calibration import cohens_kappa
+
+    a = ["pass", "fail", "pass", "fail"]
+    b = ["fail", "pass", "fail", "pass"]
+    assert cohens_kappa(a, b) < 0
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — cohens_kappa length mismatch => ValueError.
+# ---------------------------------------------------------------------------
+def test_cohens_kappa_length_mismatch_raises() -> None:
+    from src.eval.runner.calibration import cohens_kappa
+
+    with pytest.raises(ValueError):
+        cohens_kappa(["pass", "fail"], ["pass"])
+
+
+def test_compute_calibration_length_mismatch_raises() -> None:
+    from src.eval.runner.calibration import compute_calibration
+
+    with pytest.raises(ValueError):
+        compute_calibration([0.9, 0.1], ["pass"], threshold=0.5)
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — binarize boundary is INCLUSIVE (>=), discriminating partner below.
+# ---------------------------------------------------------------------------
+def test_binarize_boundary_is_inclusive() -> None:
+    from src.eval.runner.calibration import binarize_score
+
+    assert binarize_score(0.5, 0.5) == "pass"          # == threshold -> pass
+    assert binarize_score(0.5 - 1e-9, 0.5) == "fail"   # one step below -> fail
+    assert binarize_score(0.9, 0.5) == "pass"
+    assert binarize_score(0.1, 0.5) == "fail"
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — detect_drift strictness: kappa == min_kappa -> False; below -> True.
+# ---------------------------------------------------------------------------
+def test_detect_drift_strict_boundary() -> None:
+    from src.eval.runner.calibration import detect_drift
+
+    assert detect_drift(0.6, min_kappa=0.6) is False        # equal -> no drift
+    assert detect_drift(0.6 - 1e-9, min_kappa=0.6) is True   # below -> drift
+    assert detect_drift(0.9, min_kappa=0.6) is False
+    assert detect_drift(0.2, min_kappa=0.6) is True
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — drift alert fires (WARNING on drift, INFO + no WARNING otherwise).
+# ---------------------------------------------------------------------------
+def test_drift_alert_fires_warning(caplog) -> None:
+    from src.eval.runner.calibration import (
+        CalibrationAlert,
+        send_calibration_alert,
+    )
+
+    payload = CalibrationAlert(
+        pack_name="opentitan",
+        qtype="factoid",
+        kappa=0.30,
+        min_kappa=0.60,
+        drift_detected=True,
+        timestamp=FIXED_NOW.isoformat(),
+        record_path="/tmp/opentitan_cal.json",
+    )
+    with caplog.at_level(logging.WARNING, logger="rag.eval.calibration"):
+        assert send_calibration_alert(payload) is None
+
+    warnings = [
+        r for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert len(warnings) == 1
+    assert "DRIFT" in warnings[0].getMessage()
+
+
+def test_no_drift_alert_is_info_not_warning(caplog) -> None:
+    from src.eval.runner.calibration import (
+        CalibrationAlert,
+        send_calibration_alert,
+    )
+
+    payload = CalibrationAlert(
+        pack_name="opentitan",
+        qtype="factoid",
+        kappa=0.90,
+        min_kappa=0.60,
+        drift_detected=False,
+        timestamp=FIXED_NOW.isoformat(),
+    )
+    with caplog.at_level(logging.INFO, logger="rag.eval.calibration"):
+        send_calibration_alert(payload)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    infos = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert warnings == []
+    assert len(infos) == 1
+    assert "OK" in infos[0].getMessage()
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — persist round-trip: deterministic filename + EXACT values back.
+# ---------------------------------------------------------------------------
+def test_persist_calibration_record_roundtrip(tmp_path: Path) -> None:
+    from src.eval.runner.calibration import (
+        CalibrationRecord,
+        CalibrationResult,
+        persist_calibration_record,
+    )
+
+    result = CalibrationResult(
+        kappa=0.4,
+        n=10,
+        agreement_rate=0.7,
+        confusion_counts={"tp": 4, "tn": 3, "fp": 2, "fn": 1},
+        threshold=0.5,
+        timestamp=FIXED_NOW.isoformat(),
+    )
+    record = CalibrationRecord(
+        pack_name="opentitan",
+        qtype="factoid",
+        min_kappa=0.6,
+        drift_detected=True,
+        result=result,
+    )
+
+    out_dir = tmp_path / "calibration"
+    path = persist_calibration_record(record, out_dir, now=FIXED_NOW)
+
+    # Deterministic filename: {pack_name}_{filesafe_ts}.json (no colons).
+    filesafe_ts = FIXED_NOW.isoformat().replace(":", "")
+    assert path.name == f"opentitan_{filesafe_ts}.json"
+    assert ":" not in path.name
+    assert path.exists()
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    # EXACT values (serialization-test-teeth: not mere key-presence).
+    assert payload["pack_name"] == "opentitan"
+    assert payload["qtype"] == "factoid"
+    assert payload["min_kappa"] == 0.6
+    assert payload["drift_detected"] is True
+    assert payload["result"]["kappa"] == 0.4
+    assert payload["result"]["n"] == 10
+    assert payload["result"]["agreement_rate"] == 0.7
+    assert payload["result"]["confusion_counts"] == {
+        "tp": 4, "tn": 3, "fp": 2, "fn": 1
+    }
+    assert payload["result"]["threshold"] == 0.5
+    assert payload["result"]["timestamp"] == FIXED_NOW.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — frozen dataclasses (mirror test_judge_client.py:226-237 style).
+# ---------------------------------------------------------------------------
+def test_calibration_result_is_frozen() -> None:
+    from src.eval.runner.calibration import CalibrationResult
+
+    result = CalibrationResult(
+        kappa=0.4,
+        n=10,
+        agreement_rate=0.7,
+        confusion_counts={"tp": 4, "tn": 3, "fp": 2, "fn": 1},
+        threshold=0.5,
+        timestamp=FIXED_NOW.isoformat(),
+    )
+    assert dataclasses.is_dataclass(result)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        result.kappa = 0.99  # type: ignore[misc]


### PR DESCRIPTION
## P9 — Judge calibration loop

Adds `src/eval/runner/calibration.py`: quantifies agreement between the automated judge's continuous faithfulness scores and a categorical reference (human / Tier-3) by binarizing judge scores at a configurable threshold and computing **Cohen's κ**, then persisting a deterministic calibration record and raising a log-only drift alert when κ falls below a floor.

### Public surface (routed through `runner/__init__.py` for a stable import)
- `cohens_kappa(labels_a, labels_b)` — pure, general multi-class; `ValueError` on length mismatch; `pe==1.0` all-one-class edge defined as κ=1.0 (no 0/0).
- `binarize_score(score, threshold)` — inclusive `>=` boundary.
- `compute_calibration(judge_scores, reference_labels, *, threshold, now)` → frozen `CalibrationResult` (κ, n, `agreement_rate`=pₒ, confusion tp/tn/fp/fn vs reference, threshold, timestamp). Fails fast if `reference_labels` aren't `"pass"`/`"fail"`.
- `detect_drift(kappa, *, min_kappa)` — strict `κ < min_kappa`.
- `CalibrationRecord` + `persist_calibration_record(...)` — mirrors `persistence.persist_eval_report`'s `{pack}_{filesafe-ts}.json` layout.
- `CalibrationAlert` + `send_calibration_alert(...)` — log-only (WARNING on drift, INFO otherwise); mirrors `alert.send_alert`; trailing-additive `record_path`.

### Scope decisions
- **Lean clean-map MVP** (vs the plan's `src/eval/judge/` package): lives beside `judge`/`baseline`/`alert` in `runner/`, since the shipped judge is the leaner chunk-level float scorer (`runner/judge.py`), not the planned multi-subtask service. Validated on **seeded label pairs**.
- **Binary-at-gate-threshold** κ binning, threshold configurable (caller supplies the pack faithfulness floor — pure function stays decoupled from `EvalPack`).
- **Deferred** (unchanged from plan): the 10-example hand-graded human fixture (P5.0) and periodic Tier-2 drift checks.

### Tests (`tests/eval/test_calibration.py`, 14)
Named acceptance `test_kappa_on_seeded_disagreement` uses a hand-computed oracle (κ=0.4, agreement=0.7, confusion 4/3/2/1 — κ≠agreement, so an agreement-in-place-of-κ mutation reds). Plus perfect/all-one-class/total-disagreement κ edges, strict drift boundary, drift-alert caplog (WARNING vs INFO), FIXED_NOW persistence round-trip with exact-value asserts, frozen guard, binary-reference contract guard (discriminating partner), and empty-input vacuous path.

### Verification
- SA1 (surface map) → SA2 (TDD impl, RED-reason proof = `ModuleNotFoundError`) → main commit → SA3 (adversarial). SA3 ran **8 mutation probes — every one red'd a named test (zero coverage gaps)**, independently re-derived the κ oracle, verdict **PASS-WITH-NITS**; the two cheap nits (unenforced reference contract, untested n==0) were hardened in the second commit.
- Full eval suite: **215 passed, 4 skipped**. (CI does not run `tests/eval`; validated locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)