### PR TITLE
feat(eval): show-trend — read-only run-history inspection CLI

### DIFF
--- a/docs/eval/EVAL_LOOP_ENGINEERING_GUIDE.md
+++ b/docs/eval/EVAL_LOOP_ENGINEERING_GUIDE.md
@@ -175,7 +175,7 @@ evals/packs/opentitan_riscv/        # Reference pack
 
 ## CLI Interface
 
-The CLI is a single subcommand. See [`cli.py`](../../src/eval/cli.py) (`_build_parser`).
+The `run` subcommand drives the full loop. See [`cli.py`](../../src/eval/cli.py) (`_build_parser`). Sibling subcommands: `promote-baseline` (commits a report to the pack baseline) and the read-only `show-trend` (run-history inspection — see [Inspecting the trend](#inspecting-the-trend-show-trend-subcommand--runnershow_trendpy)).
 
 ```bash
 python -m src.eval run <pack_path> \
@@ -478,6 +478,29 @@ or alters any other alert field. Granularity is per-QTYPE (parity with
 explicitly out of scope here and noted as future work.** This slice adds NO CLI
 changes, NO pack-format changes, and does NOT touch the gate or
 `fail_on_regression` exit-flip behaviour.
+
+### Inspecting the trend (`show-trend` subcommand + `runner/show_trend.py`)
+
+`python -m src.eval show-trend <pack> [--reports-dir eval_reports] [--runs 3]
+[--window 3] [--min-regressed 2] [--epsilon 0.05]` is a **read-only** inspection
+surface over the data the two layers above produce. It loads the pack's
+append-only history index via `load_run_history(pack, reports_dir)` (missing file
+→ `[]`) and renders it with the pure
+[`render_trend_table`](../../src/eval/runner/show_trend.py)`(history, *, runs,
+window, min_regressed, epsilon)`. The table has one row per `(qtype, metric)`
+seen in the last `runs` runs (sorted for determinism): a delta column per
+displayed run (em-dash when a run lacks the pair, via `ci._fmt(None)`), then
+`regressed/window`, `latest`, and a `sustained` YES/NO flag. The YES flag and its
+`runs_regressed`/`window`/`latest` figures come straight from
+`detect_sustained_regressions` so the strict `delta < -epsilon` predicate stays
+single-sourced — `show_trend.py` never re-implements regression logic.
+
+`--runs` (how many recent runs to **display** as columns) is deliberately
+distinct from `--window` (how many recent runs the **detector** looks back over).
+The command performs NO writes, NO pack load, and NO ingest/retrieve/judge; an
+empty or missing history renders `(no run history yet)` and still exits `0` (a
+pack with no runs yet is normal, not an error). The only exit code other than `0`
+is argparse's own `2` for bad arguments.
 
 ## Known Limitations and Future Work
 

--- a/src/eval/README.md
+++ b/src/eval/README.md
@@ -25,6 +25,7 @@ into a single CLI subcommand. End-to-end answer-faithfulness for production runt
 | `orchestrator.py` | Nightly batch core: `run_nightly(...)` runs the loop per pack, persists, alerts, and returns a binary pass/fail code. Forwards the three `run_eval` DI seams. After each persist+baseline-diff it appends the run to a per-pack append-only run-history index via `runner/run_history.py`, then (best-effort) reloads that history and runs `runner/sustained_regression.py` to attach a multi-run sustained-regression verdict to the alert (never fails the run). |
 | `runner/run_history.py` | Per-pack append-only run-history index + per-qid regression deltas vs baseline. `compute_per_query_deltas` diffs the three per-query metric maps at qid granularity (sign = current − baseline, mirroring `baseline.py`); `index_run_report` appends one JSONL line (timestamp/pack_name/k/gate_passed/per_query_deltas/per_qtype_deltas) to `<output_dir>/<pack>.history.jsonl`; `load_run_history` reads it back sorted by timestamp. Feeds a future Ralph-on-regression auto-fixer. |
 | `runner/sustained_regression.py` | Multi-run sustained-regression detector over the run-history index. `detect_sustained_regressions(history, *, window=3, min_regressed=2, epsilon=0.05)` flags each `(qtype, metric)` that regressed (delta ≤ −epsilon, mirroring `baseline.py`) in ≥`min_regressed` of the most-recent `window` runs — suppressing one-off judge/retrieval dips a single-run `baseline_diff` would alarm on. Per-QTYPE granularity (parity with `baseline_diff`); per-QID sustained detection is future work. Returns a deterministically sorted tuple of frozen `SustainedMetricRegression`; surfaced on `AlertPayload.sustained_regressions`. |
+| `runner/show_trend.py` | Pure markdown formatter for the read-only `show-trend` subcommand. `render_trend_table(history, *, runs=3, window=3, min_regressed=2, epsilon=0.05)` maps run-history entries to a per-`(qtype, metric)` trend table (one delta column per the last `runs` runs, plus `regressed/window`, `latest`, and a `sustained` YES/NO flag from `detect_sustained_regressions`). NO I/O; empty history → a friendly one-line message. Reuses `ci._fmt`. |
 | `smoke.py` | Offline PR-gate smoke (P10): `python -m src.eval.smoke` drives the FULL loop (`run_nightly → run_eval → persist → gate → alert`) against a tiny synthetic pack via the DI seams — no live Weaviate/embeddings/LLM. Runs a clean (rc 0) and an injected-regression (rc 1) scenario; exits 0 iff BOTH behave. |
 | `__main__.py` | Module entry — delegates to `cli.main`. |
 
@@ -39,6 +40,10 @@ python -m src.eval run evals/packs/opentitan_riscv --samples-per-claim 1
 
 # Incremental update mode (do NOT drop the collection first).
 python -m src.eval run evals/packs/opentitan_riscv --no-fresh
+
+# READ-ONLY: print a markdown trend table from a pack's run-history index.
+# No ingest/retrieve/judge, no writes; missing history → friendly message, exit 0.
+python -m src.eval show-trend opentitan_riscv --reports-dir eval_reports --runs 3
 ```
 
 Exit codes: `0` pass, `1` gate fail, `2` pack load/validation error, `3` runtime/infra error.

--- a/src/eval/cli.py
+++ b/src/eval/cli.py
@@ -24,8 +24,12 @@
 # the live runner symbol at CALL TIME after the lazy import). These let the
 # offline CI smoke (src.eval.smoke) drive the FULL loop with no live infra and
 # no monkeypatch; run_cli is unchanged (live CLI keeps the live defaults).
+# show-trend adds a READ-ONLY run-history inspection subcommand:
+# show_trend(pack, ...) calls load_run_history → render_trend_table and prints a
+# markdown per-(qtype, metric) trend table. It performs NO writes/ingest/
+# retrieve/judge; missing/empty history → friendly message at exit 0.
 # Exports: _build_parser, _report_payload, run_eval, EvalRunResult, run_cli,
-#          promote_baseline, main
+#          promote_baseline, show_trend, main
 # Deps: argparse, json, logging, os, sys; src.eval.pack (errors, loader);
 #       src.eval.runner (lazy) — execute_plan, retrieve_for_goldens,
 #       score_goldens, build_judge_client, build_eval_report,
@@ -38,8 +42,10 @@
 The ``run`` subcommand chains the full eval pipeline against a loaded
 eval_pack and exits with a deterministic code reflecting the gate outcome.
 The ``promote-baseline`` subcommand (P8b) writes a report to the pack's
-committed ``baseline.json``. The CLI is a thin orchestrator — no business
-logic.
+committed ``baseline.json``. The ``show-trend`` subcommand is a READ-ONLY
+inspection surface that loads a pack's append-only run-history index and prints
+a markdown per-``(qtype, metric)`` trend table (no ingest/retrieve/judge, no
+writes). The CLI is a thin orchestrator — no business logic.
 
 Lazy imports for heavy modules keep argparse-time work to a minimum and
 sidestep langchain_core stub-timing hazards in the test environment.
@@ -175,6 +181,49 @@ def _build_parser() -> argparse.ArgumentParser:
         default="eval_reports",
         help="Directory of persisted reports for latest-discovery "
         "(default: eval_reports).",
+    )
+
+    # --- show-trend subcommand (read-only run-history inspection) ---
+    trend_parser = subparsers.add_parser(
+        "show-trend",
+        help="Print a markdown per-(qtype, metric) trend table from a pack's "
+        "run-history index (read-only; no ingest/retrieve/judge).",
+    )
+    trend_parser.add_argument(
+        "pack",
+        help="Pack name whose <pack>.history.jsonl lives under --reports-dir.",
+    )
+    trend_parser.add_argument(
+        "--reports-dir",
+        default="eval_reports",
+        help="Directory containing <pack>.history.jsonl (default: eval_reports).",
+    )
+    trend_parser.add_argument(
+        "--runs",
+        type=int,
+        default=3,
+        help="How many most-recent runs to show as delta columns (default: 3).",
+    )
+    trend_parser.add_argument(
+        "--window",
+        type=int,
+        default=3,
+        help="Detector lookback: recent runs inspected for sustained "
+        "regression (default: 3).",
+    )
+    trend_parser.add_argument(
+        "--min-regressed",
+        type=int,
+        default=2,
+        help="Min regressed runs in the window to flag a pair sustained "
+        "(default: 2).",
+    )
+    trend_parser.add_argument(
+        "--epsilon",
+        type=float,
+        default=0.05,
+        help="Regression tolerance band; predicate is strict delta < -epsilon "
+        "(default: 0.05).",
     )
     return parser
 
@@ -641,6 +690,53 @@ def promote_baseline(
     return 0
 
 
+def show_trend(
+    pack: str,
+    *,
+    reports_dir: str = "eval_reports",
+    runs: int = 3,
+    window: int = 3,
+    min_regressed: int = 2,
+    epsilon: float = 0.05,
+    stdout: Any = None,
+) -> int:
+    """Print a markdown trend table from ``pack``'s run-history index.
+
+    READ-ONLY inspection surface: loads the append-only history index via
+    :func:`~src.eval.runner.run_history.load_run_history` (missing file → ``[]``),
+    renders it with the pure
+    :func:`~src.eval.runner.show_trend.render_trend_table`, prints to stdout, and
+    returns ``0``. Does NOT write anything, load the pack, ingest, retrieve,
+    judge, or run the loop. An empty/missing history renders a friendly one-line
+    message — still exit ``0`` (a pack with no runs yet is normal, not an error).
+
+    :param pack: pack name whose ``<pack>.history.jsonl`` lives under
+        ``reports_dir``.
+    :param reports_dir: directory holding the history index (default
+        ``eval_reports``; maps to ``history_dir``).
+    :param runs: how many most-recent runs to show as delta columns.
+    :param window: detector lookback (distinct from ``runs``).
+    :param min_regressed: min regressed runs in the window to flag a pair.
+    :param epsilon: regression tolerance band (strict ``delta < -epsilon``).
+    :returns: ``0`` always (including empty/missing history and no-sustained).
+    """
+    out = stdout if stdout is not None else sys.stdout
+
+    from src.eval.runner.run_history import load_run_history
+    from src.eval.runner.show_trend import render_trend_table
+
+    history = load_run_history(pack, reports_dir)
+    table = render_trend_table(
+        history,
+        runs=runs,
+        window=window,
+        min_regressed=min_regressed,
+        epsilon=epsilon,
+    )
+    print(table, file=out)
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """Parse argv, dispatch to a subcommand, return its exit code."""
     parser = _build_parser()
@@ -663,6 +759,15 @@ def main(argv: list[str] | None = None) -> int:
             report_json=args.report_json,
             packs_root=args.packs_root,
             reports_dir=args.reports_dir,
+        )
+    if args.command == "show-trend":
+        return show_trend(
+            args.pack,
+            reports_dir=args.reports_dir,
+            runs=args.runs,
+            window=args.window,
+            min_regressed=args.min_regressed,
+            epsilon=args.epsilon,
         )
     parser.error(f"unknown command: {args.command}")
     return 2  # pragma: no cover — parser.error() exits.

--- a/src/eval/runner/show_trend.py
+++ b/src/eval/runner/show_trend.py
@@ -1,0 +1,164 @@
+# @summary
+# Pure markdown formatter for the read-only `show-trend` CLI subcommand.
+# render_trend_table(history, *, runs, window, min_regressed, epsilon) takes a
+# run-history entry list (as loaded by run_history.load_run_history) and returns
+# a deterministic per-(qtype, metric) markdown trend table — one delta column
+# per the last `runs` timestamp-sorted entries, a `regressed (shown)` count +
+# `latest` computed over those SHOWN runs, and a sustained YES/NO flag that is
+# the detector's verdict over its own `--window` (sourced AS-IS from
+# sustained_regression.detect_sustained_regressions, strict `delta < -epsilon`;
+# may look back further than the shown runs). Empty history -> a friendly
+# one-line message. NO I/O, no now(),
+# no randomness; reuses ci._fmt for 3-decimal / em-dash formatting.
+# Exports: render_trend_table
+# Deps: stdlib only; src.eval.runner.ci (_fmt),
+#       src.eval.runner.sustained_regression (detect_sustained_regressions).
+# @end-summary
+"""Pure markdown renderer for the read-only ``show-trend`` inspection surface.
+
+``render_trend_table(history, ...)`` is a side-effect-free formatter: it maps a
+run-history entry list to a markdown string and performs NO I/O, no pack load,
+no ingest/retrieve/judge. The CLI (:mod:`src.eval.cli`) owns history loading and
+stdout; this module owns presentation only.
+
+The table has one row per ``(qtype, metric)`` pair seen in the most-recent
+``runs`` entries (sorted by ``(qtype, metric)`` for determinism). Each row shows
+a delta column per displayed run (em-dash when that run lacks the pair), then a
+``regressed (shown)`` count and ``latest`` delta — BOTH computed over the
+displayed runs so every number ties to a visible column — and a ``sustained``
+YES/NO flag.
+
+The ``sustained`` flag is the verdict of
+:func:`~src.eval.runner.sustained_regression.detect_sustained_regressions` over
+its own ``window`` (strict ``delta < -epsilon``, single-sourced — this module
+never re-implements regression logic). Because ``window`` may look back FURTHER
+than the displayed ``runs``, a pair can be flagged YES while its shown columns
+look clean; that is an intentional cue to widen ``--runs``. When ``runs ==
+window`` (the default) the shown count and the detector verdict coincide.
+
+``runs`` (how many recent runs to DISPLAY as delta columns) is deliberately
+distinct from ``window`` (how many recent runs the detector looks BACK over).
+"""
+from __future__ import annotations
+
+from src.eval.runner.ci import _fmt
+from src.eval.runner.sustained_regression import detect_sustained_regressions
+
+_EMPTY_MESSAGE = "(no run history yet)"
+
+
+def render_trend_table(
+    history: list[dict],
+    *,
+    runs: int = 3,
+    window: int = 3,
+    min_regressed: int = 2,
+    epsilon: float = 0.05,
+) -> str:
+    """Render a deterministic per-``(qtype, metric)`` markdown trend table.
+
+    :param history: run-history entries, timestamp-sorted ascending (as returned
+        by :func:`~src.eval.runner.run_history.load_run_history`). Each entry
+        carries ``timestamp`` and ``per_qtype_deltas = {qtype: {metric: delta}}``.
+    :param runs: how many most-recent runs to show as delta columns (default 3).
+    :param window: detector lookback passed straight to
+        :func:`~src.eval.runner.sustained_regression.detect_sustained_regressions`
+        (default 3) — distinct from ``runs``.
+    :param min_regressed: detector min regressed-run count to flag a pair
+        (default 2).
+    :param epsilon: detector tolerance band; the regression predicate is strict
+        ``delta < -epsilon`` (default 0.05).
+    :returns: a markdown table string, or :data:`_EMPTY_MESSAGE` when ``history``
+        is empty (never an empty string, never a crash).
+    """
+    if not history:
+        return _EMPTY_MESSAGE
+
+    # Display window: the most-recent `runs` entries (history is ascending).
+    displayed = history[-runs:] if runs > 0 else []
+    if not displayed:
+        return _EMPTY_MESSAGE
+
+    # Collect every (qtype, metric) appearing in the displayed runs, sorted.
+    pairs: set[tuple[str, str]] = set()
+    for entry in displayed:
+        per_qtype = entry.get("per_qtype_deltas") or {}
+        for qtype, metric_map in per_qtype.items():
+            for metric in (metric_map or {}):
+                pairs.add((qtype, metric))
+    sorted_pairs = sorted(pairs)
+
+    # Sustained flags from the detector (single-sourced regression predicate).
+    sustained = detect_sustained_regressions(
+        history,
+        window=window,
+        min_regressed=min_regressed,
+        epsilon=epsilon,
+    )
+    flagged = {(s.qtype, s.metric): s for s in sustained}
+
+    # Run-delta columns: one per displayed run, labeled by timestamp.
+    run_labels = [str(entry.get("timestamp", "")) for entry in displayed]
+
+    header_cells = ["qtype", "metric", *run_labels, "regressed (shown)",
+                    "latest", "sustained"]
+    sep_cells = ["---"] * len(header_cells)
+
+    lines: list[str] = []
+    lines.append("| " + " | ".join(header_cells) + " |")
+    lines.append("| " + " | ".join(sep_cells) + " |")
+
+    for qtype, metric in sorted_pairs:
+        # Per-run delta cells (em-dash when a run lacks the pair).
+        delta_cells: list[str] = []
+        for entry in displayed:
+            metric_map = (entry.get("per_qtype_deltas") or {}).get(qtype) or {}
+            delta_cells.append(
+                _fmt(metric_map[metric]) if metric in metric_map else _fmt(None)
+            )
+
+        # The `regressed (shown)` count and `latest` are ALWAYS computed over the
+        # DISPLAYED runs, so every number in the row ties to a visible delta
+        # column — never to a run not shown. The `sustained` flag, by contrast,
+        # is the detector's verdict over its own `--window` (which may look back
+        # FURTHER than the displayed `--runs`): single-sourced from
+        # detect_sustained_regressions, so YES can hold even when the shown runs
+        # look clean — a cue to widen `--runs`. When runs == window (the default)
+        # the two bases coincide.
+        regressed_count = sum(
+            1 for entry in displayed if _regressed_in(entry, qtype, metric, epsilon)
+        )
+        regressed = f"{regressed_count}/{len(displayed)}"
+        latest = _latest_delta_for(displayed, qtype, metric)
+        flag = "YES" if (qtype, metric) in flagged else "NO"
+
+        row = ["", qtype, metric, *delta_cells, regressed, latest, flag, ""]
+        lines.append(" | ".join(row).strip())
+
+    return "\n".join(lines)
+
+
+def _regressed_in(entry: dict, qtype: str, metric: str, epsilon: float) -> bool:
+    """Whether ``(qtype, metric)`` regressed in ``entry`` (strict delta < -eps).
+
+    Mirrors the detector's predicate; absent pair → not regressed.
+    """
+    metric_map = (entry.get("per_qtype_deltas") or {}).get(qtype) or {}
+    if metric not in metric_map:
+        return False
+    return float(metric_map[metric]) < -epsilon
+
+
+def _latest_delta_for(
+    displayed: list[dict], qtype: str, metric: str
+) -> str:
+    """Formatted latest delta for ``(qtype, metric)`` over the displayed runs.
+
+    Walks the displayed runs most-recent-first and returns the first delta found
+    for the pair (em-dash if none of the displayed runs carry it).
+    """
+    for entry in reversed(displayed):
+        metric_map = (entry.get("per_qtype_deltas") or {}).get(qtype) or {}
+        if metric in metric_map:
+            return _fmt(metric_map[metric])
+    return _fmt(None)

--- a/tests/eval/test_show_trend.py
+++ b/tests/eval/test_show_trend.py
@@ -1,0 +1,230 @@
+# @summary
+# Tests for the read-only `show-trend` eval CLI subcommand + its pure
+# render_trend_table formatter. Drives the public CLI surface (main([...]))
+# with hand-seeded <pack>.history.jsonl files (no pack load / ingest / judge),
+# asserting: a sustained-regressing (qtype, metric) is flagged YES; a transient
+# dip is NOT; missing/empty history degrades to a friendly message at rc 0;
+# --runs limits the displayed delta columns to the most-recent runs; and the
+# formatter is pure (input list[dict] -> markdown string).
+# Exports: test_show_trend_flags_sustained,
+#          test_show_trend_missing_history_is_graceful,
+#          test_show_trend_no_sustained_all_no,
+#          test_render_trend_table_pure_no_sustained_vs_sustained,
+#          test_show_trend_runs_limits_columns,
+#          test_show_trend_runs_differs_from_window_consistent_basis,
+#          test_show_trend_main_dispatch_returns_int
+# Deps: src.eval.cli, src.eval.runner.show_trend
+# @end-summary
+"""Tests for the read-only ``show-trend`` subcommand (run-history inspection)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _write_history(tmp_path: Path, pack: str, entries: list[dict]) -> None:
+    """Hand-seed a ``<pack>.history.jsonl`` index (one JSON line per entry)."""
+    path = tmp_path / f"{pack}.history.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def _entry(ts: str, per_qtype_deltas: dict) -> dict:
+    """A minimal history entry carrying only what show-trend reads."""
+    return {
+        "timestamp": ts,
+        "pack_name": "p",
+        "k": 5,
+        "gate_passed": True,
+        "per_query_deltas": {},
+        "per_qtype_deltas": per_qtype_deltas,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Headline RED test — drives the public CLI surface.
+# ---------------------------------------------------------------------------
+
+
+def test_show_trend_flags_sustained(tmp_path: Path, capsys) -> None:
+    """A (qtype, metric) regressing in >= min_regressed of the window is YES.
+
+    factoid/recall regresses (delta < -epsilon) in 2 of the last 3 runs →
+    sustained YES; lookup/mrr stays flat → NO. Read-only: rc 0, markdown table.
+    """
+    from src.eval.cli import main
+
+    pack = "p"
+    _write_history(
+        tmp_path,
+        pack,
+        [
+            _entry("2026-01-01T00:00:00", {"factoid": {"recall": 0.01},
+                                           "lookup": {"mrr": 0.0}}),
+            _entry("2026-01-02T00:00:00", {"factoid": {"recall": -0.20},
+                                           "lookup": {"mrr": 0.01}}),
+            _entry("2026-01-03T00:00:00", {"factoid": {"recall": -0.30},
+                                           "lookup": {"mrr": 0.0}}),
+        ],
+    )
+
+    rc = main(["show-trend", pack, "--reports-dir", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Markdown table present.
+    assert "| qtype | metric |" in out
+    # factoid/recall row flagged sustained YES.
+    factoid_row = [ln for ln in out.splitlines()
+                   if ln.startswith("| factoid | recall |")]
+    assert factoid_row, out
+    assert "YES" in factoid_row[0]
+    # lookup/mrr row present and NOT sustained.
+    lookup_row = [ln for ln in out.splitlines()
+                  if ln.startswith("| lookup | mrr |")]
+    assert lookup_row, out
+    assert "NO" in lookup_row[0]
+    assert "YES" not in lookup_row[0]
+
+
+def test_show_trend_missing_history_is_graceful(tmp_path: Path, capsys) -> None:
+    """A pack with no history index → friendly message, rc 0 (never a trace)."""
+    from src.eval.cli import main
+
+    rc = main(["show-trend", "neverran", "--reports-dir", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "no run history" in out.lower()
+    assert "Traceback" not in out
+
+
+def test_show_trend_no_sustained_all_no(tmp_path: Path, capsys) -> None:
+    """History where nothing regressed → every row SUSTAINED=NO, rc 0."""
+    from src.eval.cli import main
+
+    pack = "p"
+    _write_history(
+        tmp_path,
+        pack,
+        [
+            _entry("2026-01-01T00:00:00", {"factoid": {"recall": 0.10}}),
+            _entry("2026-01-02T00:00:00", {"factoid": {"recall": 0.02}}),
+            _entry("2026-01-03T00:00:00", {"factoid": {"recall": 0.05}}),
+        ],
+    )
+
+    rc = main(["show-trend", pack, "--reports-dir", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    data_rows = [ln for ln in out.splitlines()
+                 if ln.startswith("| factoid |")]
+    assert data_rows
+    for row in data_rows:
+        assert "NO" in row
+        assert "YES" not in row
+
+
+def test_render_trend_table_pure_no_sustained_vs_sustained() -> None:
+    """Direct unit test on render_trend_table — no CLI, no I/O.
+
+    factoid/recall is sustained (2 of 3 regressed) → YES; lookup/mrr is a single
+    transient dip (1 of 3) → NO.
+    """
+    from src.eval.runner.show_trend import render_trend_table
+
+    history = [
+        _entry("2026-01-01T00:00:00", {"factoid": {"recall": -0.30},
+                                       "lookup": {"mrr": 0.0}}),
+        _entry("2026-01-02T00:00:00", {"factoid": {"recall": 0.0},
+                                       "lookup": {"mrr": -0.40}}),
+        _entry("2026-01-03T00:00:00", {"factoid": {"recall": -0.20},
+                                       "lookup": {"mrr": 0.0}}),
+    ]
+    table = render_trend_table(history)
+    assert isinstance(table, str)
+    assert "| qtype | metric |" in table
+
+    factoid_row = next(ln for ln in table.splitlines()
+                       if ln.startswith("| factoid | recall |"))
+    assert "YES" in factoid_row
+
+    lookup_row = next(ln for ln in table.splitlines()
+                      if ln.startswith("| lookup | mrr |"))
+    assert "NO" in lookup_row
+    assert "YES" not in lookup_row
+
+
+def test_show_trend_runs_limits_columns(tmp_path: Path, capsys) -> None:
+    """--runs 2 over a 4-entry history shows only the 2 most-recent runs.
+
+    The two most-recent timestamps appear as delta columns; the two oldest do
+    not. Pins recency ordering + the runs limit (distinct from --window).
+    """
+    from src.eval.cli import main
+
+    pack = "p"
+    _write_history(
+        tmp_path,
+        pack,
+        [
+            _entry("2026-01-01T00:00:00", {"factoid": {"recall": 0.01}}),
+            _entry("2026-01-02T00:00:00", {"factoid": {"recall": 0.01}}),
+            _entry("2026-01-03T00:00:00", {"factoid": {"recall": 0.01}}),
+            _entry("2026-01-04T00:00:00", {"factoid": {"recall": 0.01}}),
+        ],
+    )
+
+    rc = main(["show-trend", pack, "--reports-dir", str(tmp_path), "--runs", "2"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Header carries exactly the 2 most-recent run timestamps.
+    assert "2026-01-04T00:00:00" in out
+    assert "2026-01-03T00:00:00" in out
+    assert "2026-01-02T00:00:00" not in out
+    assert "2026-01-01T00:00:00" not in out
+
+
+def test_show_trend_runs_differs_from_window_consistent_basis() -> None:
+    """With runs != window the shown count ties to displayed runs, flag to window.
+
+    5-entry history: the OLDEST 2 runs regress factoid/recall, the NEWEST 3 are
+    clean. With --runs 2 (display newest 2 = clean) and --window 5 / min 2 the
+    detector flags the pair SUSTAINED (2 regressed over its window). The row must
+    show `0/2` (count over the SHOWN runs — never a phantom 2/5 referencing
+    rows not displayed) AND sustained YES (the detector's wider-window verdict).
+    Pins the unified displayed-basis count against the detector-basis flag.
+    """
+    from src.eval.runner.show_trend import render_trend_table
+
+    regress = {"factoid": {"recall": -0.30}}
+    clean = {"factoid": {"recall": 0.0}}
+    history = [
+        _entry("2026-01-01T00:00:00", regress),
+        _entry("2026-01-02T00:00:00", regress),
+        _entry("2026-01-03T00:00:00", clean),
+        _entry("2026-01-04T00:00:00", clean),
+        _entry("2026-01-05T00:00:00", clean),
+    ]
+    table = render_trend_table(history, runs=2, window=5, min_regressed=2)
+
+    # Only the 2 newest runs are shown as columns.
+    assert "2026-01-05T00:00:00" in table
+    assert "2026-01-04T00:00:00" in table
+    assert "2026-01-02T00:00:00" not in table
+
+    row = next(ln for ln in table.splitlines()
+               if ln.startswith("| factoid | recall |"))
+    # Count is over the SHOWN runs (0 of 2 clean) — NOT the detector's 2/5.
+    assert "0/2" in row, row
+    assert "2/5" not in row, row
+    # Flag is the detector's wider-window verdict.
+    assert "YES" in row, row
+
+
+def test_show_trend_main_dispatch_returns_int(tmp_path: Path) -> None:
+    """main(['show-trend', ...]) returns an int exit code (argv dispatch)."""
+    from src.eval.cli import main
+
+    rc = main(["show-trend", "neverran", "--reports-dir", str(tmp_path)])
+    assert isinstance(rc, int)
+    assert rc == 0


### PR DESCRIPTION
## What & why

A human/Ralph-A **inspection surface** over the trusted-signal data shipped in #140 (run-history index) + #141 (sustained-regression detector). Until now both were machine-only — nothing let you *view* the trend on demand. This is the deferred "option 2" read surface (P13), kept additive and read-only.

```
python -m src.eval show-trend <pack> [--reports-dir eval_reports] \
  [--runs 3] [--window 3] [--min-regressed 2] [--epsilon 0.05]
```

Loads `<reports-dir>/<pack>.history.jsonl` via `load_run_history`, runs `detect_sustained_regressions`, and prints a markdown per-`(qtype, metric)` trend table. **READ-ONLY** — no writes, no pack load, no ingest/retrieve/judge, no loop (SA3 proved this empirically: a real run creates/modifies no files). Missing/empty history → a friendly one-line message at exit 0; bad args → exit 2.

## Changes
- **New `src/eval/runner/show_trend.py`** — `render_trend_table(history, *, runs=3, window=3, min_regressed=2, epsilon=0.05) -> str`. Pure (input→string), no I/O / `now()` / randomness. Reuses `ci._fmt` and `detect_sustained_regressions` AS-IS (strict `delta < -epsilon` stays single-sourced). `runs` (display columns) is deliberately distinct from `window` (detector lookback).
- **`cli.py`** — `show-trend` subparser + thin `show_trend(...)` handler (with a `stdout` injection seam for tests) + `main()` dispatch. Existing `run`/`promote-baseline` dispatch untouched.

The `regressed (shown)` count and `latest` are computed over the **displayed** runs for every row (uniform basis — no column references a run not shown); the `sustained` flag alone is the detector's verdict over its own `--window`, so a pair can read YES with clean shown columns (a cue to widen `--runs`). With the default `runs == window` the two bases coincide.

## Tests (TDD red→green→refactor, adversarially verified)
`tests/eval/test_show_trend.py` (7): missing-history graceful (rc 0, friendly message, no traceback); no-sustained all-NO; sustained flagged YES; pure-formatter unit (sustained vs transient); `--runs` limits/recency of delta columns; **`runs!=window` consistent-basis** (shown count `0/2`, not a phantom `2/5`, flag still YES from the wider window); argv dispatch returns int. Bad args → exit 2.

`tests/eval`: **255 passed, 4 skipped**. Offline smoke (`python -m src.eval.smoke`) PASS, exit 0.

## Verification
SA1 (map) → SA2 (TDD impl) → SA3 (adversarial). SA3 returned **PASS-WITH-NITS** — read-only invariant proven empirically; all 5 mutation probes (recency, sustained flag, empty message, return code, dispatch) have teeth. The one nit fixed pre-PR: **unified the `regressed`/`latest` columns to the displayed-run basis** (was dual-basis: detector window for YES rows vs displayed for NO rows, which referenced runs not shown when `runs != window`) + added the `runs!=window` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)