### PR TITLE
feat(eval): Ralph-A proposal-only eval-failure investigator (P11a)

### DIFF
--- a/EVAL_LOOP_PLAN.md
+++ b/EVAL_LOOP_PLAN.md
@@ -19,9 +19,10 @@ The plan below describes the *intended* architecture. This ledger records what i
 | Run-history index (#140) | ✅ shipped | `src/eval/runner/run_history.py` → `<pack>.history.jsonl` |
 | Sustained-regression detector (#141) | ✅ shipped | `src/eval/runner/sustained_regression.py`, wired into `run_nightly` |
 | show-trend inspection CLI (#142) | ✅ shipped | `src/eval/runner/show_trend.py`, `src/eval/cli.py show-trend` |
-| **Headless Claude CLI judge backend (P14)** | 🚧 this initiative | `src/eval/runner/judge_cli.py` (new), `--judge-backend` flag |
-| **Judge-call robustness: isolation + timeout/retry (P15)** | 🚧 this initiative | `src/eval/runner/faithfulness.py`, `judge.py` |
-| Ralph-A eval-failure investigator (P11) | ⏸️ HELD by decision | §10.3; un-defer once headless driver + signal trio are trusted |
+| Headless Claude CLI judge backend (P14) | ✅ shipped (#143) | `src/eval/runner/judge_cli.py`, `--judge-backend` flag |
+| Judge-call robustness: per-golden isolation + retry (P15) | ✅ shipped (#143) | `src/eval/runner/faithfulness.py`, `--judge-retries` |
+| **Ralph-A proposal-only investigator (P11a)** | 🚧 this initiative | `src/eval/runner/ralph.py`, `ralph` CLI subcommand |
+| Ralph-A apply+measure+open-PR (P11b) | ⏸️ deferred | the riskier actuation; build on P11a once proposals are trusted |
 | Real Slack/webhook alert delivery | ⏸️ deferred | `src/eval/runner/alert.py` is a log-only sink today |
 | Cross-pack dashboard (Grafana) | ⏸️ deferred | premature until multiple customer packs exist |
 
@@ -310,17 +311,19 @@ Each slice prompt is self-contained: file paths, contracts, DoD, E2E test all sp
 
 ### 10.3 Ralph loops (where they fit)
 
-**Ralph-A — Eval-failure investigator (non-merging) — HELD until P14+P15 land:**
+**Ralph-A — Eval-failure investigator (non-merging) — split into two slices:**
 ```
 while sustained_regressions_exist and iterations < cap:
-    pick the worst SUSTAINED-regressing (qtype, metric)        # from #141 detector
-    dispatch subagent: "diagnose + propose minimal patch"
-    apply patch in isolated branch
-    re-run smoke eval (and, where credentialled, --judge-backend claude-cli)  # P14 driver
-    if improvement: commit + open PR for human review
-    else: revert + try next hypothesis
+    pick the worst SUSTAINED-regressing (qtype, metric)        # from #141 detector  ─┐
+    investigate: "diagnose + propose minimal fix"  (headless claude, constrained)    │ P11a (shipped):
+    record into a human-reviewable RalphReport                                       ─┘ proposal-only, NEVER mutates
+    apply proposal in an ISOLATED branch                                             ─┐
+    re-run smoke eval (and, where credentialled, --judge-backend claude-cli)         │ P11b (deferred):
+    if improvement: commit + open PR for human review                                │ apply + measure + draft PR
+    else: discard + try next hypothesis                                              ─┘
 ```
-Never auto-merges. Bounded iterations. Each PR human-reviewed. It reads `load_run_history` + `detect_sustained_regressions` (the signal trio) and actuates through the P14 headless driver (no API key needed). P15 ensures a flaky judge call doesn't abort its smoke re-runs.
+- **P11a (shipped, proposal-only):** `run_ralph_a` (`src/eval/runner/ralph.py`) loads `load_run_history` + `detect_sustained_regressions` (the signal trio), ranks worst-first (`latest_delta` asc, then `runs_regressed` desc), and for the top-K invokes a CONSTRAINED headless-claude investigator (reusing P14's `build_claude_argv`) to emit a `RalphReport` of diagnoses + suggested fixes. **It applies nothing, commits nothing, opens no PR, merges nothing — proven empirically (repo tree byte-identical before/after).** `investigate_fn` is an injectable seam (default real headless claude; tests inject fakes). CLI: `python -m src.eval ralph <pack>`.
+- **P11b (deferred):** apply a proposal in an isolated worktree, re-run the eval via the P14 driver to MEASURE improvement, and (if improved) open a DRAFT PR for human review. Never auto-merges. Bounded iterations + diff-size cap. P15 ensures a flaky judge call doesn't abort its re-runs.
 
 **Ralph-B — Golden expander (human-gated):** drafts to `goldens/_drafts/`; human promotes. Unchanged.
 

--- a/src/eval/cli.py
+++ b/src/eval/cli.py
@@ -36,8 +36,12 @@
 # show_trend(pack, ...) calls load_run_history → render_trend_table and prints a
 # markdown per-(qtype, metric) trend table. It performs NO writes/ingest/
 # retrieve/judge; missing/empty history → friendly message at exit 0.
+# ralph adds a PROPOSAL-ONLY regression investigator subcommand: ralph(pack,...)
+# calls run_ralph_a to rank+investigate the worst sustained regressions, prints
+# a markdown diagnosis/suggested-fix report, and persists it under
+# <reports-dir>/ralph/. It never applies patches, commits, opens PRs, or merges.
 # Exports: _build_parser, _report_payload, run_eval, EvalRunResult, run_cli,
-#          promote_baseline, show_trend, main
+#          promote_baseline, show_trend, ralph, main
 # Deps: argparse, json, logging, os, sys; src.eval.pack (errors, loader);
 #       src.eval.runner (lazy) — execute_plan, retrieve_for_goldens,
 #       score_goldens, build_judge_client, build_eval_report,
@@ -247,6 +251,58 @@ def _build_parser() -> argparse.ArgumentParser:
         "(default: 2).",
     )
     trend_parser.add_argument(
+        "--epsilon",
+        type=float,
+        default=0.05,
+        help="Regression tolerance band; predicate is strict delta < -epsilon "
+        "(default: 0.05).",
+    )
+
+    # --- ralph subcommand (proposal-only regression investigator, P11a) ---
+    ralph_parser = subparsers.add_parser(
+        "ralph",
+        help="Investigate a pack's worst sustained regressions with a "
+        "constrained headless investigator and print a human-reviewable "
+        "diagnosis + suggested fix. PROPOSAL-ONLY: never applies patches, "
+        "commits, opens PRs, or merges.",
+    )
+    ralph_parser.add_argument(
+        "pack",
+        help="Pack name whose <pack>.history.jsonl lives under --reports-dir.",
+    )
+    ralph_parser.add_argument(
+        "--reports-dir",
+        default="eval_reports",
+        help="Directory containing <pack>.history.jsonl; the ralph report is "
+        "persisted under <reports-dir>/ralph/ (default: eval_reports).",
+    )
+    ralph_parser.add_argument(
+        "--packs-root",
+        default="evals/packs",
+        help="Root holding pack source dirs; <packs-root>/<pack> supplies "
+        "golden context when it exists (default: evals/packs).",
+    )
+    ralph_parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=3,
+        help="Top-K worst sustained regressions to investigate (default: 3).",
+    )
+    ralph_parser.add_argument(
+        "--window",
+        type=int,
+        default=3,
+        help="Detector lookback: recent runs inspected for sustained "
+        "regression (default: 3).",
+    )
+    ralph_parser.add_argument(
+        "--min-regressed",
+        type=int,
+        default=2,
+        help="Min regressed runs in the window to flag a pair sustained "
+        "(default: 2).",
+    )
+    ralph_parser.add_argument(
         "--epsilon",
         type=float,
         default=0.05,
@@ -779,6 +835,105 @@ def show_trend(
     return 0
 
 
+def ralph(
+    pack: str,
+    *,
+    reports_dir: str = "eval_reports",
+    packs_root: str = "evals/packs",
+    max_iterations: int = 3,
+    window: int = 3,
+    min_regressed: int = 2,
+    epsilon: float = 0.05,
+    investigate_fn: Any = None,
+    stdout: Any = None,
+) -> int:
+    """Investigate a pack's worst sustained regressions — proposal-only.
+
+    Calls :func:`~src.eval.runner.ralph.run_ralph_a` (which reads the run-history
+    + sustained-regression detector and ranks worst-first), prints a markdown
+    report (one section per investigation, or a friendly line when there are no
+    sustained regressions), and persists the report under
+    ``<reports-dir>/ralph/`` via
+    :func:`~src.eval.runner.persistence.persist_ralph_report`. Returns ``0``.
+
+    PROPOSAL-ONLY: this never applies patches, commits, opens PRs, or merges —
+    ``run_ralph_a`` performs no git/subprocess except the read-only investigator
+    CLI call, and persistence writes only the advisory JSON report.
+
+    :param pack: pack name whose ``<pack>.history.jsonl`` lives under
+        ``reports_dir`` (also the history dir).
+    :param reports_dir: directory holding the history index + the persisted
+        ralph report subdir.
+    :param packs_root: root holding pack source dirs; ``<packs_root>/<pack>``
+        supplies golden context when it exists.
+    :param max_iterations: top-K worst regressions to investigate.
+    :param window: detector lookback (default 3).
+    :param min_regressed: min regressed runs in the window to flag (default 2).
+    :param epsilon: regression tolerance band (strict ``delta < -epsilon``).
+    :param investigate_fn: optional fake investigator for tests; ``None`` uses
+        the real constrained headless investigator.
+    :param stdout: optional stream for the markdown report.
+    :returns: ``0`` always.
+    """
+    out = stdout if stdout is not None else sys.stdout
+
+    from src.eval.runner.persistence import persist_ralph_report
+    from src.eval.runner.ralph import run_ralph_a
+
+    # Only pass a pack_dir when it actually exists on disk.
+    pack_dir: str | None = None
+    candidate = Path(packs_root) / pack
+    if candidate.exists():
+        pack_dir = str(candidate)
+
+    report = run_ralph_a(
+        pack,
+        history_dir=reports_dir,
+        pack_dir=pack_dir,
+        max_iterations=max_iterations,
+        window=window,
+        min_regressed=min_regressed,
+        epsilon=epsilon,
+        investigate_fn=investigate_fn,
+    )
+
+    print(_render_ralph_markdown(report), file=out)
+    persist_ralph_report(report, reports_dir)
+    return 0
+
+
+def _render_ralph_markdown(report: Any) -> str:
+    """Render a :class:`~src.eval.runner.ralph.RalphReport` as markdown.
+
+    One section per investigation (target + delta + diagnosis + suggested_fix),
+    or a friendly ``(no sustained regressions)`` line when there are none.
+    """
+    lines: list[str] = []
+    lines.append(f"# Ralph-A report — {report.pack_name}")
+    lines.append(f"timestamp: {report.timestamp}")
+    lines.append(
+        f"sustained regressions: {report.sustained_count} "
+        f"(investigating up to {report.max_iterations})"
+    )
+    lines.append("")
+    if not report.investigations:
+        lines.append("(no sustained regressions)")
+        return "\n".join(lines)
+
+    for inv in report.investigations:
+        lines.append(f"## {inv.qtype} / {inv.metric}")
+        lines.append(
+            f"latest_delta: {inv.latest_delta} "
+            f"(regressed {inv.runs_regressed}/{inv.window} runs)"
+        )
+        lines.append("")
+        lines.append(f"**Diagnosis:** {inv.diagnosis}")
+        lines.append("")
+        lines.append(f"**Suggested fix:** {inv.suggested_fix}")
+        lines.append("")
+    return "\n".join(lines)
+
+
 def main(argv: list[str] | None = None) -> int:
     """Parse argv, dispatch to a subcommand, return its exit code."""
     parser = _build_parser()
@@ -809,6 +964,16 @@ def main(argv: list[str] | None = None) -> int:
             args.pack,
             reports_dir=args.reports_dir,
             runs=args.runs,
+            window=args.window,
+            min_regressed=args.min_regressed,
+            epsilon=args.epsilon,
+        )
+    if args.command == "ralph":
+        return ralph(
+            args.pack,
+            reports_dir=args.reports_dir,
+            packs_root=args.packs_root,
+            max_iterations=args.max_iterations,
             window=args.window,
             min_regressed=args.min_regressed,
             epsilon=args.epsilon,

--- a/src/eval/runner/__init__.py
+++ b/src/eval/runner/__init__.py
@@ -86,8 +86,18 @@ from .metrics import (
     recall_at_k,
     reciprocal_rank,
 )
-from .persistence import persist_eval_report
+from .persistence import persist_eval_report, persist_ralph_report
 from .plan import IngestPlan, plan_pack_ingest
+from .ralph import (
+    InvestigationProposal,
+    RalphInvestigation,
+    RalphReport,
+    build_investigation_context,
+    build_ralph_investigator,
+    rank_regressions,
+    run_ralph_a,
+    select_worst_regression,
+)
 from .report import EvalReport, IngestReport, build_eval_report
 from .reporting import (
     render_baseline_diff_markdown,
@@ -115,6 +125,7 @@ __all__ = [
     "GateResult",
     "IngestPlan",
     "IngestReport",
+    "InvestigationProposal",
     "JudgeBackendError",
     "JudgeClient",
     "JudgeQuestion",
@@ -122,6 +133,8 @@ __all__ = [
     "MetricDelta",
     "QueryFaithfulnessResult",
     "QueryRetrievalResult",
+    "RalphInvestigation",
+    "RalphReport",
     "RetrievalResults",
     "SustainedMetricRegression",
     "aggregate_faithfulness_by_qtype",
@@ -130,7 +143,9 @@ __all__ = [
     "binarize_score",
     "build_claude_cli_judge_client",
     "build_eval_report",
+    "build_investigation_context",
     "build_judge_client",
+    "build_ralph_investigator",
     "cohens_kappa",
     "compute_baseline_diff",
     "compute_calibration",
@@ -141,7 +156,9 @@ __all__ = [
     "load_judge_prompt",
     "persist_calibration_record",
     "persist_eval_report",
+    "persist_ralph_report",
     "plan_pack_ingest",
+    "rank_regressions",
     "read_max_parallel_judges",
     "read_samples_per_claim",
     "recall_at_k",
@@ -152,7 +169,9 @@ __all__ = [
     "render_regression_section",
     "retrieve_for_goldens",
     "run_calibration",
+    "run_ralph_a",
     "score_goldens",
+    "select_worst_regression",
     "send_alert",
     "send_calibration_alert",
     "validate_eval_report",

--- a/src/eval/runner/persistence.py
+++ b/src/eval/runner/persistence.py
@@ -4,8 +4,10 @@
 # <pack_name>_<filesafe-iso-timestamp>.json, carrying the same eval payload
 # shape _emit_json produces (single-sourced via cli._report_payload) PLUS
 # top-level pack_name + timestamp. The orchestrator (P8a) consumes these files
-# to persist and alert on eval runs.
-# Exports: persist_eval_report
+# to persist and alert on eval runs. P11a adds persist_ralph_report, which
+# mirrors the same filesafe-timestamp + mkdir(parents=True) convention to write
+# a RalphReport (proposal-only investigation) to <output_dir>/ralph/.
+# Exports: persist_eval_report, persist_ralph_report
 # Deps: stdlib (datetime, json, pathlib); src.eval.cli._report_payload (shared
 #       payload builder — single source for the JSON shape).
 # @end-summary
@@ -68,5 +70,62 @@ def persist_eval_report(
     # Filesafe timestamp: colons are illegal on some filesystems, so drop them.
     filesafe_ts = now.isoformat().replace(":", "")
     path = out_dir / f"{pack_name}_{filesafe_ts}.json"
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def persist_ralph_report(
+    report: Any,
+    output_dir: str | Path,
+    *,
+    now: datetime | None = None,
+) -> Path:
+    """Write a :class:`~src.eval.runner.ralph.RalphReport` to a JSON file.
+
+    Mirrors :func:`persist_eval_report`'s conventions: a filesafe ISO timestamp
+    (colons dropped) and ``mkdir(parents=True, exist_ok=True)``. The file lands
+    under ``<output_dir>/ralph/`` named
+    ``<pack_name>_ralph_<filesafe-iso-ts>.json`` and carries all report fields
+    plus the flattened investigations list.
+
+    This is the ONLY write in the Ralph-A surface — the loop itself
+    (:func:`~src.eval.runner.ralph.run_ralph_a`) writes nothing, so persistence
+    is an explicit, opt-in step the CLI performs.
+
+    :param report: the :class:`~src.eval.runner.ralph.RalphReport` to persist.
+    :param output_dir: base directory; the report is written under a ``ralph/``
+        subdirectory (created if absent).
+    :param now: injected timestamp for the filesafe filename; defaults to
+        ``datetime.now(timezone.utc)``. (The payload ``timestamp`` always comes
+        from ``report.timestamp`` — single-sourced with the run.)
+    :returns: the :class:`~pathlib.Path` written.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    payload = {
+        "pack_name": report.pack_name,
+        "timestamp": report.timestamp,
+        "sustained_count": report.sustained_count,
+        "max_iterations": report.max_iterations,
+        "investigations": [
+            {
+                "qtype": inv.qtype,
+                "metric": inv.metric,
+                "runs_regressed": inv.runs_regressed,
+                "window": inv.window,
+                "latest_delta": inv.latest_delta,
+                "diagnosis": inv.diagnosis,
+                "suggested_fix": inv.suggested_fix,
+            }
+            for inv in report.investigations
+        ],
+    }
+
+    out_dir = Path(output_dir) / "ralph"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    filesafe_ts = now.isoformat().replace(":", "")
+    path = out_dir / f"{report.pack_name}_ralph_{filesafe_ts}.json"
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     return path

--- a/src/eval/runner/ralph.py
+++ b/src/eval/runner/ralph.py
@@ -1,0 +1,511 @@
+# @summary
+# P11a — Ralph-A proposal-only eval-failure investigator. run_ralph_a reads a
+# pack's run-history (#140) + sustained-regression detector (#141), ranks the
+# worst regressions worst-first (rank_regressions; exact key = (latest_delta,
+# -runs_regressed, qtype, metric)), and for the top-K invokes a CONSTRAINED
+# headless-`claude` investigator (reusing P14 judge_cli.build_claude_argv +
+# _strip_json_fence so the cost/safety constraint stays single-sourced) to
+# produce a diagnosis + suggested-fix, returning a human-reviewable RalphReport.
+# It NEVER applies patches, commits, opens PRs, or merges: this module imports
+# NO git, runs NO subprocess except the read-only investigator CLI call, and
+# writes NOTHING (persistence is a separate explicit function the CLI calls).
+# Determinism: `now` resolved ONCE at top via datetime.now(timezone.utc);
+# build_investigation_context is pure.
+# Exports: InvestigationProposal, RalphInvestigation, RalphReport,
+#          rank_regressions, select_worst_regression, build_investigation_context,
+#          build_ralph_investigator, run_ralph_a.
+# Deps: stdlib (json, dataclasses, datetime, logging); src.eval.runner.judge_cli
+#       (build_claude_argv, _strip_json_fence, JudgeBackendError — constraint
+#       single-sourced); src.eval.runner.run_history (load_run_history);
+#       src.eval.runner.sustained_regression (detect_sustained_regressions);
+#       src.eval.pack (load_pack — optional, lazy).
+# @end-summary
+"""Ralph-A — a proposal-only investigator for sustained eval regressions.
+
+This is the *read-only, human-in-the-loop* counterpart to a Ralph-style
+auto-fixer. It builds on the run-history index (#140) and the sustained-
+regression detector (#141): rank the worst sustained ``(qtype, metric)``
+regressions, and for the top ``max_iterations`` ask a CONSTRAINED headless
+``claude`` investigator to diagnose the likely cause and suggest a minimal fix.
+
+The output — a :class:`RalphReport` — is purely advisory. By construction this
+module:
+
+* applies NO patches, makes NO commits, opens NO PRs, and merges NOTHING;
+* imports NO git and performs NO subprocess EXCEPT the read-only investigator
+  CLI call (itself tool-free + clean-room via
+  :func:`~src.eval.runner.judge_cli.build_claude_argv`);
+* writes NOTHING — persistence is a *separate* explicit function
+  (:func:`~src.eval.runner.persistence.persist_ralph_report`) the CLI calls.
+
+The investigator's cost/safety constraint is single-sourced with the headless
+judge: :func:`run_ralph_a`'s default investigator reuses
+:func:`~src.eval.runner.judge_cli.build_claude_argv` (``--allowed-tools ""``,
+``--setting-sources ""``, ``--output-format json``, pinned ``--model``) and
+:func:`~src.eval.runner.judge_cli._strip_json_fence`, so a future edit cannot
+silently turn the investigator into the full tool-enabled coding agent.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.eval.runner.judge_cli import (
+    JudgeBackendError,
+    _strip_json_fence,
+    build_claude_argv,
+)
+from src.eval.runner.run_history import load_run_history
+from src.eval.runner.sustained_regression import (
+    SustainedMetricRegression,
+    detect_sustained_regressions,
+)
+
+logger = logging.getLogger("rag.eval.ralph")
+
+# Default investigator model: Haiku is cheap and adequate for a diagnosis.
+_DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+
+# System-prompt rubric: an investigator persona that NEVER applies changes.
+_INVESTIGATOR_RUBRIC = (
+    "You are an eval-regression investigator. Diagnose the likely cause of the "
+    "regression and suggest a minimal fix. You do NOT apply changes."
+)
+
+# Appended to the investigation prompt to force a parseable, prose-free answer.
+_JSON_ONLY_INSTRUCTION = (
+    "\n\nRespond with ONLY a JSON object of the form "
+    '{"diagnosis": <string>, "suggested_fix": <string>} '
+    "— no prose, no markdown, no code fences."
+)
+
+# How many recent history entries to summarize in the investigation context.
+_CONTEXT_TRAIL = 6
+# How many goldens of the target qtype to include in the context (when a pack
+# is provided).
+_CONTEXT_GOLDENS = 3
+
+
+# ---------------------------------------------------------------------------
+# Frozen contracts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InvestigationProposal:
+    """What an ``investigate_fn`` returns for one regression target.
+
+    :param diagnosis: the investigator's likely-cause analysis.
+    :param suggested_fix: a minimal suggested fix (advisory — never applied).
+    """
+
+    diagnosis: str
+    suggested_fix: str
+
+
+@dataclass(frozen=True)
+class RalphInvestigation:
+    """One recorded investigation: the target fields flattened + the proposal.
+
+    :param qtype: the golden question-type the regressed metric aggregates over.
+    :param metric: the regressed metric label (``recall`` / ``mrr`` /
+        ``faithfulness``).
+    :param runs_regressed: how many considered runs regressed for this pair.
+    :param window: the number of recent runs the detector considered.
+    :param latest_delta: the most-recent delta for this pair (negative = worse).
+    :param diagnosis: the investigator's likely-cause analysis.
+    :param suggested_fix: the investigator's advisory minimal fix.
+    """
+
+    qtype: str
+    metric: str
+    runs_regressed: int
+    window: int
+    latest_delta: float
+    diagnosis: str
+    suggested_fix: str
+
+
+@dataclass(frozen=True)
+class RalphReport:
+    """The human-reviewable result of a Ralph-A run.
+
+    :param pack_name: the pack investigated.
+    :param timestamp: ISO-8601 string of the run's resolved ``now``.
+    :param sustained_count: how many sustained regressions the detector found
+        (may exceed ``len(investigations)`` when ``max_iterations`` truncates).
+    :param max_iterations: the top-K cap applied to investigations.
+    :param investigations: the recorded investigations, worst-first.
+    """
+
+    pack_name: str
+    timestamp: str
+    sustained_count: int
+    max_iterations: int
+    investigations: tuple[RalphInvestigation, ...]
+
+
+# ---------------------------------------------------------------------------
+# Ranking — deterministic, worst-first
+# ---------------------------------------------------------------------------
+
+
+def rank_regressions(
+    sustained: Any,
+) -> list[SustainedMetricRegression]:
+    """Sort sustained regressions worst-first, deterministically.
+
+    The EXACT key is ``(latest_delta, -runs_regressed, qtype, metric)``:
+
+    * most-negative ``latest_delta`` first (the worst regression),
+    * ties broken by MORE ``runs_regressed`` (``-runs_regressed`` ascending),
+    * then ``qtype`` then ``metric`` for total determinism.
+
+    :param sustained: an iterable of :class:`SustainedMetricRegression`.
+    :returns: a new worst-first sorted list.
+    """
+    return sorted(
+        sustained,
+        key=lambda r: (r.latest_delta, -r.runs_regressed, r.qtype, r.metric),
+    )
+
+
+def select_worst_regression(
+    sustained: Any,
+) -> SustainedMetricRegression | None:
+    """Return the single worst sustained regression, or ``None`` when empty."""
+    ranked = rank_regressions(sustained)
+    return ranked[0] if ranked else None
+
+
+# ---------------------------------------------------------------------------
+# Investigation context — deterministic, pure
+# ---------------------------------------------------------------------------
+
+
+def build_investigation_context(
+    target: SustainedMetricRegression,
+    history: list[dict],
+    pack: Any | None = None,
+) -> str:
+    """Build a deterministic, pure investigation-context string for *target*.
+
+    Summarizes (no I/O beyond what is passed in):
+
+    * the target — qtype, metric, latest_delta, runs_regressed, window;
+    * the per-qtype delta trail for that ``(qtype, metric)`` across the most
+      recent history entries (timestamp + delta, oldest→newest);
+    * IF ``pack`` is provided — up to :data:`_CONTEXT_GOLDENS` goldens of the
+      target qtype (qid + query + expected_answer_span).
+
+    :param target: the regression to investigate.
+    :param history: the run-history entries (timestamp-ascending).
+    :param pack: an optional :class:`~src.eval.pack.schema.EvalPack` for golden
+        context; ``None`` omits the goldens section.
+    :returns: a stable multi-line context string (identical for identical
+        inputs).
+    """
+    lines: list[str] = []
+    lines.append("# Eval regression to investigate")
+    lines.append(f"qtype: {target.qtype}")
+    lines.append(f"metric: {target.metric}")
+    lines.append(f"latest_delta: {target.latest_delta}")
+    lines.append(
+        f"runs_regressed: {target.runs_regressed} of window {target.window}"
+    )
+    lines.append("(delta = current - baseline; negative = worse)")
+
+    # Per-qtype delta trail for THIS (qtype, metric), oldest→newest.
+    trail = history[-_CONTEXT_TRAIL:]
+    lines.append("")
+    lines.append("## Recent delta trail for this (qtype, metric)")
+    any_trail = False
+    for entry in trail:
+        per_qtype = entry.get("per_qtype_deltas") or {}
+        metric_map = per_qtype.get(target.qtype) or {}
+        if target.metric not in metric_map:
+            continue
+        any_trail = True
+        ts = entry.get("timestamp", "")
+        lines.append(f"- {ts}: delta={metric_map[target.metric]}")
+    if not any_trail:
+        lines.append("(no recorded deltas for this pair in the recent trail)")
+
+    # Optional goldens of the target qtype.
+    if pack is not None:
+        goldens = getattr(pack, "goldens", {}) or {}
+        qtype_goldens = list(goldens.get(target.qtype, []))[:_CONTEXT_GOLDENS]
+        if qtype_goldens:
+            lines.append("")
+            lines.append(f"## Sample {target.qtype} goldens")
+            for g in qtype_goldens:
+                span = getattr(g, "expected_answer_span", None)
+                lines.append(
+                    f"- qid={getattr(g, 'qid', '')} "
+                    f"query={getattr(g, 'query', '')!r} "
+                    f"expected_answer_span={span!r}"
+                )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Default investigator — constrained headless `claude` (reuses judge_cli)
+# ---------------------------------------------------------------------------
+
+
+def _default_run_fn(argv: list[str], *, timeout: float):
+    """Default runner: spawn the real ``claude`` CLI via subprocess.run.
+
+    This is the ONLY subprocess this module ever performs — a read-only,
+    tool-free, clean-room investigation call (the argv is built by
+    :func:`~src.eval.runner.judge_cli.build_claude_argv`).
+    """
+    return subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _build_investigation_prompt(
+    target: SustainedMetricRegression, context: str
+) -> str:
+    """Assemble the investigation prompt (target + context + JSON instruction)."""
+    return (
+        "Investigate the following sustained eval regression and propose a "
+        "minimal fix. Do NOT apply any changes.\n\n"
+        f"{context}"
+        f"{_JSON_ONLY_INSTRUCTION}"
+    )
+
+
+def _parse_proposal_envelope(stdout: str) -> InvestigationProposal:
+    """Parse the ``--output-format json`` envelope into an InvestigationProposal.
+
+    Reuses :func:`~src.eval.runner.judge_cli._strip_json_fence` so fence
+    handling stays single-sourced with the judge backend. Raises
+    :class:`~src.eval.runner.judge_cli.JudgeBackendError` on any failure.
+    """
+    try:
+        envelope = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise JudgeBackendError(
+            f"ralph investigator returned unparseable envelope JSON: {exc}"
+        ) from exc
+
+    if envelope.get("is_error") is not False:
+        raise JudgeBackendError(
+            f"ralph investigator envelope reported an error: "
+            f"is_error={envelope.get('is_error')!r}"
+        )
+    if envelope.get("subtype") != "success":
+        raise JudgeBackendError(
+            f"ralph investigator envelope subtype was not 'success': "
+            f"{envelope.get('subtype')!r}"
+        )
+
+    result = envelope.get("result")
+    if not result or not isinstance(result, str):
+        raise JudgeBackendError(
+            f"ralph investigator envelope missing/empty .result: {result!r}"
+        )
+
+    payload_text = _strip_json_fence(result)
+    try:
+        payload = json.loads(payload_text)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise JudgeBackendError(
+            f"ralph investigator .result was not parseable JSON: {exc}"
+        ) from exc
+
+    try:
+        diagnosis = str(payload["diagnosis"])
+        suggested_fix = str(payload["suggested_fix"])
+    except (KeyError, TypeError) as exc:
+        raise JudgeBackendError(
+            f"ralph investigator .result missing diagnosis/suggested_fix: {exc}"
+        ) from exc
+
+    return InvestigationProposal(diagnosis=diagnosis, suggested_fix=suggested_fix)
+
+
+def build_ralph_investigator(
+    *,
+    model: str = _DEFAULT_MODEL,
+    run_fn: Callable[..., Any] | None = None,
+    timeout: float = 60.0,
+) -> Callable[[SustainedMetricRegression, str], InvestigationProposal]:
+    """Build the default ``investigate_fn`` — a constrained headless investigator.
+
+    The returned callable, given ``(target, context)``:
+
+    * builds an investigation prompt (context + a strict JSON-only instruction),
+    * builds the constrained argv via
+      :func:`~src.eval.runner.judge_cli.build_claude_argv` (the cost/safety
+      constraint — ``--allowed-tools ""``, ``--setting-sources ""``,
+      ``--output-format json``, pinned ``--model`` — is single-sourced there),
+    * runs it via ``run_fn`` (default real :func:`subprocess.run`),
+    * parses the envelope into an :class:`InvestigationProposal`, raising
+      :class:`~src.eval.runner.judge_cli.JudgeBackendError` on any failure.
+
+    :param model: investigator model (Haiku by default — cheap).
+    :param run_fn: testability seam ``(argv, *, timeout) -> obj`` exposing
+        ``.returncode`` / ``.stdout`` / ``.stderr``; ``None`` uses subprocess.
+    :param timeout: per-call subprocess timeout in seconds.
+    """
+    runner = run_fn if run_fn is not None else _default_run_fn
+
+    def _investigate(
+        target: SustainedMetricRegression, context: str
+    ) -> InvestigationProposal:
+        prompt = _build_investigation_prompt(target, context)
+        argv = build_claude_argv(
+            prompt, model=model, system_prompt=_INVESTIGATOR_RUBRIC
+        )
+        try:
+            completed = runner(argv, timeout=timeout)
+        except subprocess.TimeoutExpired as exc:
+            raise JudgeBackendError(
+                f"ralph investigator timed out after {timeout}s"
+            ) from exc
+
+        if completed.returncode != 0:
+            raise JudgeBackendError(
+                f"ralph investigator exited with code {completed.returncode}: "
+                f"{(completed.stderr or '').strip()[:500]}"
+            )
+
+        return _parse_proposal_envelope(completed.stdout)
+
+    return _investigate
+
+
+# ---------------------------------------------------------------------------
+# The loop — run_ralph_a
+# ---------------------------------------------------------------------------
+
+
+def run_ralph_a(
+    pack_name: str,
+    *,
+    history_dir: str | Path,
+    pack_dir: str | Path | None = None,
+    max_iterations: int = 3,
+    window: int = 3,
+    min_regressed: int = 2,
+    epsilon: float = 0.05,
+    investigate_fn: Callable[
+        [SustainedMetricRegression, str], InvestigationProposal
+    ]
+    | None = None,
+    now: datetime | None = None,
+) -> RalphReport:
+    """Investigate a pack's worst sustained regressions — proposal-only.
+
+    Reads the run-history (:func:`~src.eval.runner.run_history.load_run_history`),
+    detects sustained regressions
+    (:func:`~src.eval.runner.sustained_regression.detect_sustained_regressions`),
+    ranks them worst-first (:func:`rank_regressions`), and for the top
+    ``max_iterations`` invokes ``investigate_fn`` to produce a diagnosis +
+    suggested fix. Returns a :class:`RalphReport`.
+
+    NEVER mutates anything: imports no git, performs no subprocess except the
+    read-only investigator CLI call, and writes nothing (persistence is the
+    caller's explicit concern via
+    :func:`~src.eval.runner.persistence.persist_ralph_report`).
+
+    :param pack_name: the pack whose ``<pack_name>.history.jsonl`` lives under
+        ``history_dir``.
+    :param history_dir: directory holding the run-history index.
+    :param pack_dir: optional pack directory for golden context; a missing/bad
+        pack dir degrades to no-goldens rather than crashing the run.
+    :param max_iterations: top-K worst regressions to investigate (default 3).
+    :param window: detector lookback (default 3).
+    :param min_regressed: min regressed runs in the window to flag (default 2).
+    :param epsilon: regression tolerance band, strict ``delta < -epsilon``.
+    :param investigate_fn: the per-target investigator; ``None`` lazily builds
+        the default constrained headless investigator — but ONLY when there is
+        something to investigate.
+    :param now: injected timestamp, resolved ONCE at top for determinism;
+        defaults to ``datetime.now(timezone.utc)``.
+    :returns: a :class:`RalphReport`.
+    """
+    # Resolve `now` ONCE at the top (determinism convention).
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    history = load_run_history(pack_name, history_dir)
+    sustained = detect_sustained_regressions(
+        history,
+        window=window,
+        min_regressed=min_regressed,
+        epsilon=epsilon,
+    )
+
+    # No sustained regressions → never invoke the investigator.
+    if not sustained:
+        return RalphReport(
+            pack_name=pack_name,
+            timestamp=now.isoformat(),
+            sustained_count=0,
+            max_iterations=max_iterations,
+            investigations=(),
+        )
+
+    ranked = rank_regressions(sustained)
+    targets = ranked[:max_iterations]
+
+    # Lazily build the default investigator — only now that there is work.
+    if investigate_fn is None:
+        investigate_fn = build_ralph_investigator()
+
+    # Optional pack load for golden context — a missing/bad pack dir must NOT
+    # crash the investigation (deliberate broad-ish degrade, narrowed to the
+    # known load failures).
+    pack = None
+    if pack_dir is not None:
+        from src.eval.pack import load_pack
+        from src.eval.pack.errors import PackValidationError
+
+        try:
+            pack = load_pack(pack_dir)
+        except (PackValidationError, FileNotFoundError, OSError) as exc:
+            logger.warning(
+                "ralph: could not load pack at %s for golden context (%s); "
+                "proceeding without goldens",
+                pack_dir,
+                exc,
+            )
+            pack = None
+
+    investigations: list[RalphInvestigation] = []
+    for target in targets:
+        context = build_investigation_context(target, history, pack)
+        proposal = investigate_fn(target, context)
+        investigations.append(
+            RalphInvestigation(
+                qtype=target.qtype,
+                metric=target.metric,
+                runs_regressed=target.runs_regressed,
+                window=target.window,
+                latest_delta=target.latest_delta,
+                diagnosis=proposal.diagnosis,
+                suggested_fix=proposal.suggested_fix,
+            )
+        )
+
+    return RalphReport(
+        pack_name=pack_name,
+        timestamp=now.isoformat(),
+        sustained_count=len(sustained),
+        max_iterations=max_iterations,
+        investigations=tuple(investigations),
+    )

--- a/tests/eval/test_ralph.py
+++ b/tests/eval/test_ralph.py
@@ -1,0 +1,622 @@
+# @summary
+# Tests for P11a — the Ralph-A proposal-only eval-failure investigator
+# (src/eval/runner/ralph.py + persist_ralph_report + the `ralph` CLI
+# subcommand). The HEADLINE test proves run_ralph_a ranks sustained
+# regressions worst-first, investigates the top-K via an injected fake
+# investigate_fn, returns a human-reviewable RalphReport, and — EMPIRICALLY —
+# NEVER mutates the repo/cwd/pack tree (byte-identical snapshot + clean
+# `git status --porcelain` before/after). Unit tests pin the exact ranking
+# key (mutation-aware), the no-sustained no-op, max_iterations truncation,
+# persistence filename/round-trip, the default investigator's envelope
+# parsing + every JudgeBackendError raise path, the constrained argv contract,
+# and the argv→handler CLI wiring. One model-gated live test (never run here).
+# Exports: test_run_ralph_a_investigates_worst_first_and_never_mutates,
+#          test_run_ralph_a_no_sustained_is_noop,
+#          test_rank_regressions_orders_worst_first,
+#          test_run_ralph_a_respects_max_iterations,
+#          test_persist_ralph_report_shape,
+#          test_build_ralph_investigator_parses_proposal,
+#          test_ralph_investigator_argv_is_constrained,
+#          test_ralph_cli_dispatch_returns_int,
+#          test_ralph_investigator_real_claude
+# Deps: src.eval.runner.ralph, src.eval.runner.persistence, src.eval.cli
+# @end-summary
+"""Tests for the Ralph-A proposal-only investigator (P11a).
+
+All fast tests inject a fake ``investigate_fn`` (or a fake ``run_fn`` for the
+default investigator), so NO ``claude`` process is ever spawned and NO
+Weaviate/embeddings/LLM are touched. The one live test is double-gated on a
+``claude`` binary on PATH AND an explicit opt-in env var.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# History-seeding helpers (mirror tests/eval/test_show_trend.py)
+# ---------------------------------------------------------------------------
+
+
+def _write_history(tmp_path: Path, pack: str, entries: list[dict]) -> None:
+    """Hand-seed a ``<pack>.history.jsonl`` index (one JSON line per entry)."""
+    path = tmp_path / f"{pack}.history.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def _entry(ts: str, per_qtype_deltas: dict) -> dict:
+    """A minimal history entry carrying only what the detector reads."""
+    return {
+        "timestamp": ts,
+        "pack_name": "p",
+        "k": 5,
+        "gate_passed": True,
+        "per_query_deltas": {},
+        "per_qtype_deltas": per_qtype_deltas,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fake investigate_fn helpers
+# ---------------------------------------------------------------------------
+
+
+def _recording_investigate_fn(recorder: list):
+    """A fake investigate_fn that records target order and returns canned text."""
+    from src.eval.runner.ralph import InvestigationProposal
+
+    def _fn(target, context):
+        recorder.append(target)
+        return InvestigationProposal(
+            diagnosis=f"diag::{target.qtype}/{target.metric}",
+            suggested_fix=f"fix::{target.qtype}/{target.metric}",
+        )
+
+    return _fn
+
+
+def _raising_investigate_fn(target, context):
+    """A fake investigate_fn that fails the test if it is ever called."""
+    raise AssertionError("investigate_fn must NOT be called when no sustained")
+
+
+# ---------------------------------------------------------------------------
+# Empirical no-mutation snapshot helper
+# ---------------------------------------------------------------------------
+
+
+def _tree_snapshot(*roots: Path) -> set[tuple[str, float, int]]:
+    """Snapshot (path, mtime, size) for every file under each root.
+
+    This is the empirical teeth behind the never-mutate invariant: a created,
+    modified, or deleted file changes the set, so an identical set proves the
+    file tree is byte-stable across a run.
+    """
+    snap: set[tuple[str, float, int]] = set()
+    for root in roots:
+        if not root.exists():
+            continue
+        for p in sorted(root.rglob("*")):
+            if p.is_file():
+                st = p.stat()
+                snap.add((str(p), st.st_mtime, st.st_size))
+    return snap
+
+
+# ===========================================================================
+# HEADLINE RED — worst-first investigation + EMPIRICAL never-mutate
+# ===========================================================================
+
+
+def test_run_ralph_a_investigates_worst_first_and_never_mutates(
+    tmp_path: Path,
+) -> None:
+    """Worst regression is investigated first; the run mutates NOTHING.
+
+    Seeds a history producing TWO sustained regressions of distinct severity
+    (factoid/recall at -0.40 is worse than lookup/mrr at -0.10). With
+    max_iterations=1 only the WORST must be investigated, the canned proposal
+    must flow into the single RalphInvestigation, and — empirically — the cwd +
+    pack-dir file tree AND `git status --porcelain` must be byte-identical
+    before and after.
+    """
+    from src.eval.runner.ralph import RalphReport, run_ralph_a
+
+    pack = "p"
+    # Both pairs regress in 3/3 runs (sustained). factoid/recall is the worse
+    # latest_delta, so it must be ranked + investigated first.
+    _write_history(
+        tmp_path,
+        pack,
+        [
+            _entry("2026-01-01T00:00:00", {"factoid": {"recall": -0.40},
+                                           "lookup": {"mrr": -0.10}}),
+            _entry("2026-01-02T00:00:00", {"factoid": {"recall": -0.40},
+                                           "lookup": {"mrr": -0.10}}),
+            _entry("2026-01-03T00:00:00", {"factoid": {"recall": -0.40},
+                                           "lookup": {"mrr": -0.10}}),
+        ],
+    )
+
+    recorder: list = []
+    investigate_fn = _recording_investigate_fn(recorder)
+
+    # Snapshot the worktree (cwd) + the tmp history dir BEFORE the run.
+    cwd = Path.cwd()
+    git_before = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=cwd, capture_output=True, text=True,
+    ).stdout
+    snap_before = _tree_snapshot(cwd, tmp_path)
+
+    report = run_ralph_a(
+        pack,
+        history_dir=tmp_path,
+        max_iterations=1,
+        investigate_fn=investigate_fn,
+    )
+
+    snap_after = _tree_snapshot(cwd, tmp_path)
+    git_after = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=cwd, capture_output=True, text=True,
+    ).stdout
+
+    # (a) the WORST target (most-negative latest_delta) was investigated first.
+    assert recorder, "investigate_fn was never called"
+    assert (recorder[0].qtype, recorder[0].metric) == ("factoid", "recall")
+
+    # (b) exactly one investigation, carrying the canned proposal.
+    assert isinstance(report, RalphReport)
+    assert report.pack_name == pack
+    assert report.sustained_count == 2
+    assert report.max_iterations == 1
+    assert len(report.investigations) == 1
+    inv = report.investigations[0]
+    assert inv.qtype == "factoid" and inv.metric == "recall"
+    assert inv.latest_delta == pytest.approx(-0.40)
+    assert inv.runs_regressed == 3
+    assert inv.diagnosis == "diag::factoid/recall"
+    assert inv.suggested_fix == "fix::factoid/recall"
+
+    # (c) EMPIRICAL no-mutation: tree + git status byte-identical.
+    assert snap_after == snap_before, (
+        "run_ralph_a mutated the file tree:\n"
+        f"created/changed: {sorted(snap_after - snap_before)}\n"
+        f"removed: {sorted(snap_before - snap_after)}"
+    )
+    assert git_after == git_before, "run_ralph_a changed `git status --porcelain`"
+
+
+# ===========================================================================
+# No sustained → no-op (investigate_fn never called)
+# ===========================================================================
+
+
+def test_run_ralph_a_no_sustained_is_noop(tmp_path: Path) -> None:
+    """A clean history → sustained_count 0, no investigations, fn never called."""
+    from src.eval.runner.ralph import run_ralph_a
+
+    pack = "p"
+    _write_history(
+        tmp_path,
+        pack,
+        [
+            _entry("2026-01-01T00:00:00", {"factoid": {"recall": 0.10}}),
+            _entry("2026-01-02T00:00:00", {"factoid": {"recall": 0.02}}),
+            _entry("2026-01-03T00:00:00", {"factoid": {"recall": 0.05}}),
+        ],
+    )
+
+    report = run_ralph_a(
+        pack,
+        history_dir=tmp_path,
+        investigate_fn=_raising_investigate_fn,
+    )
+    assert report.sustained_count == 0
+    assert report.investigations == ()
+
+
+# ===========================================================================
+# rank_regressions — EXACT key, mutation-aware
+# ===========================================================================
+
+
+def test_rank_regressions_orders_worst_first() -> None:
+    """The exact sort key (latest_delta, -runs_regressed, qtype, metric) is pinned.
+
+    Cases chosen so each tie-break level is load-bearing:
+      * R_worst: most-negative delta (-0.50) but FEWEST runs (2) -> still FIRST
+        (delta dominates runs_regressed).
+      * R_a / R_b: SAME delta (-0.20); R_a has MORE runs (3 > 2) -> R_a before
+        R_b (more runs_regressed wins on a delta tie).
+      * R_q: same delta+runs as R_b but qtype "z" sorts after "a" -> last.
+    """
+    from src.eval.runner.ralph import rank_regressions
+    from src.eval.runner.sustained_regression import SustainedMetricRegression
+
+    r_worst = SustainedMetricRegression("factoid", "recall", 2, 3, -0.50)
+    r_a = SustainedMetricRegression("alpha", "mrr", 3, 3, -0.20)
+    r_b = SustainedMetricRegression("alpha", "recall", 2, 3, -0.20)
+    r_q = SustainedMetricRegression("zeta", "recall", 2, 3, -0.20)
+
+    # Feed in a deliberately scrambled order.
+    ranked = rank_regressions([r_b, r_q, r_worst, r_a])
+    assert ranked == [r_worst, r_a, r_b, r_q]
+
+
+def test_select_worst_regression_picks_head_or_none() -> None:
+    """select_worst_regression returns the ranked head, or None when empty."""
+    from src.eval.runner.ralph import select_worst_regression
+    from src.eval.runner.sustained_regression import SustainedMetricRegression
+
+    assert select_worst_regression(()) is None
+    a = SustainedMetricRegression("a", "recall", 2, 3, -0.10)
+    b = SustainedMetricRegression("b", "recall", 2, 3, -0.40)
+    assert select_worst_regression((a, b)) == b
+
+
+# ===========================================================================
+# max_iterations truncation
+# ===========================================================================
+
+
+def test_run_ralph_a_respects_max_iterations(tmp_path: Path) -> None:
+    """3 sustained, max_iterations=2 → top-2 worst investigated; 3rd detected only."""
+    from src.eval.runner.ralph import run_ralph_a
+
+    pack = "p"
+    # Three distinct sustained severities: -0.40 (worst), -0.25, -0.10 (mildest).
+    deltas = {
+        "factoid": {"recall": -0.40},
+        "lookup": {"mrr": -0.25},
+        "howto": {"faithfulness": -0.10},
+    }
+    _write_history(
+        tmp_path,
+        pack,
+        [
+            _entry("2026-01-01T00:00:00", deltas),
+            _entry("2026-01-02T00:00:00", deltas),
+            _entry("2026-01-03T00:00:00", deltas),
+        ],
+    )
+
+    recorder: list = []
+    report = run_ralph_a(
+        pack,
+        history_dir=tmp_path,
+        max_iterations=2,
+        investigate_fn=_recording_investigate_fn(recorder),
+    )
+
+    assert report.sustained_count == 3
+    assert len(report.investigations) == 2
+    investigated = [(i.qtype, i.metric) for i in report.investigations]
+    assert investigated == [("factoid", "recall"), ("lookup", "mrr")]
+    # The mildest (howto/faithfulness) was detected but NOT investigated.
+    assert ("howto", "faithfulness") not in investigated
+
+
+# ===========================================================================
+# persist_ralph_report — filename + round-trip
+# ===========================================================================
+
+
+def test_persist_ralph_report_shape(tmp_path: Path) -> None:
+    """persist_ralph_report writes <pack>_ralph_<ts>.json under ralph/ + round-trips."""
+    from datetime import datetime, timezone
+
+    from src.eval.runner.persistence import persist_ralph_report
+    from src.eval.runner.ralph import RalphInvestigation, RalphReport
+
+    now = datetime(2026, 6, 2, 12, 30, 45, tzinfo=timezone.utc)
+    report = RalphReport(
+        pack_name="mypack",
+        timestamp=now.isoformat(),
+        sustained_count=2,
+        max_iterations=1,
+        investigations=(
+            RalphInvestigation(
+                qtype="factoid",
+                metric="recall",
+                runs_regressed=3,
+                window=3,
+                latest_delta=-0.40,
+                diagnosis="recall dropped after chunker change",
+                suggested_fix="revert chunk overlap to 64",
+            ),
+        ),
+    )
+
+    out_dir = tmp_path / "out"
+    path = persist_ralph_report(report, out_dir, now=now)
+
+    filesafe_ts = now.isoformat().replace(":", "")
+    assert path == out_dir / "ralph" / f"mypack_ralph_{filesafe_ts}.json"
+    assert path.is_file()
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["pack_name"] == "mypack"
+    assert payload["timestamp"] == now.isoformat()
+    assert payload["sustained_count"] == 2
+    assert payload["max_iterations"] == 1
+    assert len(payload["investigations"]) == 1
+    pinv = payload["investigations"][0]
+    assert pinv["qtype"] == "factoid"
+    assert pinv["metric"] == "recall"
+    assert pinv["runs_regressed"] == 3
+    assert pinv["window"] == 3
+    assert pinv["latest_delta"] == pytest.approx(-0.40)
+    assert pinv["diagnosis"] == "recall dropped after chunker change"
+    assert pinv["suggested_fix"] == "revert chunk overlap to 64"
+
+
+# ===========================================================================
+# build_ralph_investigator — envelope parsing + raise paths
+# ===========================================================================
+
+
+def _success_envelope(result_payload: str) -> str:
+    """Serialize a VERIFIED-shape success envelope with a stringified result."""
+    return json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": result_payload,
+        }
+    )
+
+
+def _make_run_fn(envelope_stdout: str, *, returncode: int = 0, capture: list | None = None):
+    """Return a (argv, *, timeout) -> result callable serving a canned stdout."""
+
+    def _run_fn(argv, *, timeout):
+        if capture is not None:
+            capture.append(argv)
+        return SimpleNamespace(returncode=returncode, stdout=envelope_stdout, stderr="")
+
+    return _run_fn
+
+
+def _target():
+    from src.eval.runner.sustained_regression import SustainedMetricRegression
+
+    return SustainedMetricRegression("factoid", "recall", 3, 3, -0.40)
+
+
+def test_build_ralph_investigator_parses_proposal() -> None:
+    """The default investigator parses a success envelope into InvestigationProposal."""
+    from src.eval.runner.ralph import InvestigationProposal, build_ralph_investigator
+
+    run_fn = _make_run_fn(
+        _success_envelope(json.dumps({"diagnosis": "D", "suggested_fix": "F"}))
+    )
+    investigate = build_ralph_investigator(run_fn=run_fn)
+    out = investigate(_target(), "CONTEXT")
+    assert isinstance(out, InvestigationProposal)
+    assert out.diagnosis == "D"
+    assert out.suggested_fix == "F"
+
+
+def test_build_ralph_investigator_strips_fence() -> None:
+    """A ```json ... ``` fenced result is stripped before parsing."""
+    from src.eval.runner.ralph import build_ralph_investigator
+
+    fenced = "```json\n" + json.dumps({"diagnosis": "D", "suggested_fix": "F"}) + "\n```"
+    investigate = build_ralph_investigator(run_fn=_make_run_fn(_success_envelope(fenced)))
+    out = investigate(_target(), "CONTEXT")
+    assert out.diagnosis == "D"
+    assert out.suggested_fix == "F"
+
+
+def test_build_ralph_investigator_is_error_raises() -> None:
+    """is_error: true raises JudgeBackendError (valid payload so guard is the cause)."""
+    from src.eval.runner.judge_cli import JudgeBackendError
+    from src.eval.runner.ralph import build_ralph_investigator
+
+    envelope = json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": True,
+            "result": json.dumps({"diagnosis": "D", "suggested_fix": "F"}),
+        }
+    )
+    investigate = build_ralph_investigator(run_fn=_make_run_fn(envelope))
+    with pytest.raises(JudgeBackendError):
+        investigate(_target(), "CONTEXT")
+
+
+def test_build_ralph_investigator_unparseable_raises() -> None:
+    """A non-JSON result payload raises JudgeBackendError."""
+    from src.eval.runner.judge_cli import JudgeBackendError
+    from src.eval.runner.ralph import build_ralph_investigator
+
+    investigate = build_ralph_investigator(
+        run_fn=_make_run_fn(_success_envelope("not json at all"))
+    )
+    with pytest.raises(JudgeBackendError):
+        investigate(_target(), "CONTEXT")
+
+
+def test_build_ralph_investigator_nonzero_returncode_raises() -> None:
+    """A non-zero CLI returncode raises JudgeBackendError before parsing."""
+    from src.eval.runner.judge_cli import JudgeBackendError
+    from src.eval.runner.ralph import build_ralph_investigator
+
+    investigate = build_ralph_investigator(
+        run_fn=_make_run_fn(
+            _success_envelope(json.dumps({"diagnosis": "D", "suggested_fix": "F"})),
+            returncode=1,
+        )
+    )
+    with pytest.raises(JudgeBackendError):
+        investigate(_target(), "CONTEXT")
+
+
+# ===========================================================================
+# argv constraint contract — single-sourced via build_claude_argv
+# ===========================================================================
+
+
+def test_ralph_investigator_argv_is_constrained() -> None:
+    """The investigator's argv carries the cost/safety constraints.
+
+    Pins --model, --system-prompt, --allowed-tools, --setting-sources, and
+    --output-format json so a future edit can't silently turn the investigator
+    into the full (expensive, tool-enabled) coding agent that could mutate.
+    """
+    from src.eval.runner.ralph import build_ralph_investigator
+
+    captured: list = []
+    run_fn = _make_run_fn(
+        _success_envelope(json.dumps({"diagnosis": "D", "suggested_fix": "F"})),
+        capture=captured,
+    )
+    investigate = build_ralph_investigator(run_fn=run_fn, model="claude-haiku-4-5-20251001")
+    investigate(_target(), "CONTEXT")
+
+    assert captured, "run_fn was never invoked"
+    argv = captured[0]
+    assert argv[0] == "claude"
+
+    def _val(flag):
+        return argv[argv.index(flag) + 1]
+
+    assert "--model" in argv and _val("--model") == "claude-haiku-4-5-20251001"
+    assert "--system-prompt" in argv
+    assert "--output-format" in argv and _val("--output-format") == "json"
+    # No tools, clean room — the never-mutate guard at the CLI level.
+    assert "--allowed-tools" in argv and _val("--allowed-tools") == ""
+    assert "--setting-sources" in argv and _val("--setting-sources") == ""
+
+
+# ===========================================================================
+# build_investigation_context — deterministic, pure
+# ===========================================================================
+
+
+def test_build_investigation_context_is_pure_and_summarizes(tmp_path: Path) -> None:
+    """Context summarizes the target + delta trail; includes goldens when pack given."""
+    from src.eval.runner.ralph import build_investigation_context
+
+    history = [
+        _entry("2026-01-01T00:00:00", {"factoid": {"recall": -0.40}}),
+        _entry("2026-01-02T00:00:00", {"factoid": {"recall": -0.40}}),
+    ]
+    target = _target()
+    ctx = build_investigation_context(target, history, None)
+    assert isinstance(ctx, str)
+    assert "factoid" in ctx and "recall" in ctx
+    assert "-0.4" in ctx
+    # Pure: calling twice with the same inputs yields the same string.
+    assert build_investigation_context(target, history, None) == ctx
+
+
+# ===========================================================================
+# CLI dispatch — argv→handler wiring
+# ===========================================================================
+
+
+def test_ralph_cli_dispatch_returns_int(tmp_path: Path, capsys) -> None:
+    """main(['ralph', pack, ...]) returns int 0, prints markdown, persists a file."""
+    from src.eval.cli import main
+    from src.eval.runner.ralph import InvestigationProposal
+
+    pack = "p"
+    _write_history(
+        tmp_path,
+        pack,
+        [
+            _entry("2026-01-01T00:00:00", {"factoid": {"recall": -0.40}}),
+            _entry("2026-01-02T00:00:00", {"factoid": {"recall": -0.40}}),
+            _entry("2026-01-03T00:00:00", {"factoid": {"recall": -0.40}}),
+        ],
+    )
+
+    def fake_investigate(target, context):
+        return InvestigationProposal(diagnosis="DIAG-CLI", suggested_fix="FIX-CLI")
+
+    # Drive the public handler directly with an injected fake (no real claude).
+    from src.eval.cli import ralph as ralph_handler
+
+    rc = ralph_handler(
+        pack,
+        reports_dir=str(tmp_path),
+        investigate_fn=fake_investigate,
+    )
+    assert isinstance(rc, int)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "DIAG-CLI" in out
+    assert "FIX-CLI" in out
+    # A ralph report file was persisted under <reports-dir>/ralph/.
+    persisted = list((tmp_path / "ralph").glob("p_ralph_*.json"))
+    assert persisted, "no ralph report persisted"
+
+
+def test_ralph_cli_main_argv_wires_to_handler(tmp_path: Path, monkeypatch) -> None:
+    """main(['ralph', ...]) parses argv and dispatches to the ralph handler.
+
+    Spies the handler to prove the argv→handler wiring (independent of the real
+    investigator), and pins that main() returns the handler's int.
+    """
+    from src.eval import cli as cli_mod
+
+    calls: list = []
+
+    def spy_ralph(pack, **kwargs):
+        calls.append((pack, kwargs))
+        return 0
+
+    monkeypatch.setattr(cli_mod, "ralph", spy_ralph)
+    rc = cli_mod.main(["ralph", "p", "--reports-dir", str(tmp_path), "--max-iterations", "2"])
+    assert rc == 0
+    assert calls, "ralph handler was never dispatched"
+    pack, kwargs = calls[0]
+    assert pack == "p"
+    assert kwargs["reports_dir"] == str(tmp_path)
+    assert kwargs["max_iterations"] == 2
+
+
+# ===========================================================================
+# MODEL-GATED REAL TEST — live claude CLI (double opt-in)
+# ===========================================================================
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_ralph_investigator_real_claude() -> None:
+    """Investigate one synthetic target with a real `claude` CLI.
+
+    Double-gated: skipped unless a `claude` binary is on PATH AND the explicit
+    RAGWEAVE_EVAL_CLI_LIVE=1 opt-in is set, so it never runs by accident.
+    """
+    if not shutil.which("claude"):
+        pytest.skip("no `claude` binary on PATH")
+    if os.environ.get("RAGWEAVE_EVAL_CLI_LIVE") != "1":
+        pytest.skip("RAGWEAVE_EVAL_CLI_LIVE != 1 (live investigator opt-in not set)")
+
+    from src.eval.runner.ralph import build_investigation_context, build_ralph_investigator
+
+    target = _target()
+    history = [
+        _entry("2026-01-01T00:00:00", {"factoid": {"recall": -0.40}}),
+        _entry("2026-01-02T00:00:00", {"factoid": {"recall": -0.40}}),
+    ]
+    context = build_investigation_context(target, history, None)
+    investigate = build_ralph_investigator()
+    out = investigate(target, context)
+    assert out.diagnosis.strip()
+    assert out.suggested_fix.strip()

--- a/tests/eval/test_ralph.py
+++ b/tests/eval/test_ralph.py
@@ -307,6 +307,59 @@ def test_run_ralph_a_respects_max_iterations(tmp_path: Path) -> None:
     assert ("howto", "faithfulness") not in investigated
 
 
+def test_run_ralph_a_degrades_when_pack_dir_missing_or_invalid(tmp_path: Path) -> None:
+    """A missing OR invalid pack_dir degrades to pack=None — investigation still runs.
+
+    The optional pack context has THREE states: present / absent / **invalid**.
+    Absent and invalid must BOTH degrade like "no extra context" via the narrow
+    catch, never crash the investigation. Removing/​broadening that catch (so
+    load_pack's error escapes) reds this test — giving the degrade branch teeth.
+    """
+    from src.eval.runner.ralph import run_ralph_a
+
+    pack = "p"
+    deltas = {"factoid": {"recall": -0.40}}
+    _write_history(
+        tmp_path,
+        pack,
+        [
+            _entry("2026-01-01T00:00:00", deltas),
+            _entry("2026-01-02T00:00:00", deltas),
+            _entry("2026-01-03T00:00:00", deltas),
+        ],
+    )
+
+    # (a) pack_dir points at a path that does not exist.
+    missing = tmp_path / "no_such_pack"
+    rec_a: list = []
+    report_a = run_ralph_a(
+        pack,
+        history_dir=tmp_path,
+        pack_dir=missing,
+        max_iterations=1,
+        investigate_fn=_recording_investigate_fn(rec_a),
+    )
+    assert report_a.sustained_count == 1
+    assert len(report_a.investigations) == 1  # did not crash; investigated
+    assert len(rec_a) == 1
+
+    # (b) pack_dir exists but is NOT a valid pack (no pack.yaml/manifest/goldens).
+    invalid = tmp_path / "invalid_pack"
+    invalid.mkdir()
+    (invalid / "junk.txt").write_text("not a pack")
+    rec_b: list = []
+    report_b = run_ralph_a(
+        pack,
+        history_dir=tmp_path,
+        pack_dir=invalid,
+        max_iterations=1,
+        investigate_fn=_recording_investigate_fn(rec_b),
+    )
+    assert report_b.sustained_count == 1
+    assert len(report_b.investigations) == 1  # degraded to pack=None, still ran
+    assert len(rec_b) == 1
+
+
 # ===========================================================================
 # persist_ralph_report — filename + round-trip
 # ===========================================================================


### PR DESCRIPTION
## What & why

Un-defers **P11 (Ralph-A)** as a **proposal-only MVP** — the safest, fully-testable first slice. Ralph-A turns the trusted-signal trio (#140 run-history + #141 sustained-regression detector) into ranked, human-reviewable **diagnoses** via the P14 headless-judge infra. It **never applies patches, commits, opens PRs, or merges** — proven empirically.

Every precondition for this was already on `develop`: the signal trio (#140/#141/#142), the headless driver (P14, no API key), and the judge robustness floor (P15).

### Slice scope (decided with the user)
- **P11a (this PR):** investigate + rank + emit `RalphReport`. Applies nothing.
- **P11b (deferred):** apply-in-sandbox + measure improvement + open a draft PR. The riskier actuation, built on P11a once proposals are trusted.

## How it maps to the system
- `src/eval/runner/ralph.py`:
  - `run_ralph_a(pack_name, *, history_dir, pack_dir=None, max_iterations=3, window, min_regressed, epsilon, investigate_fn=None, now=None) -> RalphReport` — `load_run_history` → `detect_sustained_regressions` → rank worst-first → investigate top-K → report.
  - `rank_regressions` key: `latest_delta` ascending (most-negative = worst), tie-break `runs_regressed` descending, then `(qtype, metric)`.
  - `build_ralph_investigator` — the default real investigator **reuses P14's `build_claude_argv` + `_strip_json_fence`**, so the cost/safety constraint (haiku, system-prompt replace, tool-less, clean-room) stays single-sourced. `investigate_fn` is an injectable seam.
  - Frozen `InvestigationProposal` / `RalphInvestigation` / `RalphReport`.
- `persistence.py`: `persist_ralph_report` → `<reports-dir>/ralph/<pack>_ralph_<ts>.json`.
- `cli.py`: `python -m src.eval ralph <pack>` subcommand (markdown report; persists artifact).

## Safety invariant (the load-bearing point)
`ralph.py` imports no git, writes nothing itself, and its only subprocess is the read-only investigator CLI call. The headline test proves this **empirically**: it snapshots the worktree file tree + `git status` before and after a run and asserts byte-identical. SA3 confirmed teeth by making the loop write a stray file → the test went red.

## Tests
- `tests/eval/test_ralph.py`: **16** (15 fast + 1 model-gated live) — worst-first + empirical no-mutation headline, no-sustained no-op, ranking-key teeth (discriminating data), max-iterations bound, persistence shape, investigator parse/fence/error, argv-constraint single-sourcing, CLI dispatch, **pack-load degrade (third-state)**, and a `RAGWEAVE_EVAL_CLI_LIVE`-gated real-claude test.
- `tests/eval` full: **291 passed / 6 skipped**. Offline smoke: exit 0. Cross-area CI sweep: **2450 passed / 4 skipped**.
- TDD: red-reason proof captured; SA3 adversarial verify **PASS** (all 6 mutation probes bite, incl. the non-mutation invariant); one nit (untested degrade path) fixed + mutation-proven.
- Plan ledger synced (P14/P15 shipped; P11a/P11b split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
