### PR TITLE
feat(eval): headless Claude CLI judge backend + judge-call robustness (P14/P15)

### DIFF
--- a/EVAL_LOOP_PLAN.md
+++ b/EVAL_LOOP_PLAN.md
@@ -1,0 +1,383 @@
+# RagWeave Eval Loop — Plan (Vertical-Slice / TDD / Ralph-Aligned)
+
+## 0. Shipped-state ledger (keep this current)
+
+The plan below describes the *intended* architecture. This ledger records what is **actually shipped on `develop`** so the document stops drifting from the code. Update it whenever a slice lands.
+
+| Area | Status | Where |
+|---|---|---|
+| Collection-selection plumbing (P0) | ✅ shipped | `src/vector_db/weaviate/`, `RAG_COLLECTION_NAME` |
+| eval_pack format + validator + loader (P0.5) | ✅ shipped | `src/eval/pack/{schema,validate,loader,errors}.py` |
+| Pack min-count gates (P2.0) | ✅ shipped | `src/eval/pack/validate.py`, `tests/eval/test_pack_min_counts.py` |
+| OpenTitan goldens (P2) | ✅ shipped | `evals/packs/opentitan_riscv/`, `tests/eval/test_opentitan_goldens.py` (73 goldens) |
+| Metric library (P3) | ✅ shipped | `src/eval/runner/metrics.py` (recall@k, MRR), `src/eval/metrics.py` |
+| Factoid/retrieval suite runner (P4) | ✅ shipped | `src/eval/runner/{retrieve,execute,report}.py`, `src/eval/cli.py run` |
+| LLM-as-judge Tier-1 (P5) + calibration (P9) | ✅ shipped | `src/eval/runner/{judge,faithfulness,calibration}.py` |
+| Orchestrator + baseline diff + alert (P7/P8) | ✅ shipped | `src/eval/orchestrator.py`, `src/eval/runner/{baseline,alert,persistence}.py` |
+| Multi-sample + parallel judging (P7b/P7c) | ✅ shipped | `src/eval/runner/faithfulness.py` (`max_parallel_judges`) |
+| Offline PR smoke gate (P10) | ✅ shipped | `python -m src.eval.smoke` → `ci.yml`; live gate is `eval-gate.yml` |
+| Run-history index (#140) | ✅ shipped | `src/eval/runner/run_history.py` → `<pack>.history.jsonl` |
+| Sustained-regression detector (#141) | ✅ shipped | `src/eval/runner/sustained_regression.py`, wired into `run_nightly` |
+| show-trend inspection CLI (#142) | ✅ shipped | `src/eval/runner/show_trend.py`, `src/eval/cli.py show-trend` |
+| **Headless Claude CLI judge backend (P14)** | 🚧 this initiative | `src/eval/runner/judge_cli.py` (new), `--judge-backend` flag |
+| **Judge-call robustness: isolation + timeout/retry (P15)** | 🚧 this initiative | `src/eval/runner/faithfulness.py`, `judge.py` |
+| Ralph-A eval-failure investigator (P11) | ⏸️ HELD by decision | §10.3; un-defer once headless driver + signal trio are trusted |
+| Real Slack/webhook alert delivery | ⏸️ deferred | `src/eval/runner/alert.py` is a log-only sink today |
+| Cross-pack dashboard (Grafana) | ⏸️ deferred | premature until multiple customer packs exist |
+
+**Signal-trajectory note.** #140 (data) → #141 (verdict) → #142 (view) built the *trusted signal* substrate so a future Ralph-A has something honest to act on. P14 (headless driver) is the *actuation* substrate: it lets an automated agent **run the eval with no API key**, reusing local Claude auth. P15 hardens the judge so that automation doesn't die on the first transient error. Together they are the precondition for un-holding P11.
+
+## 1. Goals & success criteria
+
+**Primary goal:** A content-agnostic eval loop that grades RagWeave on factoid, QFS, multi-topic, multi-aspect, and command-reference queries against pluggable customer-shaped corpora, with LLM-as-judge for generation quality, trend tracking for regression detection, and a **headless driver** so the loop can be run and scored by an unattended agent.
+
+**Two layers, deliberately separated:**
+
+1. **The loop** — fixed runtime (ingest → suites → metrics → judge → report → alert → trend). Customer-agnostic.
+2. **The content** — a declarable, versioned `eval_pack` (corpus + goldens + thresholds + prompt overrides). Swappable per customer/profile.
+
+The loop ships once and stays stable. New customers, new domains, new corpora land as new eval_packs without touching the runtime.
+
+**Three pluggable backends (DI seams, resolved at call-time in `run_eval`):** `execute_fn` (ingest), `retrieve_fn` (retrieval), `judge_client_factory` (LLM-as-judge). Each can be a live implementation, an offline fake (smoke), or — new in P14 — a **headless Claude CLI** judge.
+
+**Success criteria (binary — no wall-clock targets):**
+- `python -m src.eval run <pack>` runs the full loop end-to-end against any conforming eval_pack and emits a scored report.
+- `python -m src.eval run <pack> --judge-backend claude-cli` scores the pack using the **local headless `claude` CLI** — no `RAG_LLM_API_KEY` required, reusing local Claude auth.
+- Test collection is fully isolated from prod by collection-name plumbing — provably no cross-write.
+- Every metric has unit tests with synthetic-input expected outputs.
+- LLM-as-judge ships with a hand-graded calibration fixture; agreement ≥ 0.8 vs. human before the judge is trusted in production reports.
+- Injected regressions in CI synthetic packs are caught and reported (`python -m src.eval.smoke` exit 0).
+- **A single transient judge/LLM failure does not abort a run** — the affected golden is skipped and counted; the run completes and reports (P15).
+- Every vertical slice is independently shippable, has a failing→passing E2E test as its definition of done, and can be picked up by a fresh agent with the slice prompt alone.
+
+**Non-goals:**
+- Real-time eval on production traffic.
+- Multi-tenant collection management beyond one collection per pack per env.
+- Cross-model A/B for embedding-model migration (separate harness).
+- Auto-merging eval-driven fixes (Ralph-on-regression stays human-reviewed).
+- Replacing the litellm judge backend — the headless CLI judge is an **alternate**, opt-in backend; litellm remains the default.
+
+## 2. Domain & first customer
+
+RagWeave's first commercial surface is **ASIC design** — RISC-V cores, memory chips, complex SoCs, and EDA tooling (Synopsys, Cadence). The eval content reflects this:
+
+- **OpenTitan + Ibex** — open-source RISC-V SoC IP. Markdown specs, register tables, hierarchical sections, cross-doc entity references. Representative of customer IP documentation. **(Shipped as the reference pack.)**
+- **RISC-V Privileged ISA spec (PDF)** — standards-doc pathology: deep cross-refs, large doc, formal language.
+- **EDA tool reference manuals (Synopsys / Cadence)** — command-reference pathology: thousands of commands, each with argument semantics. Queries here look like *"what does `set_max_delay -from X -to Y` do?"* — a structured-lookup query type. **First-class query type.**
+
+OpenTitan/Ibex/RISC-V form the **initial reference eval_pack**. The EDA pack lands when a customer corpus is available. Generic / non-ASIC packs land later — same loop, different content.
+
+## 3. Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Orchestrator (cron-script `scripts/run_nightly_eval.py` today;   │
+│ Temporal workflow once volume justifies it). Reads pack paths:   │
+│   1. Resolve pack → 2. Reset/ingest collection → 3. Run suites   │
+│   → 4. Judge → 5. Aggregate + baseline-diff → 6. Persist report  │
+│   → 7. Index run-history → 8. Detect sustained regressions       │
+│   → 9. Alert                                                     │
+└──────────────────────────────────────────────────────────────────┘
+              │
+              ├─► eval_pack loader (corpus manifest + goldens + thresholds + prompts)
+              │
+              ├─► Test Collection Selector ──► Weaviate `ragweave_test_<pack>_<hash>`
+              │
+              ├─► Query Suites (one per qtype, pack-driven)
+              │
+              ├─► Metric Library (recall@k, MRR; faithfulness via judge)
+              │
+              ├─► LLM-as-Judge Service  ◄── pluggable backend (judge_client_factory)
+              │     ├─ litellm backend (default; src/common/llm/provider.py)
+              │     └─ headless Claude CLI backend (P14; src/eval/runner/judge_cli.py)
+              │
+              ├─► Reporter (JSON artifact + Markdown summary + baseline-diff)
+              │
+              └─► Trend layer
+                    ├─ run-history index   (#140; <pack>.history.jsonl)
+                    ├─ sustained-regression detector (#141)
+                    └─ show-trend CLI      (#142; read-only inspection)
+```
+
+## 3.5 Headless Claude CLI judge backend (P14 — the actuation keystone)
+
+**Why.** Today the LLM-as-judge calls models through litellm, which requires `RAG_LLM_API_KEY` and a router config. That is a hard dependency for any unattended runner (CI agent, Ralph-A) on a box that already has an authenticated `claude` CLI. A headless-CLI backend lets the eval **run and score with zero extra credentials**, reusing local Claude auth. It is also the natural backend for a future agent that drives the eval via `claude -p`.
+
+**The seam.** The judge is a single-method client:
+
+```python
+class JudgeClient(Protocol):
+    def score(self, question: JudgeQuestion) -> JudgmentScore: ...
+```
+
+`run_eval` resolves `judge_client_factory` at call-time (`src/eval/cli.py`). A new factory `build_claude_cli_judge_client(pack, *, ...)` returns a `ClaudeCliJudgeClient` satisfying the same contract. **One wiring point.**
+
+**Constrained invocation (load-bearing — do NOT call bare `claude -p`).** A naked `claude -p` loads the *entire Claude Code agent*: full system prompt, tools, MCP, Opus by default. Measured cost of one such call: **~$0.20 and ~29k cache-creation tokens**, and the agent may treat the rubric as a prompt-injection and refuse to echo values. The CLI judge therefore invokes a **clean-room, tool-less, cheap-model** judge:
+
+```
+claude -p "<rendered judge prompt + strict JSON-only instruction>"
+  --output-format json
+  --model <pack.judge.tier1_model>          # default claude-haiku-4-5-20251001
+  --system-prompt "<judge rubric>"          # FULL REPLACE of the coding-agent persona
+  --allowed-tools ""                        # no tools
+  --setting-sources ""                      # clean room: ignore project/user settings
+  --permission-mode <non-prompting>
+```
+
+**Output contract.** `--output-format json` yields an envelope:
+`{"type":"result","subtype":"success","is_error":false,"result":"<model text>", ...}`.
+The model's answer is the **stringified `.result`** field. The client must:
+1. parse stdout as JSON (the envelope);
+2. assert `is_error is False` and `subtype == "success"`;
+3. extract `.result`, strip optional ```json fences;
+4. `json.loads` → `JudgmentScore(score, reasoning)`, clamping `score` to `[0.0, 1.0]`.
+
+**Testability seam.** `ClaudeCliJudgeClient` takes an injectable `run_fn` (defaults to a `subprocess.run` wrapper). Unit tests inject a fake `run_fn` returning canned envelopes — **no real subprocess in unit tests**. Exactly one model-gated test (env opt-in + `claude` on PATH, mirroring the real-Docling test pattern) shells out for real and asserts a `JudgmentScore` round-trips.
+
+**Robustness (folds into P15 contract).** `score()` wraps the call in a timeout and a bounded retry; a non-zero exit, `is_error`, malformed envelope, or unparseable `.result` raises a typed `JudgeBackendError`, which the faithfulness layer isolates per-golden (skip + count, never crash the run).
+
+## 4. The eval_pack format (keystone — Phase 0.5, shipped)
+
+The format is the architectural keystone. Get this right and every later phase becomes content-agnostic.
+
+### 4.1 Directory layout
+
+```
+evals/packs/opentitan_riscv/
+├── pack.yaml              # Metadata: name, version, profile, corpus_pin, judge
+├── corpus/
+│   ├── manifest.json      # Sorted list of doc paths + per-doc SHA-256
+│   └── docs/              # Or a git-submodule pin pointing externally
+├── goldens/
+│   ├── factoid.jsonl
+│   ├── qfs.jsonl
+│   ├── multi_topic.jsonl
+│   ├── multi_aspect.jsonl
+│   ├── command_reference.jsonl     # Optional per qtype
+│   ├── adversarial.jsonl
+│   └── out_of_corpus.jsonl
+├── thresholds.yaml        # Per-qtype, per-category pass/fail gates + min counts
+└── prompts/               # Optional per-pack judge-prompt overrides
+    └── faithfulness.md
+```
+
+### 4.2 `pack.yaml`
+
+```yaml
+name: opentitan_riscv
+version: 1
+profile: asic_riscv_soc
+corpus_pin: <sha256-of-(sorted-doc-paths + per-doc-content-hashes)>
+description: OpenTitan IP + RISC-V Privileged ISA + Ibex
+judge:
+  tier1_model: claude-haiku-4-5-20251001     # also the default --judge-backend claude-cli model
+  tier1_prompt_version: v1
+  temperature: 0
+  samples_per_claim: 3
+collection_name_template: "ragweave_test_{name}_{corpus_pin_short}"
+```
+
+### 4.3 Golden query schema (uniform across qtypes)
+
+```json
+{
+  "qid": "factoid-uart-baud-001",
+  "qtype": "factoid",
+  "query": "What is the default baud rate of the OpenTitan UART after reset?",
+  "expected_answer_span": "the default UART baud rate is configured via the NCO register...",
+  "expected_source_docs": ["hw/ip/uart/doc/index.md"],
+  "expected_chunk_ids": null,
+  "category": "register",
+  "difficulty": "easy",
+  "min_targets": { "recall_at_5": 0.8, "mrr": 0.5 }
+}
+```
+
+For QFS: `reference_answer`, `expected_cited_chunks`, `required_aspects` replace `expected_answer_span`.
+For command-reference: `command`, `expected_arg_semantics` (per-flag meaning dict) replace the span.
+
+### 4.4 `thresholds.yaml`
+
+Per-profile defaults, overridable per-qtype, per-category, per-difficulty; carries `min_goldens_per_qtype`. ASIC datasheets, RISC-V specs, and EDA manuals have different structural pathologies — one global threshold either passes everything or fails everything. Bake per-profile thresholds in.
+
+### 4.5 Pack validator
+
+`src/eval/pack/validate.py` — schema-validates a pack before any suite runs. Refuses to load malformed packs. **Third-state hardening (see §11.5):** the corrupt-but-present case (truncated manifest, merge-conflict-marked YAML, symlink loop) must degrade with a typed `PackValidationError`, never an uncaught `OSError`.
+
+## 5. Collection-selection plumbing (Phase 0, shipped)
+
+`WeaviateStore`/`RagChain`/ingest accept `collection_name`; `RAG_COLLECTION_NAME` env var; `--collection` CLI flags; `src/vector_db/weaviate/admin.py` lifecycle helpers. Isolation is the hard boundary that keeps eval corpora out of prod collections.
+
+## 6. Query taxonomy
+
+| Type | Definition | Metrics | Ground truth |
+|---|---|---|---|
+| **Factoid** | Single fact, one correct passage | recall@k, MRR, nDCG@k | Answer span + source doc |
+| **QFS — single-doc** | Summarize within one doc | Faithfulness, completeness, citation accuracy | Reference summary + cited chunks |
+| **QFS — cross-doc** | Synthesize across docs | Same + cross-doc coverage | Reference summary + cited chunks across docs |
+| **Multi-topic disjoint** | One query, N unrelated topics | Per-topic recall@k, topic coverage | Per-topic expected sources |
+| **Multi-aspect (1 topic)** | One topic, N sub-questions | Sub-question coverage, recall@k | Per-sub-question expected chunks |
+| **Command-reference (EDA)** | Tool command with arg semantics | Arg-semantic-match + citation accuracy | Per-flag meaning dict + source manual section |
+| **Adversarial / prompt-injection** | Malicious query | Sanitization behavior | Expected sanitizer action |
+| **Out-of-corpus** | Unanswerable | Correct refusal | Expected refuse + low confidence |
+| **Messy / typo** | Garbled clean query | Recall preservation vs. clean | Same as clean variant |
+
+## 7. Metric library
+
+```
+src/eval/runner/metrics.py    # recall@k, MRR (shipped; pure, unit-tested)
+src/eval/metrics.py           # facade / additional metric helpers
+```
+
+Each metric ships with: unit tests on synthetic inputs with known outputs, boundary tests (empty / all-relevant / none-relevant), and a golden-fixture integration test against a tiny mini-corpus. **Mutation-aware test data:** design samples so first/last/max/mean differ, or coincident values silently insulate aggregator mutations.
+
+## 8. LLM-as-judge
+
+### Tiering
+- **Tier 1** — runs on every query. Default `claude-haiku-4-5-20251001`; pack can override. Per-golden faithfulness scoring against the expected answer span / retrieved chunks (chunk-level; not answer synthesis).
+- **Tier 2** — sampled calibration over a subset; compares Tier-1 ↔ Tier-2 agreement.
+- **Tier 3** — human-graded fixture (once-off baseline, expanded over time). Validates Tier 2.
+
+### Backends (P14)
+- **litellm** (default) — `src/common/llm/provider.py` → litellm Router. Needs `RAG_LLM_API_KEY`.
+- **claude-cli** — `src/eval/runner/judge_cli.py`, constrained `claude -p` (§3.5). Needs only local Claude auth.
+
+Backend is selected by `--judge-backend {litellm,claude-cli}` (default `litellm`) and is independent of the pack — the same pack scores identically in shape under either backend; only the model call site differs.
+
+### Calibration gate
+Before a judge is trusted in production reports, it must clear ≥ 0.8 agreement (Cohen's kappa or equivalent) on the Tier-3 human-graded fixture. **A backend swap is a recalibration trigger:** the claude-cli backend must clear the same calibration gate against the frozen fixture before its scores are reported in production (its scores may differ from litellm's even at temperature 0 because the harness/system-prompt differs).
+
+### Prompts
+Version-tagged under `src/eval/runner/prompts/`, pack-overridable. The judge rubric used as the CLI `--system-prompt` is sourced from the same template (single source of truth).
+
+## 9. Vertical slices
+
+Each slice is **self-contained** — a fresh agent picks it up with the slice prompt alone and produces a red E2E test, minimum implementation, refactor pass, and updated docs.
+
+### Slice dependency DAG (current)
+
+```
+[shipped] P0 → P0.5 → P1 → {P2.0→P2, P3→P4, P5.0→P5→P6, P6.5.0→P6.5} → P7 → P8 → P9 → P10
+[shipped] #140 run-history ──► #141 sustained-regression ──► #142 show-trend
+                                                                   │
+                              ┌────────────────────────────────────┘
+                              ▼
+        P14 headless Claude CLI judge backend ──► P15 judge-call robustness
+                              │                          │
+                              └──────────┬───────────────┘
+                                         ▼
+                          [HELD] P11(A) Ralph-on-regression investigator
+```
+
+### P14 — Headless Claude CLI judge backend
+
+> **Goal:** Add `src/eval/runner/judge_cli.py` with `ClaudeCliJudgeClient` (satisfies `score(JudgeQuestion) -> JudgmentScore`) and a factory `build_claude_cli_judge_client`, wired behind a new `--judge-backend {litellm,claude-cli}` flag on `python -m src.eval run` (default `litellm`). Invocation is the constrained, tool-less, haiku-pinned `claude -p` of §3.5. `ClaudeCliJudgeClient` takes an injectable `run_fn` for testability.
+>
+> **Red E2E:** `tests/eval/test_judge_cli.py::test_run_eval_scores_via_claude_cli_backend` — wires the claude-cli factory through `run_eval` with a **fake `run_fn`** returning a canned `--output-format json` envelope; asserts a scored `EvalReport` with the parsed faithfulness value (the integration seam, where teeth go missing).
+> **Red-reason proof:** before implementation the test fails with `ImportError`/`AttributeError` on the missing `judge_cli` module / `--judge-backend` flag — not a fixture or parse error.
+> **Unit teeth:** envelope parse success; ```json fence stripping; `is_error: true` → `JudgeBackendError`; malformed envelope → error; unparseable `.result` → error; `score` clamped to `[0,1]`; the constructed argv contains `--model`, `--system-prompt`, `--allowed-tools`, `--output-format json` (pins the constraint contract so a future edit can't silently un-constrain it).
+> **Model-gated real test:** `test_claude_cli_judge_smoke_real` — `@pytest.mark.slow + integration`, skipped unless `claude` is on PATH **and** `RAGWEAVE_EVAL_CLI_LIVE=1`; shells out once, asserts a `JudgmentScore` with `0.0 ≤ score ≤ 1.0`.
+> **DoD:** All teeth green; `tests/eval` full suite green; `python -m src.eval.smoke` exit 0 (unchanged — default backend untouched); CLI `--help` shows `--judge-backend`.
+
+### P15 — Judge-call robustness (isolation + timeout/retry)
+
+> **Goal:** Make a single judge failure non-fatal. In `src/eval/runner/faithfulness.py` (sequential `:179` and parallel `:219/:227` paths), wrap each `judge_client.score()` so a raised exception is caught, logged, the golden counted as **skipped** (incrementing `total_queries_skipped`, excluded from faithfulness aggregation), and the run continues. Add a configurable timeout + bounded retry (default: 1 retry, conservative timeout) around the call; expose `JudgeBackendError` as the typed failure both backends raise.
+>
+> **Red E2E:** `tests/eval/test_judge_robustness.py::test_one_golden_failure_does_not_abort_run` — a judge client that raises on golden *N* and scores the rest; assert the run completes, golden *N* is skipped (counted), the other goldens are scored, and the gate evaluates on the survivors. **Before the fix this test red-fails with the raised exception propagating out of `run_eval`.**
+> **Discriminating teeth:** retry-then-succeed (transient error on attempt 1, success on attempt 2 → golden scored, not skipped); retry-exhausted → skipped, not crash; timeout path → `JudgeBackendError` → skipped. Parallel-path isolation: failure of one submitted future does not poison the pool (other futures still resolve).
+> **Coverage backfill (same slice):** add the three currently-zero-coverage error tests flagged by audit — judge raises (litellm path), corrupted `baseline.json` degrades to "absent" (orchestrator narrow-catch), and ingest error surfaces without crashing aggregation.
+> **DoD:** All teeth green; full `tests/eval` green; smoke exit 0; the orchestrator still isolates per-pack (broad catch) AND now isolates per-golden (narrow catch around `score`).
+
+### Existing slices P0–P10 (shipped — see §0 ledger)
+
+P0 collection plumbing · P0.5 pack format+validator · P1 OpenTitan pack · P2.0/P2 goldens · P3.0/P3 metrics · P4 factoid/multi-topic suite · P5.0/P5 judge Tier-1 · P6 QFS · P6.5.0/P6.5 command-reference · P7 orchestrator · P8 reporting/baseline-diff · P9 calibration loop · P10 offline smoke gate. Their slice contracts are preserved in git history and the engineering guide; this revision does not re-specify them.
+
+## 10. Delivery patterns (orthogonal to phases)
+
+### 10.0 Slice precondition contract — every slice must declare
+1. **Named red-test path** — exact `file::test_name`, runnable verbatim before any code.
+2. **Concrete numeric targets** where applicable — exact counts/thresholds, no "tight"/"enough".
+3. **Frozen fixture SHAs** for any hand-graded inputs the slice consumes.
+4. **Red-reason proof** — capture the failure output; confirm "feature absent" (`ImportError`/`NotImplementedError`/missing flag), not a test-harness error.
+5. **Agent green-gate vs. human-review checkpoint, separated** — machine-checkable assertions end the slice; human-judgment gates unblock the *next* slice.
+6. **Fixture immutability** — a slice consuming a frozen fixture declares "fixture not modified by this slice."
+
+### 10.1 TDD per slice — non-negotiable
+red → green → refactor; the failing E2E test must fail for the *right* reason. For metric/judge work, "eval of eval" applies: synthetic inputs with known outputs before any metric code; hand-graded fixtures before any judge prompt is trusted.
+
+### 10.2 Vertical-slice independence
+Each slice prompt is self-contained: file paths, contracts, DoD, E2E test all specified. Commit before any backgrounded soak; never end a turn with an unresolved stash.
+
+### 10.3 Ralph loops (where they fit)
+
+**Ralph-A — Eval-failure investigator (non-merging) — HELD until P14+P15 land:**
+```
+while sustained_regressions_exist and iterations < cap:
+    pick the worst SUSTAINED-regressing (qtype, metric)        # from #141 detector
+    dispatch subagent: "diagnose + propose minimal patch"
+    apply patch in isolated branch
+    re-run smoke eval (and, where credentialled, --judge-backend claude-cli)  # P14 driver
+    if improvement: commit + open PR for human review
+    else: revert + try next hypothesis
+```
+Never auto-merges. Bounded iterations. Each PR human-reviewed. It reads `load_run_history` + `detect_sustained_regressions` (the signal trio) and actuates through the P14 headless driver (no API key needed). P15 ensures a flaky judge call doesn't abort its smoke re-runs.
+
+**Ralph-B — Golden expander (human-gated):** drafts to `goldens/_drafts/`; human promotes. Unchanged.
+
+### 10.4 End-to-end testing — the meta-recursion
+The eval *is* the E2E test for RagWeave's retrieval+generation. "E2E testing of the eval loop" means: **does the loop catch injected regressions in a known-bad pack?** That is the canonical meta-test (`src/eval/smoke.py`). Every later change must preserve injected-regression detection.
+
+## 11. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Judge model drift breaks comparisons over time | Pin judge model + prompt version in every report; calibration loop (P9); recalibrate on bump **or backend swap** |
+| Test collection storage accumulates | Auto-delete `ragweave_test_*` older than retention; documented GC job |
+| Pack format churn invalidates goldens | `pack.yaml` version field; loader rejects mismatched versions |
+| Goldens authoring is the long pole | Start tight; expand via Ralph-B with human review |
+| Flaky judge scores cause spurious regressions | Temperature 0 + multi-sample mean; cache by content hash; P15 isolation |
+| **Headless `claude -p` is expensive / persona-contaminated** | Never call bare `claude -p`: pin haiku, replace system prompt, disable tools, clean-room settings (§3.5) |
+| **Headless CLI auth/PATH absent in CI** | claude-cli backend is opt-in; default stays litellm; real CLI test is env-gated + skipped when `claude` absent |
+| **A transient judge error aborts the nightly run** | P15 per-golden isolation + timeout/bounded-retry; orchestrator already isolates per-pack |
+| Per-customer corpora leak into shared infra | Collection-name plumbing (P0) is the hard boundary; CI isolation regression test |
+| Ralph-A proposes bad patches | Never auto-merges; PR-only; bounded iterations |
+
+## 11.5 Robustness dimension (audit-derived — explicit acceptance bar)
+
+The eval loop is itself production software; its robustness is graded on the same bar as the system it grades. Current audit verdict: **MEDIUM** — strong pack validation, resilient per-pack orchestration, clean resource cleanup; brittle at the judge/ingest call sites.
+
+**Robustness invariants (must hold; tested):**
+1. **Per-golden judge isolation** — one `score()` failure → skipped+counted, never a run abort. *(P15)*
+2. **Bounded external calls** — every LLM/CLI judge call has a timeout and a bounded retry; no unbounded hang. *(P15)*
+3. **Narrow best-effort wiring** — trend/baseline wiring in the orchestrator catches *specific* exception types (`OSError`, `json.JSONDecodeError`, `ValueError`, `KeyError`), never broad `except Exception`, except the deliberate per-pack isolation boundary in `run_nightly`.
+4. **Optional-file third state** — present / absent / **corrupt** are three states; corrupt must degrade like absent via a *narrow* catch, not crash. Applies to `baseline.json`, history JSONL, manifest, goldens.
+5. **Determinism** — temperature 0 + submission-order sample re-sort + timestamp-sorted history + injected `now`; no `random`, no `utcnow()`. Backend swap may change *values* (recalibrate) but not *ordering*.
+6. **No silent coverage loss** — if a run skips goldens (judge failure, empty query), the skip count is reported, never silently dropped from the denominator.
+
+**Coverage targets (raise to here as part of P14/P15):**
+- Judge error paths: from **0 tests** → cover raise / timeout / malformed-output / retry-then-succeed / retry-exhausted, for **both** backends.
+- Ingest error paths: from **0 tests** → at least one doc-level-failure-tolerated test.
+- Corrupted `baseline.json`: from **0 tests** → one degrade-to-absent test.
+- New modules (`judge_cli.py`) ship with `@summary` + docstrings and direct unit tests at parity with `judge.py`.
+
+## 12. Open decisions
+
+- **claude-cli judge default model** — haiku 4.5 (cheap, fast) is the default; a pack may pin a stronger model for high-stakes calibration runs. Keep haiku as the global default to bound cost.
+- **claude-cli concurrency** — subprocess-per-call is heavier than an in-process litellm call; bound it with the existing `max_parallel_judges` and a per-call timeout. Revisit a batched/stream-json mode only if nightly wall-clock becomes a problem.
+- **Where retry lives** — in the client (`score`) vs. the faithfulness layer. Decision: a *thin* timeout+retry in the client (transport concern), and *isolation* (skip+count) in the faithfulness layer (policy concern). Don't double-retry.
+- **EDA pack timing** — synthetic for P6.5 unit; real pack lands when corpus arrives.
+- **Multi-pack nightly orchestration** — one-per-pack workflow once >1 pack exists; cron-script handles single-pack until then.
+
+## 13. Done definition for the whole loop
+
+The loop is "shipped" when **all** hold:
+- Every slice P0 → P10 has its red E2E test green in main. *(met)*
+- The OpenTitan reference pack runs end-to-end via `python -m src.eval run <pack>` and produces a valid report. *(met)*
+- An injected regression in a copy of the OpenTitan pack is detected and alerted (`smoke` exit 0). *(met)*
+- Judge Tier-1 has cleared its calibration gate (agreement ≥ 0.8). *(met for litellm; claude-cli must clear the same gate before production use — P14)*
+- A second eval_pack loads and runs through the same runtime with no code changes. *(met)*
+- **The loop can be run and scored with no API key via `--judge-backend claude-cli`.** *(P14)*
+- **A single transient judge failure does not abort a run.** *(P15)*
+- README + engineering guide for the eval loop exist and reflect the shipped code, including the headless backend and the robustness invariants.
+
+When those hold, the loop is content-agnostic, regression-catching, headless-runnable, and robust enough to put under an unattended Ralph-A.

--- a/src/eval/cli.py
+++ b/src/eval/cli.py
@@ -24,6 +24,11 @@
 # the live runner symbol at CALL TIME after the lazy import). These let the
 # offline CI smoke (src.eval.smoke) drive the FULL loop with no live infra and
 # no monkeypatch; run_cli is unchanged (live CLI keeps the live defaults).
+# --judge-backend {litellm,claude-cli} selects the LLM-as-judge backend on the
+# run subcommand: litellm (default, in-process chat model) or claude-cli (shells
+# out to the headless `claude` CLI via runner.build_claude_cli_judge_client).
+# The default path is unchanged; selection is resolved at CALL TIME in run_eval
+# after the lazy runner import (an explicit judge_client_factory still wins).
 # show-trend adds a READ-ONLY run-history inspection subcommand:
 # show_trend(pack, ...) calls load_run_history → render_trend_table and prints a
 # markdown per-(qtype, metric) trend table. It performs NO writes/ingest/
@@ -112,6 +117,16 @@ def _build_parser() -> argparse.ArgumentParser:
             "When omitted, falls back to $GITHUB_STEP_SUMMARY if set; "
             "otherwise no summary is written. Written on both gate-pass "
             "and gate-fail."
+        ),
+    )
+    run_parser.add_argument(
+        "--judge-backend",
+        choices=("litellm", "claude-cli"),
+        default="litellm",
+        help=(
+            "LLM-as-judge backend. 'litellm' (default) uses the in-process "
+            "litellm chat model; 'claude-cli' shells out to the local headless "
+            "`claude` CLI (constrained: no tools, clean-room settings)."
         ),
     )
     run_parser.add_argument(
@@ -384,6 +399,7 @@ def run_eval(
     samples_per_claim: int | None = None,
     max_parallel_judges: int | None = None,
     chat_model_factory: Callable[..., Any] | None = None,
+    judge_backend: str = "litellm",
     verbose: bool = False,
     stderr: Any = None,
     execute_fn: Callable[..., Any] | None = None,
@@ -454,7 +470,14 @@ def run_eval(
     # ``runner`` import) so monkeypatched ``runner.*`` symbols still take effect.
     execute_fn = execute_fn or runner_pkg.execute_plan
     retrieve_fn = retrieve_fn or retrieve_for_goldens
-    judge_client_factory = judge_client_factory or runner_pkg.build_judge_client
+    # Backend selection: an explicit ``judge_client_factory`` (DI seam / tests)
+    # always wins; otherwise pick the litellm default or the headless claude-cli
+    # factory. Resolved at CALL TIME so monkeypatched runner symbols take effect.
+    if judge_client_factory is None:
+        if judge_backend == "claude-cli":
+            judge_client_factory = runner_pkg.build_claude_cli_judge_client
+        else:
+            judge_client_factory = runner_pkg.build_judge_client
 
     effective_samples = (
         samples_per_claim
@@ -552,6 +575,7 @@ def run_cli(
     show_samples: bool = False,
     summary_file: str | None = None,
     chat_model_factory: Callable[..., Any] | None = None,
+    judge_backend: str = "litellm",
     stdout: Any = None,
     stderr: Any = None,
 ) -> int:
@@ -584,6 +608,7 @@ def run_cli(
             samples_per_claim=samples_per_claim,
             max_parallel_judges=max_parallel_judges,
             chat_model_factory=chat_model_factory,
+            judge_backend=judge_backend,
             verbose=verbose,
             stderr=stderr,
         )
@@ -752,6 +777,7 @@ def main(argv: list[str] | None = None) -> int:
             max_parallel_judges=args.max_parallel_judges,
             show_samples=getattr(args, "show_samples", False),
             summary_file=getattr(args, "summary_file", None),
+            judge_backend=getattr(args, "judge_backend", "litellm"),
         )
     if args.command == "promote-baseline":
         return promote_baseline(

--- a/src/eval/cli.py
+++ b/src/eval/cli.py
@@ -29,6 +29,9 @@
 # out to the headless `claude` CLI via runner.build_claude_cli_judge_client).
 # The default path is unchanged; selection is resolved at CALL TIME in run_eval
 # after the lazy runner import (an explicit judge_client_factory still wins).
+# P15: --judge-retries (default 1) threads through run_cli → run_eval →
+# score_goldens(judge_retries=) for bounded per-golden judge retries; a golden
+# still failing after retries is skipped + counted, not run-aborting.
 # show-trend adds a READ-ONLY run-history inspection subcommand:
 # show_trend(pack, ...) calls load_run_history → render_trend_table and prints a
 # markdown per-(qtype, metric) trend table. It performs NO writes/ingest/
@@ -154,6 +157,16 @@ def _build_parser() -> argparse.ArgumentParser:
             "Override pack.meta.judge.max_parallel_judges — bound on "
             "concurrent judge calls (1 = sequential; >1 fans all "
             "(golden, sample) calls into a bounded thread pool)."
+        ),
+    )
+    run_parser.add_argument(
+        "--judge-retries",
+        type=int,
+        default=1,
+        help=(
+            "Bounded per-golden judge retries (default: 1 → up to 2 attempts). "
+            "A golden whose judge call still fails after retries is skipped + "
+            "counted (not silently dropped) and the run continues on survivors."
         ),
     )
     fresh_group = run_parser.add_mutually_exclusive_group()
@@ -398,6 +411,7 @@ def run_eval(
     fresh: bool = True,
     samples_per_claim: int | None = None,
     max_parallel_judges: int | None = None,
+    judge_retries: int = 1,
     chat_model_factory: Callable[..., Any] | None = None,
     judge_backend: str = "litellm",
     verbose: bool = False,
@@ -514,6 +528,7 @@ def run_eval(
         judge_client,
         samples_per_claim=effective_samples,
         max_parallel_judges=effective_parallel,
+        judge_retries=judge_retries,
     )
 
     recall_by_qtype = aggregate_recall_by_qtype(retrieval_results, pack.goldens)
@@ -572,6 +587,7 @@ def run_cli(
     fresh: bool = True,
     samples_per_claim: int | None = None,
     max_parallel_judges: int | None = None,
+    judge_retries: int = 1,
     show_samples: bool = False,
     summary_file: str | None = None,
     chat_model_factory: Callable[..., Any] | None = None,
@@ -607,6 +623,7 @@ def run_cli(
             fresh=fresh,
             samples_per_claim=samples_per_claim,
             max_parallel_judges=max_parallel_judges,
+            judge_retries=judge_retries,
             chat_model_factory=chat_model_factory,
             judge_backend=judge_backend,
             verbose=verbose,
@@ -775,6 +792,7 @@ def main(argv: list[str] | None = None) -> int:
             fresh=args.fresh,
             samples_per_claim=args.samples_per_claim,
             max_parallel_judges=args.max_parallel_judges,
+            judge_retries=getattr(args, "judge_retries", 1),
             show_samples=getattr(args, "show_samples", False),
             summary_file=getattr(args, "summary_file", None),
             judge_backend=getattr(args, "judge_backend", "litellm"),

--- a/src/eval/runner/__init__.py
+++ b/src/eval/runner/__init__.py
@@ -75,6 +75,11 @@ from .judge import (
     read_samples_per_claim,
     render_judge_prompt,
 )
+from .judge_cli import (
+    ClaudeCliJudgeClient,
+    JudgeBackendError,
+    build_claude_cli_judge_client,
+)
 from .metrics import (
     aggregate_mrr_by_qtype,
     aggregate_recall_by_qtype,
@@ -102,6 +107,7 @@ __all__ = [
     "CalibrationExample",
     "CalibrationRecord",
     "CalibrationResult",
+    "ClaudeCliJudgeClient",
     "DEFAULT_CALIBRATION_FIXTURE_PATH",
     "EvalReport",
     "FaithfulnessResults",
@@ -109,6 +115,7 @@ __all__ = [
     "GateResult",
     "IngestPlan",
     "IngestReport",
+    "JudgeBackendError",
     "JudgeClient",
     "JudgeQuestion",
     "JudgmentScore",
@@ -121,6 +128,7 @@ __all__ = [
     "aggregate_mrr_by_qtype",
     "aggregate_recall_by_qtype",
     "binarize_score",
+    "build_claude_cli_judge_client",
     "build_eval_report",
     "build_judge_client",
     "cohens_kappa",

--- a/src/eval/runner/faithfulness.py
+++ b/src/eval/runner/faithfulness.py
@@ -4,9 +4,14 @@
 # opt-in bounded-concurrency path (max_parallel_judges > 1) that fans every
 # (golden, sample) judge call into one ThreadPoolExecutor and regroups by qid
 # in submission order; N<=1 keeps the byte-identical sequential loop.
+# P15 adds judge-call robustness: each golden's judge call is attempted up to
+# 1+judge_retries times (_score_with_retry — the SINGLE retry site so clients
+# stay thin), and is wrapped in a per-golden isolation boundary so a single
+# golden's judge failure is SKIPPED+COUNTED (via the same total_queries_skipped
+# accounting as empty-query goldens) instead of aborting the whole run.
 # Exports: QueryFaithfulnessResult, FaithfulnessResults, score_goldens,
 #          aggregate_faithfulness_by_qtype
-# Deps: stdlib (concurrent.futures, dataclasses, statistics, typing);
+# Deps: stdlib (concurrent.futures, dataclasses, logging, statistics, typing);
 #       src.eval.pack.schema.Golden; src.eval.runner.judge (JudgeClient,
 #       JudgeQuestion); src.eval.runner.retrieve (RetrievalResults);
 #       src.platform.observability.concurrency.submit_with_context.
@@ -24,6 +29,7 @@ The judge client is the sole LLM seam — this module imports nothing from
 """
 from __future__ import annotations
 
+import logging
 import statistics
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -34,6 +40,8 @@ from src.platform.observability.concurrency import submit_with_context
 
 from .judge import JudgeClient, JudgeQuestion, JudgmentScore
 from .retrieve import RetrievalResults
+
+logger = logging.getLogger("rag.eval.faithfulness")
 
 
 @dataclass(frozen=True)
@@ -112,6 +120,29 @@ def _assemble_result(
     )
 
 
+def _score_with_retry(
+    judge_client: JudgeClient,
+    question: JudgeQuestion,
+    *,
+    retries: int,
+) -> JudgmentScore:
+    """Score *question* with bounded transport-resilience retries.
+
+    Attempts ``judge_client.score(question)`` up to ``1 + retries`` times,
+    returning the first successful :class:`JudgmentScore` and re-raising the
+    last exception on exhaustion. This is the SINGLE retry site (P15): the
+    judge clients themselves stay thin and just raise, so we never double-retry.
+    """
+    last_exc: Exception | None = None
+    for _attempt in range(1 + retries):
+        try:
+            return judge_client.score(question)
+        except Exception as exc:  # noqa: BLE001 — re-raised on exhaustion below.
+            last_exc = exc
+    assert last_exc is not None  # 1+retries >= 1, so the loop ran at least once.
+    raise last_exc
+
+
 def score_goldens(
     retrieval_results: RetrievalResults,
     goldens: Mapping[str, list[Golden]],
@@ -119,6 +150,7 @@ def score_goldens(
     *,
     samples_per_claim: int = 1,
     max_parallel_judges: int = 1,
+    judge_retries: int = 1,
 ) -> FaithfulnessResults:
     """Score each retrieved golden via the judge client.
 
@@ -138,6 +170,14 @@ def score_goldens(
     to the sequential path for a deterministic judge regardless of completion
     order. ``max_parallel_judges == 1`` takes the plain sequential loop (no
     pool, no thread overhead) and is byte-identical to pre-P7c behavior.
+
+    **Per-golden isolation (P15).** Each golden's judge call is attempted up to
+    ``1 + judge_retries`` times (:func:`_score_with_retry`). If a golden still
+    fails after retries (ANY sample exhausting its retries fails the WHOLE
+    golden — no partial average), that golden is SKIPPED and COUNTED in
+    ``total_queries_skipped`` (the same accounting as empty-query goldens) and
+    excluded from aggregation, while every other golden is scored and the run
+    completes. A single judge failure therefore no longer aborts the run.
     """
     if samples_per_claim < 1:
         raise ValueError(
@@ -147,11 +187,17 @@ def score_goldens(
         raise ValueError(
             f"max_parallel_judges must be >= 1, got {max_parallel_judges}"
         )
+    if judge_retries < 0:
+        raise ValueError(f"judge_retries must be >= 0, got {judge_retries}")
     by_qid = _index_goldens_by_qid(goldens)
 
     if max_parallel_judges == 1:
         return _score_sequential(
-            retrieval_results, by_qid, judge_client, samples_per_claim
+            retrieval_results,
+            by_qid,
+            judge_client,
+            samples_per_claim,
+            judge_retries,
         )
     return _score_parallel(
         retrieval_results,
@@ -159,6 +205,7 @@ def score_goldens(
         judge_client,
         samples_per_claim,
         max_parallel_judges,
+        judge_retries,
     )
 
 
@@ -167,8 +214,9 @@ def _score_sequential(
     by_qid: dict[str, Golden],
     judge_client: JudgeClient,
     samples_per_claim: int,
+    judge_retries: int,
 ) -> FaithfulnessResults:
-    """Sequential path — unchanged pre-P7c behavior (one plain loop)."""
+    """Sequential path — one plain loop with per-golden retry + isolation (P15)."""
     per_query: dict[str, QueryFaithfulnessResult] = {}
     skipped = 0
     for qid, qresult in retrieval_results.per_query.items():
@@ -176,7 +224,30 @@ def _score_sequential(
             skipped += 1
             continue
         question = _build_question(qid, qresult, by_qid)
-        samples = [judge_client.score(question) for _ in range(samples_per_claim)]
+        # --- Per-golden isolation boundary (P15) ---------------------------
+        # Like run_nightly's per-pack catch, this is a DELIBERATE broad
+        # boundary: a single golden's judge failure (after bounded retries)
+        # must not abort the whole run. The golden is SKIPPED + COUNTED via the
+        # same skipped accounting as empty-query goldens, and we log LOUDLY
+        # with the qid + exception type/message (no silent swallow). If ANY
+        # sample exhausts its retries the whole golden is skipped (no partial
+        # average — see score_goldens docstring).
+        try:
+            samples = [
+                _score_with_retry(judge_client, question, retries=judge_retries)
+                for _ in range(samples_per_claim)
+            ]
+        except Exception as exc:  # noqa: BLE001 — isolation boundary (see above).
+            logger.warning(
+                "judge failed for qid=%s after %d attempt(s) (%s: %s) — "
+                "skipping this golden",
+                qid,
+                1 + judge_retries,
+                type(exc).__name__,
+                exc,
+            )
+            skipped += 1
+            continue
         per_query[qid] = _assemble_result(qid, qresult.qtype, samples)
     return FaithfulnessResults(
         collection_name=retrieval_results.collection_name,
@@ -192,21 +263,37 @@ def _score_parallel(
     judge_client: JudgeClient,
     samples_per_claim: int,
     max_parallel_judges: int,
+    judge_retries: int,
 ) -> FaithfulnessResults:
     """Parallel path — flat (golden × sample) fan-out into one bounded pool.
 
-    Each future is tagged ``(qid, sample_index)``. After all futures resolve
-    we regroup by qid and sort each qid's samples by ``sample_index`` so the
-    stored ``samples`` tuple is in submission order, not completion order.
+    Each future is tagged ``(qid, sample_index)`` and runs
+    :func:`_score_with_retry` (bounded retry inside the worker). After all
+    futures resolve we regroup by qid and sort each qid's samples by
+    ``sample_index`` so the stored ``samples`` tuple is in submission order,
+    not completion order.
+
+    **Per-golden isolation (P15).** If ANY sample-future of a golden raises
+    (after exhausting its retries) the WHOLE golden is SKIPPED + COUNTED (no
+    partial average) and the others still resolve — the pool is not poisoned.
+    Failures are collected per qid while draining (a broad catch at the
+    isolation boundary), logged loudly with the qid, and applied after the
+    drain so a deterministic failing judge yields deterministic skips.
     """
     scored_qtypes: dict[str, str] = {}
     skipped = 0
     # Tagged judge results: qid -> list[(sample_index, JudgmentScore)].
     raw: dict[str, list[tuple[int, JudgmentScore]]] = {}
+    # qids whose judge call failed (after retries) — skipped whole-golden.
+    failed: dict[str, Exception] = {}
 
     # future -> (qid, sample_index) tag, so results collected in COMPLETION
     # order can be regrouped and re-sorted into submission order below.
     tags: dict[Any, tuple[str, int]] = {}
+
+    def _retrying_score(question: JudgeQuestion) -> JudgmentScore:
+        return _score_with_retry(judge_client, question, retries=judge_retries)
+
     with ThreadPoolExecutor(max_workers=max_parallel_judges) as executor:
         for qid, qresult in retrieval_results.per_query.items():
             if len(qresult.retrieved_chunks) == 0:
@@ -216,18 +303,34 @@ def _score_parallel(
             raw[qid] = []
             question = _build_question(qid, qresult, by_qid)
             for sample_index in range(samples_per_claim):
-                fut = submit_with_context(executor, judge_client.score, question)
+                fut = submit_with_context(executor, _retrying_score, question)
                 tags[fut] = (qid, sample_index)
 
-        # Drain in completion order; the per-qid sort below restores
-        # submission order (sample 0..N-1) — that sort is load-bearing for
-        # the deterministic per_query_samples serialization.
+        # Drain in completion order; the per-qid sort below restores submission
+        # order (sample 0..N-1). Per-golden isolation boundary (P15): a future
+        # that raised (after retries) marks its qid failed instead of
+        # propagating, so one bad golden does not poison the pool.
         for fut in as_completed(tags):
             qid, sample_index = tags[fut]
-            raw[qid].append((sample_index, fut.result()))
+            try:
+                raw[qid].append((sample_index, fut.result()))
+            except Exception as exc:  # noqa: BLE001 — isolation boundary.
+                failed[qid] = exc
 
     per_query: dict[str, QueryFaithfulnessResult] = {}
     for qid in raw:
+        if qid in failed:
+            # A golden with ANY failed sample is skipped whole (no partial avg).
+            logger.warning(
+                "judge failed for qid=%s after %d attempt(s) (%s: %s) — "
+                "skipping this golden",
+                qid,
+                1 + judge_retries,
+                type(failed[qid]).__name__,
+                failed[qid],
+            )
+            skipped += 1
+            continue
         ordered = sorted(raw[qid], key=lambda pair: pair[0])
         samples = [score for _idx, score in ordered]
         per_query[qid] = _assemble_result(qid, scored_qtypes[qid], samples)

--- a/src/eval/runner/judge_cli.py
+++ b/src/eval/runner/judge_cli.py
@@ -1,0 +1,300 @@
+# @summary
+# Headless `claude` CLI LLM-as-judge backend (alternative to the litellm
+# default). Wraps a constrained, non-coding-agent `claude -p ... --output-format
+# json` invocation: no tools, clean-room settings, judge rubric as the system
+# prompt. Parses the VERIFIED result-envelope shape into a JudgmentScore.
+# Exports: JudgeBackendError, ClaudeCliJudgeClient, build_claude_argv,
+#          build_claude_cli_judge_client.
+# Deps: subprocess, json (stdlib); src.eval.runner.judge (JudgeQuestion,
+#       JudgmentScore, render_judge_prompt, load_judge_prompt); src.eval.pack
+#       .schema.EvalPack.
+# @end-summary
+"""Headless ``claude`` CLI judge backend.
+
+This is an alternative LLM-as-judge backend to the default litellm-based
+:class:`~src.eval.runner.judge.JudgeClient`. It shells out to the local
+``claude`` CLI in a *constrained* mode — never the bare coding agent — so the
+judge call is cheap (Haiku by default), tool-free, and uncontaminated by the
+project/user agent persona or settings.
+
+The runtime contract mirrors :func:`~src.eval.runner.judge.build_judge_client`:
+
+    client = build_claude_cli_judge_client(pack, pack_dir=pack_dir)
+    score  = client.score(JudgeQuestion(...))
+
+The CLI is invoked as::
+
+    claude -p "<rendered judge prompt + strict JSON-only instruction>"
+      --output-format json
+      --model <model>
+      --system-prompt "<judge rubric template, full replace>"
+      --allowed-tools ""        # no tools
+      --setting-sources ""      # clean room: ignore project/user settings
+      --permission-mode bypassPermissions   # non-prompting
+
+The ``--output-format json`` envelope wraps the model's answer in a stringified
+``.result`` field (optionally fenced); :meth:`ClaudeCliJudgeClient.score`
+unwraps and parses it. ``run_fn`` is the testability seam: fast tests inject a
+fake so no subprocess is ever spawned.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from src.eval.pack.schema import EvalPack
+from src.eval.runner.judge import (
+    JudgeQuestion,
+    JudgmentScore,
+    load_judge_prompt,
+    render_judge_prompt,
+)
+
+__all__ = [
+    "JudgeBackendError",
+    "ClaudeCliJudgeClient",
+    "build_claude_argv",
+    "build_claude_cli_judge_client",
+]
+
+# Default judge model: Haiku is cheap and adequate for chunk-level faithfulness.
+_DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+
+# Non-prompting permission mode (confirmed from `claude --help` choices). With
+# ``--allowed-tools ""`` no tools are reachable, so this only ensures the CLI
+# never blocks on an interactive permission prompt in a headless run.
+_PERMISSION_MODE = "bypassPermissions"
+
+# Appended to the rendered judge prompt to force a parseable, prose-free answer.
+_JSON_ONLY_INSTRUCTION = (
+    "\n\nRespond with ONLY a JSON object of the form "
+    '{"score": <float between 0 and 1>, "reasoning": <string>} '
+    "— no prose, no markdown, no code fences."
+)
+
+
+class JudgeBackendError(RuntimeError):
+    """Raised for any ``claude`` CLI invocation or response-parse failure.
+
+    Covers a non-zero returncode, a timeout from the default runner, an
+    ``is_error: true`` / non-success envelope, a missing/empty ``.result``, or
+    an unparseable result payload. The eval CLI buckets this (like any other
+    runtime error) into exit code 3.
+    """
+
+
+def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    """Clamp *value* into ``[low, high]``."""
+    return max(low, min(high, value))
+
+
+def _strip_json_fence(text: str) -> str:
+    """Strip surrounding whitespace and an optional ```json ... ``` fence."""
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        # Drop the opening fence line (``` or ```json) and the closing fence.
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        stripped = "\n".join(lines).strip()
+    return stripped
+
+
+def build_claude_argv(
+    prompt: str,
+    *,
+    model: str,
+    system_prompt: str,
+    permission_mode: str = _PERMISSION_MODE,
+) -> list[str]:
+    """Build the constrained ``claude`` CLI argv for a single judge call.
+
+    Pure (no I/O) so the cost/safety constraint contract is unit-testable in
+    isolation. The argv deliberately:
+
+    * uses ``-p`` (print/non-interactive) with the rendered prompt,
+    * forces ``--output-format json`` for a machine-parseable envelope,
+    * pins ``--model`` (Haiku by default — cheap),
+    * passes the rubric as ``--system-prompt`` (full replace),
+    * sets ``--allowed-tools ""`` (no tools — not the coding agent),
+    * sets ``--setting-sources ""`` (clean room — ignore project/user settings),
+    * sets a non-prompting ``--permission-mode`` so a headless run never blocks.
+    """
+    return [
+        "claude",
+        "-p",
+        prompt,
+        "--output-format",
+        "json",
+        "--model",
+        model,
+        "--system-prompt",
+        system_prompt,
+        "--allowed-tools",
+        "",
+        "--setting-sources",
+        "",
+        "--permission-mode",
+        permission_mode,
+    ]
+
+
+def _default_run_fn(argv: list[str], *, timeout: float):
+    """Default runner: spawn the real ``claude`` CLI via subprocess.run."""
+    return subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+class ClaudeCliJudgeClient:
+    """Scores :class:`JudgeQuestion` instances via the headless ``claude`` CLI.
+
+    Satisfies the same single-method ``score(question) -> JudgmentScore``
+    contract as :class:`~src.eval.runner.judge.JudgeClient`, so it is a
+    drop-in ``judge_client`` for ``score_goldens``.
+
+    :param template: the judge rubric template (passed as the CLI system
+        prompt and also rendered into the ``-p`` prompt via
+        :func:`~src.eval.runner.judge.render_judge_prompt`).
+    :param model: the judge model alias/id (Haiku by default upstream).
+    :param temperature: accepted for parity with the litellm backend; the CLI
+        does not expose a temperature flag, so it is currently informational.
+    :param run_fn: testability seam — a callable
+        ``(argv: list[str], *, timeout: float) -> obj`` exposing
+        ``.returncode`` / ``.stdout`` / ``.stderr``. When ``None`` (default) a
+        real :func:`subprocess.run` is used; tests inject a fake so no process
+        is spawned.
+    :param timeout: per-call subprocess timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        *,
+        template: str,
+        model: str,
+        temperature: float = 0.0,
+        run_fn: Callable[..., Any] | None = None,
+        timeout: float = 60.0,
+    ) -> None:
+        self.template = template
+        self.model = model
+        self.temperature = temperature
+        self._run_fn = run_fn if run_fn is not None else _default_run_fn
+        self.timeout = timeout
+
+    def score(self, question: JudgeQuestion) -> JudgmentScore:
+        """Render → invoke the CLI → parse the envelope → JudgmentScore.
+
+        Raises :class:`JudgeBackendError` on any invocation/parse failure.
+        """
+        rendered = render_judge_prompt(self.template, question)
+        prompt = rendered + _JSON_ONLY_INSTRUCTION
+        argv = build_claude_argv(
+            prompt, model=self.model, system_prompt=self.template
+        )
+
+        try:
+            completed = self._run_fn(argv, timeout=self.timeout)
+        except subprocess.TimeoutExpired as exc:
+            raise JudgeBackendError(
+                f"claude CLI judge timed out after {self.timeout}s"
+            ) from exc
+
+        if completed.returncode != 0:
+            raise JudgeBackendError(
+                f"claude CLI judge exited with code {completed.returncode}: "
+                f"{(completed.stderr or '').strip()[:500]}"
+            )
+
+        return self._parse_envelope(completed.stdout)
+
+    @staticmethod
+    def _parse_envelope(stdout: str) -> JudgmentScore:
+        """Parse the ``--output-format json`` envelope into a JudgmentScore."""
+        try:
+            envelope = json.loads(stdout)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise JudgeBackendError(
+                f"claude CLI judge returned unparseable envelope JSON: {exc}"
+            ) from exc
+
+        if envelope.get("is_error") is not False:
+            raise JudgeBackendError(
+                f"claude CLI judge envelope reported an error: "
+                f"is_error={envelope.get('is_error')!r}"
+            )
+        if envelope.get("subtype") != "success":
+            raise JudgeBackendError(
+                f"claude CLI judge envelope subtype was not 'success': "
+                f"{envelope.get('subtype')!r}"
+            )
+
+        result = envelope.get("result")
+        if not result or not isinstance(result, str):
+            raise JudgeBackendError(
+                f"claude CLI judge envelope missing/empty .result: {result!r}"
+            )
+
+        payload_text = _strip_json_fence(result)
+        try:
+            payload = json.loads(payload_text)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise JudgeBackendError(
+                f"claude CLI judge .result was not parseable JSON: {exc}"
+            ) from exc
+
+        try:
+            raw_score = float(payload["score"])
+            reasoning = str(payload.get("reasoning", ""))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise JudgeBackendError(
+                f"claude CLI judge .result missing/invalid score field: {exc}"
+            ) from exc
+
+        return JudgmentScore(score=_clamp(raw_score), reasoning=reasoning)
+
+
+def build_claude_cli_judge_client(
+    pack: EvalPack,
+    *,
+    chat_model_factory: Callable[..., Any] | None = None,
+    pack_dir: Path | None = None,
+    run_fn: Callable[..., Any] | None = None,
+) -> ClaudeCliJudgeClient:
+    """Build a :class:`ClaudeCliJudgeClient` from an EvalPack.
+
+    Mirrors :func:`~src.eval.runner.judge.build_judge_client`'s signature so it
+    is a drop-in ``judge_client_factory``. ``chat_model_factory`` is accepted
+    for signature parity and intentionally ignored (the CLI backend constructs
+    no litellm chat model). The rubric template is loaded via
+    :func:`~src.eval.runner.judge.load_judge_prompt`; model/temperature come
+    from ``pack.meta.judge``.
+
+    :param run_fn: passed through to the client as its subprocess seam (so the
+        CLI dispatch path and offline tests can inject a fake runner).
+    """
+    judge_cfg = pack.meta.judge
+    if pack_dir is not None:
+        template = load_judge_prompt(
+            pack_dir, version=judge_cfg.tier1_prompt_version
+        )
+    else:
+        from src.eval.runner.judge import _load_default_template
+
+        template = _load_default_template(version=judge_cfg.tier1_prompt_version)
+
+    model = judge_cfg.tier1_model or _DEFAULT_MODEL
+    return ClaudeCliJudgeClient(
+        template=template,
+        model=model,
+        temperature=judge_cfg.temperature,
+        run_fn=run_fn,
+    )

--- a/tests/eval/test_judge_cli.py
+++ b/tests/eval/test_judge_cli.py
@@ -300,8 +300,16 @@ def test_score_is_error_true_raises() -> None:
     """is_error: true in the envelope raises JudgeBackendError."""
     from src.eval.runner.judge_cli import JudgeBackendError
 
+    # A VALID score payload so the is_error guard is the ONLY thing that can
+    # raise — otherwise an empty "{}" result would raise KeyError on score
+    # extraction and the test would pass even with the is_error guard removed.
     envelope = json.dumps(
-        {"type": "result", "subtype": "success", "is_error": True, "result": "{}"}
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": True,
+            "result": json.dumps({"score": 0.5, "reasoning": "x"}),
+        }
     )
     run_fn = _make_run_fn(envelope)
     with pytest.raises(JudgeBackendError):

--- a/tests/eval/test_judge_cli.py
+++ b/tests/eval/test_judge_cli.py
@@ -1,0 +1,411 @@
+# @summary
+# Tests for the headless `claude` CLI LLM-as-judge backend (judge_cli.py).
+# Headline E2E proves run_eval(... judge_client_factory=ClaudeCliJudgeClient
+# with a fake run_fn ...) carries faithfulness ~0.8; a dispatch test pins the
+# argv→backend wiring through main(["run", ..., "--judge-backend", "claude-cli"]);
+# unit tests cover envelope parsing, fence stripping, clamping, and every
+# JudgeBackendError raise path; an argv-contract test pins the cost/safety
+# constraints; a model-gated real test scores one trivial question live.
+# Exports: test_run_eval_scores_via_claude_cli_backend,
+#          test_main_dispatch_routes_judge_backend_claude_cli,
+#          test_score_parses_envelope_success, test_score_strips_json_fence,
+#          test_score_clamps_out_of_range, test_score_is_error_true_raises,
+#          test_score_bad_subtype_raises, test_score_unparseable_result_raises,
+#          test_score_nonzero_returncode_raises,
+#          test_build_claude_argv_contains_constraints,
+#          test_claude_cli_judge_smoke_real
+# Deps: src.eval.runner.judge_cli, src.eval.cli, src.eval.runner.judge
+# @end-summary
+"""Tests for the headless `claude` CLI judge backend.
+
+All fast tests inject a fake ``run_fn`` so NO ``claude`` process is spawned and
+NO Weaviate/embeddings/LLM are touched. The one live test is double-gated on a
+``claude`` binary on PATH AND an explicit opt-in env var.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake subprocess result + run_fn factory
+# ---------------------------------------------------------------------------
+
+
+def _fake_completed(stdout: str, *, returncode: int = 0, stderr: str = ""):
+    """Mimic the slice of subprocess.CompletedProcess that score() reads."""
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _success_envelope(result_payload: str) -> str:
+    """Serialize a VERIFIED-shape success envelope with a stringified result."""
+    return json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": result_payload,
+        }
+    )
+
+
+def _make_run_fn(envelope_stdout: str, *, returncode: int = 0):
+    """Return a (argv, *, timeout) -> result callable serving a canned stdout."""
+
+    def _run_fn(argv, *, timeout):
+        return _fake_completed(envelope_stdout, returncode=returncode)
+
+    return _run_fn
+
+
+def _question():
+    from src.eval.runner.judge import JudgeQuestion
+
+    return JudgeQuestion(
+        qid="g1",
+        qtype="factoid",
+        query="what is alpha?",
+        expected_answer_span="alpha",
+        chunk_texts=("alpha is the first letter",),
+    )
+
+
+def _client(run_fn, *, template: str = "RUBRIC {query} {chunk_block}"):
+    from src.eval.runner.judge_cli import ClaudeCliJudgeClient
+
+    return ClaudeCliJudgeClient(
+        template=template,
+        model="claude-haiku-4-5-20251001",
+        run_fn=run_fn,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Synthetic pack (mirrors tests/eval/test_cli.py + src/eval/smoke.py)
+# ---------------------------------------------------------------------------
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _make_synthetic_pack(tmp_path: Path) -> Path:
+    """Minimal valid eval_pack on disk; single factoid golden."""
+    import yaml
+
+    pack_dir = tmp_path / "synthetic_pack"
+    pack_dir.mkdir()
+    (pack_dir / "corpus").mkdir()
+    (pack_dir / "goldens").mkdir()
+
+    doc_text = "alpha beta gamma\n"
+    (pack_dir / "corpus" / "doc1.md").write_text(doc_text)
+    doc_sha = _sha256_text(doc_text)
+    (pack_dir / "corpus" / "manifest.json").write_text(
+        json.dumps({"entries": [{"path": "doc1.md", "sha256": doc_sha}]})
+    )
+    corpus_pin = hashlib.sha256(f"doc1.md:{doc_sha}".encode("utf-8")).hexdigest()
+
+    pack_yaml = {
+        "name": "synpack",
+        "version": 1,
+        "profile": "generic",
+        "corpus_pin": corpus_pin,
+        "description": "judge-cli test pack",
+        "judge": {
+            "tier1_model": "claude-haiku-4-5-20251001",
+            "tier1_prompt_version": "v1",
+            "temperature": 0.0,
+            "samples_per_claim": 1,
+        },
+        "collection_name_template": "test_{name}_{corpus_pin_short}",
+    }
+    (pack_dir / "pack.yaml").write_text(yaml.safe_dump(pack_yaml))
+
+    golden = {
+        "qid": "g1",
+        "qtype": "factoid",
+        "query": "what is alpha?",
+        "expected_answer_span": "alpha",
+        "expected_source_docs": ["doc1.md"],
+    }
+    (pack_dir / "goldens" / "factoid.jsonl").write_text(json.dumps(golden) + "\n")
+
+    thresholds = {
+        "profile": "generic",
+        "defaults": {"factoid": {"recall_at_5": 0.5, "faithfulness": 0.5}},
+        "min_goldens_per_qtype": {"factoid": 1},
+    }
+    (pack_dir / "thresholds.yaml").write_text(yaml.safe_dump(thresholds))
+    return pack_dir
+
+
+class _FakeEmbedder:
+    def embed_documents(self, texts):
+        return [[0.0] * 8 for _ in texts]
+
+
+def _patch_infra(monkeypatch, *, retrieved_source: str = "doc1.md"):
+    """Patch execute_plan + retrieval infra to deterministic fakes (no Weaviate)."""
+    from src.eval.runner import report as report_mod
+    from src.eval.runner import retrieve as retrieve_mod
+    from src.vector_db.common.schemas import SearchResult
+    import src.eval.runner as runner_pkg
+
+    def fake_execute_plan(plan, *, fresh: bool = True):
+        return report_mod.IngestReport(
+            collection_name=plan.collection_name,
+            processed=1,
+            skipped=0,
+            failed=0,
+            stored_chunks=1,
+            document_count=1,
+            plan=plan,
+            errors=(),
+        )
+
+    def fake_search(client, query, query_embedding, alpha, limit, **kwargs):
+        return [
+            SearchResult(
+                text="alpha is the first",
+                score=1.0,
+                metadata={"source": retrieved_source},
+            )
+        ]
+
+    monkeypatch.setattr(runner_pkg, "execute_plan", fake_execute_plan)
+    monkeypatch.setattr(retrieve_mod, "search", fake_search)
+    monkeypatch.setattr(
+        retrieve_mod, "get_embedding_provider", lambda: _FakeEmbedder()
+    )
+    monkeypatch.setattr(retrieve_mod, "create_persistent_client", lambda: object())
+    monkeypatch.setattr(retrieve_mod, "close_client", lambda _c: None)
+
+
+# ---------------------------------------------------------------------------
+# HEADLINE E2E — the integration-seam teeth
+# ---------------------------------------------------------------------------
+
+
+def test_run_eval_scores_via_claude_cli_backend(tmp_path: Path, monkeypatch) -> None:
+    """run_eval with a ClaudeCliJudgeClient (fake run_fn) carries faithfulness 0.8.
+
+    Proves the headless-CLI judge plugs into the real run_eval seam: the canned
+    success envelope's result ({"score":0.8}) becomes the qtype faithfulness.
+    """
+    from src.eval.cli import run_eval
+    from src.eval.runner.judge_cli import ClaudeCliJudgeClient
+
+    pack_dir = _make_synthetic_pack(tmp_path)
+    _patch_infra(monkeypatch)
+
+    run_fn = _make_run_fn(_success_envelope(json.dumps({"score": 0.8, "reasoning": "ok"})))
+
+    def factory(pack, *, chat_model_factory=None, pack_dir=None):
+        return ClaudeCliJudgeClient(
+            template="RUBRIC {query}\n{chunk_block}",
+            model="claude-haiku-4-5-20251001",
+            run_fn=run_fn,
+        )
+
+    result = run_eval(str(pack_dir), judge_client_factory=factory)
+    assert result.report.faithfulness_by_qtype["factoid"] == pytest.approx(0.8)
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch wiring — argv→backend selection
+# ---------------------------------------------------------------------------
+
+
+def test_main_dispatch_routes_judge_backend_claude_cli(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """main(["run", ..., "--judge-backend", "claude-cli"]) selects the cli factory.
+
+    Pins the argv→backend wiring: the claude-cli factory (spied) must be the one
+    actually invoked, and main() returns an int exit code.
+    """
+    from src.eval import cli as cli_mod
+    import src.eval.runner as runner_pkg
+    from src.eval.runner.judge_cli import ClaudeCliJudgeClient
+
+    pack_dir = _make_synthetic_pack(tmp_path)
+    _patch_infra(monkeypatch)
+
+    run_fn = _make_run_fn(_success_envelope(json.dumps({"score": 0.8, "reasoning": "ok"})))
+    spy_calls: list = []
+
+    def spy_factory(pack, *, chat_model_factory=None, pack_dir=None, run_fn=None):
+        # Bind our OWN fake run_fn so no real `claude` process is ever spawned,
+        # regardless of whether the CLI threads run_fn through.
+        spy_calls.append(pack)
+        return ClaudeCliJudgeClient(
+            template="RUBRIC {query}\n{chunk_block}",
+            model="claude-haiku-4-5-20251001",
+            run_fn=run_fn or _make_run_fn(
+                _success_envelope(json.dumps({"score": 0.8, "reasoning": "ok"}))
+            ),
+        )
+
+    # Patch the symbol the CLI lazy-imports from the runner package.
+    monkeypatch.setattr(
+        runner_pkg, "build_claude_cli_judge_client", spy_factory, raising=False
+    )
+
+    rc = cli_mod.main(["run", str(pack_dir), "--judge-backend", "claude-cli"])
+    assert isinstance(rc, int)
+    assert spy_calls, "claude-cli judge factory was never invoked"
+
+
+# ---------------------------------------------------------------------------
+# score() parsing pipeline + error raises
+# ---------------------------------------------------------------------------
+
+
+def test_score_parses_envelope_success() -> None:
+    """A clean success envelope yields the embedded score + reasoning."""
+    run_fn = _make_run_fn(
+        _success_envelope(json.dumps({"score": 0.7, "reasoning": "grounded"}))
+    )
+    out = _client(run_fn).score(_question())
+    assert out.score == pytest.approx(0.7)
+    assert out.reasoning == "grounded"
+
+
+def test_score_strips_json_fence() -> None:
+    """A ```json ... ``` fenced result string is stripped before json.loads."""
+    fenced = "```json\n" + json.dumps({"score": 0.6, "reasoning": "ok"}) + "\n```"
+    run_fn = _make_run_fn(_success_envelope(fenced))
+    out = _client(run_fn).score(_question())
+    assert out.score == pytest.approx(0.6)
+
+
+def test_score_clamps_out_of_range() -> None:
+    """A model score above 1.0 is clamped into [0, 1]."""
+    run_fn = _make_run_fn(
+        _success_envelope(json.dumps({"score": 1.7, "reasoning": "hot"}))
+    )
+    out = _client(run_fn).score(_question())
+    assert out.score == pytest.approx(1.0)
+
+
+def test_score_is_error_true_raises() -> None:
+    """is_error: true in the envelope raises JudgeBackendError."""
+    from src.eval.runner.judge_cli import JudgeBackendError
+
+    envelope = json.dumps(
+        {"type": "result", "subtype": "success", "is_error": True, "result": "{}"}
+    )
+    run_fn = _make_run_fn(envelope)
+    with pytest.raises(JudgeBackendError):
+        _client(run_fn).score(_question())
+
+
+def test_score_bad_subtype_raises() -> None:
+    """A non-success subtype raises JudgeBackendError."""
+    from src.eval.runner.judge_cli import JudgeBackendError
+
+    envelope = json.dumps(
+        {
+            "type": "result",
+            "subtype": "error_max_turns",
+            "is_error": False,
+            "result": json.dumps({"score": 0.5, "reasoning": "x"}),
+        }
+    )
+    run_fn = _make_run_fn(envelope)
+    with pytest.raises(JudgeBackendError):
+        _client(run_fn).score(_question())
+
+
+def test_score_unparseable_result_raises() -> None:
+    """A non-JSON result payload raises JudgeBackendError."""
+    from src.eval.runner.judge_cli import JudgeBackendError
+
+    run_fn = _make_run_fn(_success_envelope("not json at all"))
+    with pytest.raises(JudgeBackendError):
+        _client(run_fn).score(_question())
+
+
+def test_score_nonzero_returncode_raises() -> None:
+    """A non-zero CLI returncode raises JudgeBackendError before parsing."""
+    from src.eval.runner.judge_cli import JudgeBackendError
+
+    run_fn = _make_run_fn(
+        _success_envelope(json.dumps({"score": 0.9, "reasoning": "ok"})),
+        returncode=1,
+    )
+    with pytest.raises(JudgeBackendError):
+        _client(run_fn).score(_question())
+
+
+# ---------------------------------------------------------------------------
+# argv constraint contract — cost/safety guard
+# ---------------------------------------------------------------------------
+
+
+def test_build_claude_argv_contains_constraints() -> None:
+    """build_claude_argv pins the constrained, non-coding-agent invocation.
+
+    Asserts --model, --system-prompt, --allowed-tools, --output-format json,
+    and --setting-sources are present so a future edit can't silently turn the
+    judge into the full (expensive, tool-enabled, persona-contaminated) agent.
+    """
+    from src.eval.runner.judge_cli import build_claude_argv
+
+    argv = build_claude_argv(
+        "JUDGE THIS",
+        model="claude-haiku-4-5-20251001",
+        system_prompt="RUBRIC",
+    )
+    assert argv[0] == "claude"
+    # -p / --print carries the prompt.
+    assert "JUDGE THIS" in argv
+
+    def _val(flag):
+        return argv[argv.index(flag) + 1]
+
+    assert "--model" in argv and _val("--model") == "claude-haiku-4-5-20251001"
+    assert "--system-prompt" in argv and _val("--system-prompt") == "RUBRIC"
+    assert "--output-format" in argv and _val("--output-format") == "json"
+    # No tools, clean room: contamination guard.
+    assert "--allowed-tools" in argv
+    assert "--setting-sources" in argv
+
+
+# ---------------------------------------------------------------------------
+# MODEL-GATED REAL TEST — live claude CLI (double opt-in)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_claude_cli_judge_smoke_real() -> None:
+    """Score one trivial question with a real `claude` CLI (default run_fn).
+
+    Double-gated: skipped unless a `claude` binary is on PATH AND the explicit
+    RAGWEAVE_EVAL_CLI_LIVE=1 opt-in is set, so it never runs by accident.
+    """
+    if not shutil.which("claude"):
+        pytest.skip("no `claude` binary on PATH")
+    if os.environ.get("RAGWEAVE_EVAL_CLI_LIVE") != "1":
+        pytest.skip("RAGWEAVE_EVAL_CLI_LIVE != 1 (live judge opt-in not set)")
+
+    from src.eval.runner.judge_cli import ClaudeCliJudgeClient
+
+    template = (
+        "You are a strict faithfulness judge. Score how well the chunks support "
+        "answering the query.\nQuery: {query}\nChunks:\n{chunk_block}\n"
+    )
+    client = ClaudeCliJudgeClient(
+        template=template, model="claude-haiku-4-5-20251001"
+    )
+    out = client.score(_question())
+    assert 0.0 <= out.score <= 1.0

--- a/tests/eval/test_judge_robustness.py
+++ b/tests/eval/test_judge_robustness.py
@@ -1,0 +1,474 @@
+# @summary
+# Tests for P15 — judge-call robustness (per-golden isolation + bounded retry).
+# A single judge failure must NOT abort the run: the failing golden is retried
+# (bounded), and if still failing is SKIPPED + COUNTED (via the existing
+# total_queries_skipped accounting) while every other golden is scored and the
+# run completes + gates on the survivors. Covers both the sequential and the
+# parallel (max_parallel_judges>1) paths, the JudgeBackendError isolation tie to
+# P14, plus two named-audit coverage backfills (corrupt baseline degrades to
+# absent; ingest failure isolated per pack in run_nightly).
+# Mutation targets:
+#   remove per-golden try/except (either path) → test_one_golden_failure_*,
+#       test_parallel_path_isolation, test_judge_backend_error_is_isolated
+#   drop the retry loop                        → test_retry_then_succeed
+#   off-by-one in retry bound                  → test_retry_exhausted_skips_not_crash
+#   broaden the narrow corrupt-baseline catch  → test_corrupted_baseline_degrades_*
+#   remove run_nightly per-pack try/except     → test_ingest_failure_isolated_per_pack
+# Exports: test_one_golden_failure_does_not_abort_run,
+#          test_one_golden_failure_run_eval_gates_on_survivors,
+#          test_retry_then_succeed,
+#          test_retry_exhausted_skips_not_crash,
+#          test_parallel_path_isolation,
+#          test_parallel_retry_then_succeed,
+#          test_judge_backend_error_is_isolated,
+#          test_partial_sample_failure_skips_golden,
+#          test_corrupted_baseline_degrades_to_absent,
+#          test_ingest_failure_isolated_per_pack
+# Deps: src.eval.runner (score_goldens, JudgmentScore, JudgeQuestion,
+#       RetrievalResults, QueryRetrievalResult), src.eval.runner.judge_cli
+#       (JudgeBackendError), src.eval.orchestrator (run_nightly),
+#       tests.eval.test_cli (_make_synthetic_pack, _patch_full_chain).
+# @end-summary
+"""P15 — judge-call robustness tests (per-golden isolation + bounded retry)."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.eval.pack.schema import Golden
+from src.eval.runner import (
+    JudgeQuestion,
+    JudgmentScore,
+    QueryRetrievalResult,
+    RetrievalResults,
+    score_goldens,
+)
+from src.eval.runner.judge_cli import JudgeBackendError
+
+FIXED_NOW = datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FailingJudgeClient:
+    """Judge that RAISES for a configured set of qids and scores the rest.
+
+    ``raise_qids`` maps a qid to the number of times .score should raise for
+    that qid before succeeding; a value of -1 means "always raise". qids absent
+    from the map score normally (``ok_score``). Records every call (in order)
+    plus a per-qid attempt counter so tests can assert the retry bound.
+    """
+
+    def __init__(
+        self,
+        raise_qids: dict[str, int],
+        *,
+        ok_score: float = 0.9,
+        exc_factory=None,
+    ) -> None:
+        self.raise_qids = dict(raise_qids)
+        self.ok_score = ok_score
+        self._exc_factory = exc_factory or (lambda qid: RuntimeError(f"judge boom {qid}"))
+        self.calls: list[JudgeQuestion] = []
+        self.attempts: dict[str, int] = {}
+
+    def score(self, question: JudgeQuestion) -> JudgmentScore:
+        self.calls.append(question)
+        qid = question.qid
+        self.attempts[qid] = self.attempts.get(qid, 0) + 1
+        remaining = self.raise_qids.get(qid, 0)
+        if remaining != 0:
+            # Decrement a positive counter; -1 (always) stays sticky.
+            if remaining > 0:
+                self.raise_qids[qid] = remaining - 1
+            raise self._exc_factory(qid)
+        return JudgmentScore(score=self.ok_score, reasoning=f"ok-{qid}")
+
+
+def _golden(qid: str, qtype: str = "factoid") -> Golden:
+    return Golden(
+        qid=qid,
+        qtype=qtype,
+        query=f"query-{qid}",
+        expected_answer_span="span",
+        expected_source_docs=[f"docs/{qid}.md"],
+    )
+
+
+def _qresult(qid: str, qtype: str = "factoid") -> QueryRetrievalResult:
+    return QueryRetrievalResult(
+        qid=qid,
+        qtype=qtype,
+        query=f"query-{qid}",
+        retrieved_sources=(f"docs/{qid}.md",),
+        retrieved_chunks=(f"chunk-{qid}",),
+        k=5,
+    )
+
+
+def _three_goldens_results():
+    """A pack with 3 factoid goldens f1/f2/f3, each with one retrieved chunk."""
+    goldens = {"factoid": [_golden("f1"), _golden("f2"), _golden("f3")]}
+    per_query = {
+        "f1": _qresult("f1"),
+        "f2": _qresult("f2"),
+        "f3": _qresult("f3"),
+    }
+    results = RetrievalResults(collection_name="C", k=5, per_query=per_query)
+    return goldens, results
+
+
+# ---------------------------------------------------------------------------
+# HEADLINE: one golden failure does not abort the run (sequential)
+# ---------------------------------------------------------------------------
+
+
+def test_one_golden_failure_does_not_abort_run() -> None:
+    """Judge RAISES forever for golden f2 → f2 skipped+counted, f1/f3 scored.
+
+    HEADLINE RED. Before the fix the raised RuntimeError escapes score_goldens
+    and aborts the run. After the fix: the run COMPLETES; f2 lands in
+    total_queries_skipped (NOT silently dropped); f1 and f3 are scored;
+    total_queries_scored reflects only the survivors.
+    """
+    goldens, results = _three_goldens_results()
+    judge = _FailingJudgeClient({"f2": -1}, ok_score=0.9)
+
+    fres = score_goldens(goldens=goldens, retrieval_results=results, judge_client=judge)
+
+    assert set(fres.per_query) == {"f1", "f3"}, (
+        f"survivors must be scored; got {set(fres.per_query)}"
+    )
+    assert fres.total_queries_scored == 2
+    # f2 flows through the SAME skipped accounting as empty-query goldens.
+    assert fres.total_queries_skipped == 1, (
+        f"failed golden must be counted as skipped; got {fres.total_queries_skipped}"
+    )
+    assert fres.per_query["f1"].score == pytest.approx(0.9)
+    assert fres.per_query["f3"].score == pytest.approx(0.9)
+
+
+def test_one_golden_failure_run_eval_gates_on_survivors(tmp_path: Path, monkeypatch) -> None:
+    """End-to-end via run_eval: a failing golden is skipped, gate evals survivors.
+
+    Proves the skip does not fabricate a spurious 0.0 faithfulness that would
+    fail the gate. Single-golden pack whose only golden's judge raises → it is
+    skipped → total_queries_judged == 0 → faithfulness gating is SKIPPED (gate
+    passes on recall alone), and run_eval COMPLETES (no escaped exception).
+    """
+    from tests.eval.test_cli import _make_synthetic_pack
+    from src.eval.cli import run_eval
+    from src.eval.runner import execute as execute_mod
+    from src.eval.runner import retrieve as retrieve_mod
+    from src.eval.runner import report as report_mod
+    import src.eval.runner as runner_pkg
+    from src.vector_db.common.schemas import SearchResult
+
+    pack_dir = _make_synthetic_pack(
+        tmp_path, recall_floor=0.5, faithfulness_floor=0.5
+    )
+
+    def fake_execute_plan(plan, *, fresh: bool = True):
+        return report_mod.IngestReport(
+            collection_name=plan.collection_name,
+            processed=1, skipped=0, failed=0, stored_chunks=1,
+            document_count=1, plan=plan, errors=(),
+        )
+
+    def fake_search(client, query, query_embedding, alpha, limit, **kwargs):
+        return [SearchResult(text="alpha", score=1.0, metadata={"source": "doc1.md"})]
+
+    monkeypatch.setattr(runner_pkg, "execute_plan", fake_execute_plan)
+    monkeypatch.setattr(retrieve_mod, "search", fake_search)
+    monkeypatch.setattr(retrieve_mod, "get_embedding_provider", lambda: _Embedder())
+    monkeypatch.setattr(retrieve_mod, "create_persistent_client", lambda: object())
+    monkeypatch.setattr(retrieve_mod, "close_client", lambda _c: None)
+    monkeypatch.setattr(
+        runner_pkg, "build_judge_client",
+        lambda pack, **kw: _FailingJudgeClient({"g1": -1}),
+    )
+
+    result = run_eval(str(pack_dir))
+
+    assert result.report.total_queries_judged == 0, (
+        "the only golden's judge failed → nothing judged"
+    )
+    assert result.report.total_queries_skipped == 1
+    # Faithfulness gating is judged-guarded; recall=1.0 ≥ 0.5 → gate passes.
+    assert result.gate.passed is True
+    assert "factoid" not in result.report.faithfulness_by_qtype
+
+
+class _Embedder:
+    def embed_documents(self, texts):
+        return [[0.0] * 8 for _ in texts]
+
+
+# ---------------------------------------------------------------------------
+# Bounded retry
+# ---------------------------------------------------------------------------
+
+
+def test_retry_then_succeed() -> None:
+    """Judge raises ONCE for f2 then succeeds → with judge_retries=1, f2 SCORED.
+
+    Discriminating: proves the retry actually retries (not just swallows). f2
+    is in per_query (scored), nothing is skipped, and the judge was called
+    twice for f2 (fail + success).
+    """
+    goldens, results = _three_goldens_results()
+    judge = _FailingJudgeClient({"f2": 1}, ok_score=0.7)
+
+    fres = score_goldens(
+        goldens=goldens,
+        retrieval_results=results,
+        judge_client=judge,
+        judge_retries=1,
+    )
+
+    assert set(fres.per_query) == {"f1", "f2", "f3"}, "f2 should recover on retry"
+    assert fres.total_queries_skipped == 0
+    assert fres.per_query["f2"].score == pytest.approx(0.7)
+    assert judge.attempts["f2"] == 2, (
+        f"f2 should be attempted exactly twice (fail+retry); got {judge.attempts['f2']}"
+    )
+
+
+def test_retry_exhausted_skips_not_crash() -> None:
+    """Judge ALWAYS raises for f2 → with judge_retries=1 it is skipped after 2.
+
+    Teeth on the bound: 1 + retries = 2 attempts, then skip. An off-by-one in
+    the retry loop (e.g. 1+retries+1 or only 1) reds the attempt assertion.
+    """
+    goldens, results = _three_goldens_results()
+    judge = _FailingJudgeClient({"f2": -1})
+
+    fres = score_goldens(
+        goldens=goldens,
+        retrieval_results=results,
+        judge_client=judge,
+        judge_retries=1,
+    )
+
+    assert set(fres.per_query) == {"f1", "f3"}
+    assert fres.total_queries_skipped == 1
+    assert judge.attempts["f2"] == 2, (
+        f"judge_retries=1 → exactly 2 attempts before skip; got {judge.attempts['f2']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parallel path isolation
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_path_isolation() -> None:
+    """Parallel path (max_parallel_judges=3): one failing future doesn't poison.
+
+    Same shape as the headline but through _score_parallel. f2's future raises;
+    f1 and f3 still resolve and are scored; f2 is skipped+counted; the pool is
+    not poisoned and the run completes.
+    """
+    goldens, results = _three_goldens_results()
+    judge = _FailingJudgeClient({"f2": -1}, ok_score=0.8)
+
+    fres = score_goldens(
+        goldens=goldens,
+        retrieval_results=results,
+        judge_client=judge,
+        max_parallel_judges=3,
+    )
+
+    assert set(fres.per_query) == {"f1", "f3"}
+    assert fres.total_queries_scored == 2
+    assert fres.total_queries_skipped == 1
+    assert fres.per_query["f1"].score == pytest.approx(0.8)
+    assert fres.per_query["f3"].score == pytest.approx(0.8)
+
+
+def test_parallel_retry_then_succeed() -> None:
+    """Parallel path also honors judge_retries (f2 fails once, recovers)."""
+    goldens, results = _three_goldens_results()
+    judge = _FailingJudgeClient({"f2": 1}, ok_score=0.6)
+
+    fres = score_goldens(
+        goldens=goldens,
+        retrieval_results=results,
+        judge_client=judge,
+        max_parallel_judges=3,
+        judge_retries=1,
+    )
+
+    assert set(fres.per_query) == {"f1", "f2", "f3"}
+    assert fres.total_queries_skipped == 0
+    assert fres.per_query["f2"].score == pytest.approx(0.6)
+
+
+# ---------------------------------------------------------------------------
+# JudgeBackendError isolation (ties P15 to P14)
+# ---------------------------------------------------------------------------
+
+
+def test_judge_backend_error_is_isolated() -> None:
+    """The claude-cli JudgeBackendError specifically is isolated (run completes).
+
+    Ties P15 to the P14 headless backend: its typed failure must flow through
+    the same per-golden isolation as any other exception.
+    """
+    goldens, results = _three_goldens_results()
+    judge = _FailingJudgeClient(
+        {"f2": -1},
+        exc_factory=lambda qid: JudgeBackendError(f"claude cli judge failed {qid}"),
+    )
+
+    fres = score_goldens(goldens=goldens, retrieval_results=results, judge_client=judge)
+
+    assert set(fres.per_query) == {"f1", "f3"}
+    assert fres.total_queries_skipped == 1
+
+
+def test_partial_sample_failure_skips_golden() -> None:
+    """If ANY sample for a golden exhausts retries, the WHOLE golden is skipped.
+
+    Per-sample semantics: a golden with samples_per_claim>1 whose 2nd sample
+    always fails is skipped (no partial average over the 1 good sample). The
+    judge here raises on every call for f2 EXCEPT it would succeed the first
+    time — but because one sample fails, the golden is dropped, not averaged.
+    """
+    goldens = {"factoid": [_golden("f1")]}
+    results = RetrievalResults(
+        collection_name="C", k=5, per_query={"f1": _qresult("f1")}
+    )
+
+    # Raise on the SECOND call for f1 (first sample succeeds, second fails
+    # through all retries). With judge_retries=0 that means: call1 ok, call2
+    # raises → golden skipped.
+    class _SecondSampleFails:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def score(self, question):
+            self.calls += 1
+            if self.calls >= 2:
+                raise RuntimeError("second sample boom")
+            return JudgmentScore(score=0.9, reasoning="ok")
+
+    judge = _SecondSampleFails()
+    fres = score_goldens(
+        goldens=goldens,
+        retrieval_results=results,
+        judge_client=judge,
+        samples_per_claim=2,
+        judge_retries=0,
+    )
+
+    assert fres.per_query == {}, "a partially-failed golden must be skipped, not averaged"
+    assert fres.total_queries_skipped == 1
+
+
+# ---------------------------------------------------------------------------
+# Coverage backfill: corrupt baseline degrades to ABSENT (orchestrator)
+# ---------------------------------------------------------------------------
+
+
+def test_corrupted_baseline_degrades_to_absent(tmp_path: Path, monkeypatch) -> None:
+    """A baseline.json with merge-conflict markers is treated as ABSENT.
+
+    Backfills the narrow-catch degradation at orchestrator.py ~185-204: a
+    corrupt/truncated baseline is a baseline problem, not an eval error, so the
+    pack still runs, baseline_diff is None, and the run completes (rc reflects
+    the gate only, even with fail_on_regression=True).
+    """
+    from tests.eval.test_cli import _make_synthetic_pack, _patch_full_chain
+    from src.eval.orchestrator import run_nightly
+
+    pack_dir = _make_synthetic_pack(
+        tmp_path, recall_floor=0.5, faithfulness_floor=0.5
+    )
+    _patch_full_chain(monkeypatch, retrieved_source="doc1.md", judge_score=0.9)
+    # Merge-conflict leftover + truncated JSON: json.loads cannot parse it.
+    (Path(pack_dir) / "baseline.json").write_text(
+        '<<<<<<< HEAD\n{"passed": tru', encoding="utf-8"
+    )
+
+    captured: list = []
+    out_dir = tmp_path / "reports"
+
+    rc = run_nightly(
+        [pack_dir],
+        output_dir=out_dir,
+        now=FIXED_NOW,
+        fail_on_regression=True,  # prove a corrupt baseline can't flip the exit
+        alert_fn=captured.append,
+    )
+
+    assert rc == 0, "corrupt baseline must not error the pack nor flip the exit"
+    assert len(captured) == 1, "the pack's alert must still fire"
+    assert captured[0].baseline_diff is None, "unusable baseline → treated as absent"
+    assert len(list(out_dir.glob("*.json"))) == 1, "the report was still persisted"
+
+
+# ---------------------------------------------------------------------------
+# Coverage backfill: ingest failure isolated per pack (run_nightly)
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_failure_isolated_per_pack(tmp_path: Path, monkeypatch) -> None:
+    """An execute_fn that raises for pack A → A marked failed, B still runs.
+
+    Documents+tests the existing per-pack isolation for the ingest failure
+    mode: run_nightly returns non-zero (A errored) but does NOT raise out, and
+    healthy pack B in the same batch is still evaluated, persisted, and alerted.
+    """
+    from tests.eval.test_cli import _make_synthetic_pack, _patch_full_chain
+    from src.eval.orchestrator import run_nightly
+
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    pack_a = _make_synthetic_pack(dir_a, recall_floor=0.5)
+    pack_b = _make_synthetic_pack(dir_b, recall_floor=0.5)
+    _patch_full_chain(monkeypatch, retrieved_source="doc1.md", judge_score=0.9)
+
+    # An execute_fn (ingest seam) that raises the FIRST time it is called
+    # (pack A is first in the list) and succeeds thereafter (pack B). The
+    # templated collection name does not encode the pack dir, so call-ordering
+    # is the cleanest deterministic router here.
+    from src.eval.runner import report as report_mod
+
+    state = {"n": 0}
+
+    def counting_execute(plan, *, fresh: bool = True):
+        state["n"] += 1
+        if state["n"] == 1:
+            raise RuntimeError("ingest A blew up")
+        return report_mod.IngestReport(
+            collection_name=plan.collection_name,
+            processed=1, skipped=0, failed=0, stored_chunks=1,
+            document_count=1, plan=plan, errors=(),
+        )
+
+    captured: list = []
+    out_dir = tmp_path / "reports"
+
+    rc = run_nightly(
+        [pack_a, pack_b],
+        output_dir=out_dir,
+        now=FIXED_NOW,
+        alert_fn=captured.append,
+        execute_fn=counting_execute,
+    )
+
+    assert rc == 1, "an errored (ingest-failed) pack must return non-zero"
+    written = list(out_dir.glob("*.json"))
+    assert len(written) == 1, f"only healthy pack B should persist, got {written!r}"
+    assert json.loads(written[0].read_text())["pack_name"] == "synpack"
+    assert len(captured) == 1, "pack B's alert still fires; pack A errored pre-payload"
+    assert captured[0].gate_passed is True


### PR DESCRIPTION
## What & why

Implements the eval-loop goal: **make the system able to run + score itself via the headless Claude CLI, with LLM-as-judge, and harden the judge call against transient failure.** Two backward-compatible vertical slices + a plan upgrade.

### P14 — Headless Claude CLI judge backend
A new `--judge-backend {litellm,claude-cli}` (default **litellm**, zero behavior change) lets the LLM-as-judge run through the local `claude` CLI — **no `RAG_LLM_API_KEY` required**, reusing local Claude auth. This is the actuation substrate for an unattended runner / future Ralph-A.

- `src/eval/runner/judge_cli.py`: `ClaudeCliJudgeClient.score(JudgeQuestion) -> JudgmentScore` over a **constrained** `claude -p` — pinned `--model` haiku, judge rubric via `--system-prompt` (full replace), `--allowed-tools ""` (tool-less), `--setting-sources ""` (clean room), `bypassPermissions`, `--output-format json`. Parses `envelope.result → JudgmentScore` with score clamp + typed `JudgeBackendError`.
- **Why constrained matters:** a bare `claude -p` loads the full coding agent (~$0.20/call on Opus, tool-enabled, persona-contaminated). The constraint flags make it a cheap, tool-less, single-purpose judge.
- `run_fn` injection seam → no real subprocess in unit tests; one model-gated (`RAGWEAVE_EVAL_CLI_LIVE=1` + `claude` on PATH) real-CLI test.

### P15 — Judge-call robustness (per-golden isolation + bounded retry)
Closes the #1 HIGH-severity audit finding: a single judge failure (timeout, rate-limit, malformed output, `JudgeBackendError`) previously aborted the whole nightly batch.

- `faithfulness.py`: bounded retry (`_score_with_retry`, single retry site) then **per-golden isolation** — a failed golden is skipped + counted via the existing `total_queries_skipped` accounting (honest denominator; no spurious 0.0), run continues. Applied in sequential **and** parallel paths. `--judge-retries` flag (default 1).
- Coverage backfill for previously-zero-coverage error paths: judge-raises, corrupt `baseline.json` → degrades to absent, ingest failure isolated per pack.

### Plan upgrade (`EVAL_LOOP_PLAN.md`)
Shipped-state ledger (stops drift; folds in the #140/#141/#142 trend trio), §3.5 headless-CLI backend, §11.5 robustness dimension + coverage targets, P14/P15 slice specs.

## Live proof (real `claude` judge)
Scored two factoid goldens sharing one question, fed a supporting vs. an unrelated chunk:
```
[SUPPORTED chunk ] score=1.00  (cited the expected span verbatim, addressed 'after reset')
[UNRELATED chunk] score=0.00  (bananas — supports no part of the expected answer)
```
The headless judge ran the full pipeline and **discriminated** correctly.

## Tests
- `tests/eval`: **255 → 275 passed** / 5 skipped (+20: 10 judge-cli, 10 robustness).
- Offline smoke (`python -m src.eval.smoke`): exit 0 (default backend untouched).
- CI-equivalent cross-area sweep (ingest + unit + eval): **2439 passed / 4 skipped**.
- Each slice: red-reason proof captured; SA3 adversarial mutation-probe verification (P14 PASS-WITH-NITS → nit fixed + mutation-proven; P15 PASS, all 6 probes bite incl. silent-drop on both paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
